### PR TITLE
fix: expand default snapshot process states

### DIFF
--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -57,7 +57,7 @@ struct Cli {
     s3_prefix: String,
     #[arg(long)]
     snapshot_id: Option<Uuid>,
-    #[arg(long, default_value = "100")]
+    #[arg(long, default_value_t = solver_worker::default_snapshot_process_states_arg())]
     process_states: String,
     #[arg(long)]
     include_user_id: Option<Uuid>,
@@ -2794,8 +2794,8 @@ mod tests {
     use super::{
         AllocationMode, ExchangeDirection, NormalizationMode, ParsedExchange, ProcessMeta,
         ProviderRule, add_technosphere_edge, biosphere_gross_value, geo_score,
-        resolve_allocation_fraction, resolve_multi_provider, resolve_reference_normalization,
-        time_score,
+        parse_process_states, resolve_allocation_fraction, resolve_multi_provider,
+        resolve_reference_normalization, time_score,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -2840,6 +2840,29 @@ mod tests {
             ProviderRule::parse("split_equal").expect("parse"),
             ProviderRule::SplitEqual
         );
+    }
+
+    #[test]
+    fn default_process_states_cover_100_through_199() {
+        let default_states = solver_worker::default_snapshot_process_states_arg();
+        let (all_states, parsed, label) =
+            parse_process_states(default_states.as_str()).expect("parse default states");
+
+        assert!(!all_states);
+        assert_eq!(parsed.len(), 100);
+        assert_eq!(parsed.first().copied(), Some(100));
+        assert_eq!(parsed.last().copied(), Some(199));
+        assert_eq!(label, default_states);
+    }
+
+    #[test]
+    fn explicit_process_states_still_override_default_scope() {
+        let (all_states, parsed, label) =
+            parse_process_states("100,150,199").expect("parse explicit states");
+
+        assert!(!all_states);
+        assert_eq!(parsed, vec![100, 150, 199]);
+        assert_eq!(label, "100,150,199");
     }
 
     #[test]

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -1327,7 +1327,10 @@ async fn run_snapshot_builder_job(
         "--snapshot-id".to_owned(),
         snapshot_id.to_string(),
         "--process-states".to_owned(),
-        process_states.unwrap_or("100").to_owned(),
+        process_states.map_or_else(
+            crate::default_snapshot_process_states_arg,
+            ToOwned::to_owned,
+        ),
         "--provider-rule".to_owned(),
         provider_rule.unwrap_or("strict_unique_provider").to_owned(),
         "--reference-normalization-mode".to_owned(),

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -1,5 +1,16 @@
 //! Worker crate library modules shared by binaries.
 
+pub const DEFAULT_SNAPSHOT_PROCESS_STATE_START: i32 = 100;
+pub const DEFAULT_SNAPSHOT_PROCESS_STATE_END: i32 = 199;
+
+#[must_use]
+pub fn default_snapshot_process_states_arg() -> String {
+    (DEFAULT_SNAPSHOT_PROCESS_STATE_START..=DEFAULT_SNAPSHOT_PROCESS_STATE_END)
+        .map(|state| state.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 pub mod artifacts;
 pub mod config;
 pub mod contribution_path;

--- a/crates/solver-worker/src/snapshot_artifacts.rs
+++ b/crates/solver-worker/src/snapshot_artifacts.rs
@@ -286,7 +286,7 @@ mod tests {
     fn encode_decode_snapshot_artifact_roundtrip() {
         let snapshot_id = uuid::Uuid::new_v4();
         let config = SnapshotBuildConfig {
-            process_states: "100".to_owned(),
+            process_states: crate::default_snapshot_process_states_arg(),
             include_user_id: None,
             process_limit: 0,
             provider_rule: "strict_unique_provider".to_owned(),

--- a/scripts/build_snapshot_from_ilcd.sh
+++ b/scripts/build_snapshot_from_ilcd.sh
@@ -38,7 +38,7 @@ Usage:
 
 Options:
   --snapshot-id <uuid>         explicit snapshot id (default: auto generated)
-  --process-states <csv|all>   process state_code filter, use "all" to disable filter (default: "100")
+  --process-states <csv|all>   process state_code filter, use "all" to disable filter (default: "100,101,...,199")
   --include-user-id <uuid>     include processes from this user_id in addition to --process-states
   --process-limit <n>          limit processes for debug snapshot, 0 = no limit (default: 0)
   --provider-rule <rule>       provider matching rule (default: strict_unique_provider)


### PR DESCRIPTION
## Summary
- expand the default snapshot process state range from a narrow published subset to the full `100..199` family
- keep snapshot builder defaults, artifact metadata, and DB filtering aligned on the same state set
- update the snapshot build helper script to use the expanded published range

## Validation
- cargo test -p solver-worker

## Notes
- prepared from the Neo9281 fork on top of the current upstream `main`
- excludes fork-specific documentation changes