### PR TITLE
fix: deduplicate processes and enrich singular diagnostics

### DIFF
--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -2696,10 +2696,10 @@ async fn fetch_processes(
     let rows = if all_states {
         sqlx::query(
             r#"
-            SELECT id, version, model_id, user_id, modified_at, json
+            SELECT DISTINCT ON (id) id, version, model_id, user_id, modified_at, json
             FROM public.processes
             WHERE json ? 'processDataSet'
-            ORDER BY id, version
+            ORDER BY id, version DESC
             "#,
         )
         .fetch_all(pool)
@@ -2707,11 +2707,11 @@ async fn fetch_processes(
     } else if let Some(user_id) = include_user_id {
         sqlx::query(
             r#"
-            SELECT id, version, model_id, user_id, modified_at, json
+            SELECT DISTINCT ON (id) id, version, model_id, user_id, modified_at, json
             FROM public.processes
             WHERE (state_code = ANY($1) OR user_id = $2)
               AND json ? 'processDataSet'
-            ORDER BY id, version
+            ORDER BY id, version DESC
             "#,
         )
         .bind(state_codes)
@@ -2721,11 +2721,11 @@ async fn fetch_processes(
     } else {
         sqlx::query(
             r#"
-            SELECT id, version, model_id, user_id, modified_at, json
+            SELECT DISTINCT ON (id) id, version, model_id, user_id, modified_at, json
             FROM public.processes
             WHERE state_code = ANY($1)
               AND json ? 'processDataSet'
-            ORDER BY id, version
+            ORDER BY id, version DESC
             "#,
         )
         .bind(state_codes)

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -27,10 +27,7 @@ fn extract_snapshot_id(payload: &JobPayload) -> Option<Uuid> {
 }
 
 /// Fetches snapshot coverage from `lca_snapshot_artifacts` for richer error diagnostics.
-async fn fetch_snapshot_coverage(
-    pool: &sqlx::PgPool,
-    snapshot_id: Uuid,
-) -> Option<Value> {
+async fn fetch_snapshot_coverage(pool: &sqlx::PgPool, snapshot_id: Uuid) -> Option<Value> {
     sqlx::query_scalar::<_, Value>(
         "SELECT coverage FROM public.lca_snapshot_artifacts \
          WHERE snapshot_id = $1 AND status = 'ready' \
@@ -85,13 +82,8 @@ pub async fn run_worker_loop(
                             let diagnostics =
                                 build_failure_diagnostics(&state.pool, &payload, &err_message)
                                     .await;
-                            let _ = update_job_status(
-                                &state.pool,
-                                job_id,
-                                "failed",
-                                diagnostics,
-                            )
-                            .await;
+                            let _ =
+                                update_job_status(&state.pool, job_id, "failed", diagnostics).await;
                             let _ = mark_result_cache_failed(
                                 &state.pool,
                                 job_id,

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -49,12 +49,12 @@ async fn build_failure_diagnostics(
     let mut diag = serde_json::json!({"error": err_message});
 
     // For factorization/singular errors, attach snapshot coverage for context.
-    if err_message.contains("singular") || err_message.contains("factorization") {
-        if let Some(snapshot_id) = extract_snapshot_id(payload) {
-            diag["snapshot_id"] = serde_json::json!(snapshot_id.to_string());
-            if let Some(coverage) = fetch_snapshot_coverage(pool, snapshot_id).await {
-                diag["snapshot_coverage"] = coverage;
-            }
+    if (err_message.contains("singular") || err_message.contains("factorization"))
+        && let Some(snapshot_id) = extract_snapshot_id(payload)
+    {
+        diag["snapshot_id"] = serde_json::json!(snapshot_id.to_string());
+        if let Some(coverage) = fetch_snapshot_coverage(pool, snapshot_id).await {
+            diag["snapshot_coverage"] = coverage;
         }
     }
 

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -13,6 +13,57 @@ use crate::{
     types::JobPayload,
 };
 
+fn extract_snapshot_id(payload: &JobPayload) -> Option<Uuid> {
+    match payload {
+        JobPayload::PrepareFactorization { snapshot_id, .. }
+        | JobPayload::SolveOne { snapshot_id, .. }
+        | JobPayload::SolveBatch { snapshot_id, .. }
+        | JobPayload::SolveAllUnit { snapshot_id, .. }
+        | JobPayload::AnalyzeContributionPath { snapshot_id, .. }
+        | JobPayload::InvalidateFactorization { snapshot_id, .. }
+        | JobPayload::RebuildFactorization { snapshot_id, .. } => Some(*snapshot_id),
+        JobPayload::BuildSnapshot { .. } => None,
+    }
+}
+
+/// Fetches snapshot coverage from `lca_snapshot_artifacts` for richer error diagnostics.
+async fn fetch_snapshot_coverage(
+    pool: &sqlx::PgPool,
+    snapshot_id: Uuid,
+) -> Option<Value> {
+    sqlx::query_scalar::<_, Value>(
+        "SELECT coverage FROM public.lca_snapshot_artifacts \
+         WHERE snapshot_id = $1 AND status = 'ready' \
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(snapshot_id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Builds enriched diagnostics JSON when a job fails with a factorization error.
+async fn build_failure_diagnostics(
+    pool: &sqlx::PgPool,
+    payload: &JobPayload,
+    err_message: &str,
+) -> Value {
+    let mut diag = serde_json::json!({"error": err_message});
+
+    // For factorization/singular errors, attach snapshot coverage for context.
+    if err_message.contains("singular") || err_message.contains("factorization") {
+        if let Some(snapshot_id) = extract_snapshot_id(payload) {
+            diag["snapshot_id"] = serde_json::json!(snapshot_id.to_string());
+            if let Some(coverage) = fetch_snapshot_coverage(pool, snapshot_id).await {
+                diag["snapshot_coverage"] = coverage;
+            }
+        }
+    }
+
+    diag
+}
+
 /// Runs pgmq polling loop.
 #[instrument(skip(state))]
 pub async fn run_worker_loop(
@@ -31,11 +82,14 @@ pub async fn run_worker_loop(
                             error!(error = %err, "job execution failed");
                             let job_id = extract_job_id(&payload);
                             let err_message = err.to_string();
+                            let diagnostics =
+                                build_failure_diagnostics(&state.pool, &payload, &err_message)
+                                    .await;
                             let _ = update_job_status(
                                 &state.pool,
                                 job_id,
                                 "failed",
-                                serde_json::json!({"error": err_message}),
+                                diagnostics,
                             )
                             .await;
                             let _ = mark_result_cache_failed(


### PR DESCRIPTION
## Summary

- **Process dedup**: Add `DISTINCT ON (id)` to `fetch_processes()` SQL queries in snapshot builder, keeping only the latest version per process ID. Aligns with the existing pattern used in `fetch_flow_meta()` and `load_impact_factor_sets()`.
- **Diagnostics enrichment**: When a solve job fails with a factorization/singular error, automatically attach the snapshot's coverage data (singular_risk, reference stats, allocation stats, matching stats) to `lca_jobs.diagnostics`.

## Context

User `dbcf5d8a` had 3 process IDs with 2 versions each, causing near-linearly-dependent columns in the technosphere matrix. Additionally, 3 pairs of different-ID processes had identical exchange structures, directly causing matrix singularity. The dedup fix resolves the multi-version issue; the diagnostics enhancement provides visibility into singular root causes without manual DB queries.

Closes #27

## Test plan

- [x] `cargo build -p solver-worker --bin solver-worker --bin snapshot_builder --release` compiles
- [x] `cargo test -p solver-worker --all-targets` — 20 tests pass
- [x] Verified dedup effect on prod DB: 5386 → 5371 rows for affected user
- [ ] Rollout to prod and verify diagnostics output on next singular failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)