### PR TITLE
docs: add AI doc contracts for issue #30

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ Route those tasks to:
   - `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
   - `cargo fmt --all -- --check`
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
+
 ## Operational Invariants
 
 - Solve result persistence is S3-only; `lca_results` stores artifact metadata and diagnostics, not inline payloads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ Route those tasks to:
   - `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
   - `cargo fmt --all -- --check`
 
+## Operational Invariants
+
+- Solve result persistence is S3-only; `lca_results` stores artifact metadata and diagnostics, not inline payloads.
+- Queue enqueue and protected writes must stay on service-side paths; do not move them to frontend clients or authenticated direct table writes.
+- Runtime write paths assume `service_role` ownership boundaries and existing RLS restrictions on `lca_*` tables.
+- Worker and snapshot flows expect DB connectivity plus the required S3 env set: `DATABASE_URL` or `CONN`, `S3_ENDPOINT`, `S3_REGION`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, and `S3_SECRET_ACCESS_KEY`.
+
 ## Hard Boundaries
 
 - Do not move solver or worker behavior into `edge-functions`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,396 +1,112 @@
-# AGENTS.md
+---
+title: calculator AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: calculator
+language: en
+whenToUse:
+  - when a task may change solver runtime behavior, queue workers, snapshot building, package worker flows, or calculation-side validation scripts
+  - when routing work from the workspace root into tiangong-lca-calculator
+  - when deciding whether a change belongs here, in edge-functions, in database-engine, or in lca-workspace
+whenToUpdate:
+  - when runtime job families, validation gates, or ownership boundaries change
+  - when the runtime SQL contract or package-flow contract changes
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - docs/**
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - Cargo.toml
+  - Makefile
+  - crates/**
+  - scripts/**
+  - tools/bw25-validator/**
+  - supabase/migrations/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - docs/lca-api-contract.md
+  - docs/edge-function-integration.md
+  - docs/frontend-integration.md
+  - docs/tidas-package-contract.md
+---
+
+## Repo Contract
+
+`tiangong-lca-calculator` owns the TianGong LCA solver runtime: sparse-matrix build and solve logic, worker job execution, snapshot building, provider matching, package import or export worker flows, and calculation-side diagnostics. Start here when the task may change what the compute stack does.
+
+## AI Load Order
+
+Load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. only then load the narrow contract doc that matches the task, such as:
+   - `docs/lca-api-contract.md`
+   - `docs/edge-function-integration.md`
+   - `docs/frontend-integration.md`
+   - `docs/tidas-package-contract.md`
+
+Do not start from the root workspace or from the edge repo if the change is really about compute truth.
+
+## Repo Ownership
+
+This repo owns:
+
+- solver crates under `crates/**`
+- queue workers, package workers, and snapshot builder binaries
+- runtime result persistence and diagnostics shaping
+- calculation-side manual validation and debugging scripts under `scripts/**`
+- runtime-facing contract docs under `docs/**`
+
+This repo does not own:
+
+- Edge request normalization, auth, enqueue API, or polling API behavior
+- durable schema governance, branch config, or migration source of truth
+- workspace integration state after merge
+
+Route those tasks to:
+
+- `edge-functions` for request, response, auth, enqueue, and polling API behavior
+- `database-engine` for durable schema, migration, RPC, policy, and Supabase branch-governance truth
+- `lca-workspace` for root integration after merge
+
+## Branch And Validation Facts
+
+- GitHub default branch: `main`
+- True daily trunk: `main`
+- Routine branch base: `main`
+- Routine PR base: `main`
+- Canonical repo-wide check: `make check`
+- Hard post-edit gates:
+  - `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
+  - `cargo fmt --all -- --check`
+
+## Hard Boundaries
+
+- Do not move solver or worker behavior into `edge-functions`
+- Do not treat local `supabase/migrations/**` as the workspace's durable schema governance source of truth
+- Do not weaken the Clippy or format gates
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
 
-This document is for AI coding agents working in this repository.
+## Workspace Integration
 
-## 0. Mandatory maintenance rule
+A merged PR in `tiangong-lca-calculator` is repo-complete, not delivery-complete.
 
-`AGENTS.md` is a living contract.
-Every time code/schema/runtime behavior changes in this repo, update this file in the same task.
+If the change must ship through the workspace:
 
-After every code change, run Clippy and make it pass before finishing the task.
-This is a hard gate.
-
-Required command:
-
-```bash
-cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
-```
-
-After every code change, run Rust format check and make it pass before finishing the task.
-This is a hard gate.
-
-Required command:
-
-```bash
-cargo fmt --all -- --check
-```
-
-Must always stay aligned with:
-
-- architecture boundaries
-- API/payload/result contracts
-- schema + migration expectations
-- runtime/ops workflows
-- current TODO + risks
-
-## 1. Project goal
-
-Build a production LCA sparse solver stack with strict separation:
-
-- Supabase: source data, auth, queues (`pgmq`), runtime metadata.
-- Rust worker: matrix load, factorization, solve, persistence.
-- SuiteSparse: numeric backend (UMFPACK via Rust FFI).
-
-Hard invariants:
-
-- Always solve `M x = y` where `M = I - A`.
-- Never compute explicit inverse.
-- Heavy compute must stay async (queue worker path).
-- Scope is full-library process network compute (`lifecyclemodels` not in numeric solve).
-
-## 2. Current architecture (2026-03-06)
-
-### 2.1 Rust workspace
-
-- `crates/suitesparse-ffi`
-  - CSC matrix representation + UMFPACK FFI wrappers.
-- `crates/solver-core`
-  - matrix build/validate, factorization cache, solve orchestration.
-- `crates/solver-worker`
-  - queue consumer + internal HTTP + DB/object-storage persistence.
-
-### 2.2 Worker responsibilities
-
-- consumes `pgmq` queue `lca_jobs`
-- executes:
-  - `prepare_factorization`
-  - `solve_one`
-  - `solve_batch`
-  - `solve_all_unit` (worker-internal chunked unit demand across all processes)
-  - `invalidate_factorization`
-  - `rebuild_factorization`
-- updates `lca_jobs` status/diagnostics
-- writes `lca_results` rows (artifact metadata only)
-- updates request cache state in `lca_result_cache` by `job_id`
-
-Package export/import worker path:
-
-- binary: `crates/solver-worker/src/bin/package_worker.rs`
-- consumes `pgmq` queue `lca_package_jobs`
-- executes:
-  - `export_package`
-  - `import_package`
-- updates `lca_package_jobs` status/diagnostics
-- writes `lca_package_artifacts` rows for export ZIP / reports
-- updates request cache state in `lca_package_request_cache`
-- persists resumable export traversal state in `lca_package_export_items`
-- export ZIP finalization now writes the package to a local temp file first, then uploads the final `export_zip` artifact via multipart S3 upload once the file exceeds the large-object threshold
-- package job failure diagnostics for object-storage uploads now record structured fields such as `error_code`, `stage`, `upload_mode`, `artifact_byte_size`, `http_status`, and `storage_error_code`, with oversize uploads normalized to `artifact_too_large`
-- package export `open_data` scope treats published rows as `state_code` `100..=199`
-- full-scope export seed scanning currently:
-  - rehydrates traversal cache from `lca_package_export_items` seed/external rows
-  - scans source datasets with DB-side `jsonb_path_query_array(...)` extraction so the worker fetches reference payloads instead of full `json_ordered` blobs where possible
-  - casts `json_ordered` / `json_tg` to `jsonb` inside the seed-scan query because source columns are not uniformly stored as `jsonb`
-
-### 2.3 Snapshot builder
-
-Canonical entry:
-
-- `crates/solver-worker/src/bin/snapshot_builder.rs`
-- wrapper: `scripts/build_snapshot_from_ilcd.sh`
-
-Behavior:
-
-- builds sparse payload from `processes/flows/lciamethods`
-- writes snapshot artifact (`snapshot-hdf5:v1`) to S3
-- writes metadata to `lca_network_snapshots` + `lca_snapshot_artifacts`
-- emits coverage report (`reports/snapshot-coverage/...`)
-- supports same-source skip-rebuild via source fingerprint (`count + max(modified_at) + config`)
-- same-source snapshot reuse is canonical-only:
-  - when reuse hits an existing ready snapshot, the builder now resolves to the reused canonical `snapshot_id`
-  - the builder must not persist alias snapshot rows that point a new `snapshot_id` at an older artifact URL
-  - `build_snapshot` jobs must update `lca_jobs.snapshot_id` and `lca_active_snapshots.snapshot_id` to that resolved canonical id before completion
-- process selection supports:
-  - `--process-states <csv|all>` for `state_code` filtering (default runtime scope: `100..=199`)
-  - `--include-user-id <uuid>` to include one user's processes in addition to `process-states` (OR union)
-  - `--root-process <uuid@version>` to switch from broad filtered-library selection to request-scoped closure selection
-  - request-root mode resolves the reachable public+private closure from explicit roots under the current `provider_rule`
-  - request-root mode persists `selection_mode`, `request_roots`, `scope_hash`, and resolved-scope public/private counts into snapshot metadata
-  - request-root mode does not allow `--process-limit`, because truncation would break closure semantics
-- provider matching supports:
-  - `strict_unique_provider` (legacy strict behavior)
-  - `best_provider_strict` (auto-link select one provider by geo+time score)
-  - `split_by_evidence` (strict weighted split by geo+time score)
-  - `split_by_evidence_hybrid` (weighted split, fallback to equal split)
-  - `split_equal` (always equal split for multi-provider)
-  - persisted snapshot metadata default is `split_by_evidence_hybrid`
-  - `lca_network_snapshots.provider_matching_rule` must accept the current runtime rule set plus legacy persisted values (`equal_split_multi_provider`, `custom_weighted_provider`) for backward compatibility
-- quantitative reference normalization is applied at build time:
-  - mode: `reference_normalization_mode=strict|lenient` (CLI, default `strict`)
-  - strict: missing/invalid `referenceToReferenceFlow` or reference amount => fail snapshot build
-  - lenient: fallback scale `1.0` and record diagnostics
-- allocation fraction is applied at exchange level:
-  - source: `exchanges.exchange.allocations.allocation.@allocatedFraction`
-  - mode: `allocation_fraction_mode=strict|lenient` (CLI, default `strict`)
-  - strict: missing/invalid fraction => fail snapshot build
-  - lenient: fallback fraction `1.0` and record diagnostics
-- biosphere sign convention for elementary flows uses gross mode:
-  - `Input`/`Output` no longer force direction sign flip; both are written with original `amount` sign into `B`
-  - snapshot config persists `biosphere_sign_mode` (current runtime value: `gross`; legacy artifact default: `signed`)
-- auto-link scoring currently uses only:
-  - model priority pre-filter: prefer providers with the same `processes.model_id` as consumer when available
-  - geography (`@location`) from process geography block
-  - reference year (`common:referenceYear`) from process time block
-- process source summary in request-root mode is now based on the resolved closure, not the entire broad candidate process scope
-- snapshot coverage now includes additional matching diagnostics:
-  - `matched_multi_resolved`
-  - `matched_multi_unresolved`
-  - `matched_multi_fallback_equal`
-  - `a_input_edges_written`
-- snapshot coverage also includes data-quality diagnostics:
-  - `reference`: `process_total`, `normalized_process_count`, `missing_reference_count`, `invalid_reference_count`
-  - `allocation`: `exchange_total`, `allocation_fraction_present_pct`, `allocation_fraction_missing_count`, `allocation_fraction_invalid_count`
-
-## 3. Storage/result policy (strict)
-
-## 3.1 Solve result persistence
-
-Solve results are **S3-only**.
-
-- format: `hdf5:v1`
-- container: HDF5
-- compression: chunked `deflate` (zlib level 4) on `envelope_json`
-- checksum: SHA-256 hex
-
-`lca_results` stores only metadata + diagnostics:
-
-- `artifact_url` (required)
-- `artifact_sha256` (required)
-- `artifact_byte_size` (required)
-- `artifact_format` (required, currently `hdf5:v1`)
-- `diagnostics`
-
-Inline JSON result payload is removed and not supported.
-
-## 3.2 Retention + GC
-
-Retention fields on `lca_results`:
-
-- `expires_at`
-- `is_pinned`
-
-GC tool:
-
-- binary: `cargo run -p solver-worker --bin result_gc --release -- ...`
-- wrapper: `scripts/gc_lca_results.sh`
-
-GC delete policy:
-
-- only expired rows (`expires_at < now()`)
-- skip pinned rows (`is_pinned=true`)
-- skip rows referenced by active cache (`lca_result_cache` in `pending/running/ready`)
-- keep latest 1 row per request partition:
-  - partition key: `requested_by + snapshot_id + coalesce(request_key, job_id)`
-  - delete only rows with `row_number > 1`
-
-Delete order:
-
-1. delete S3 object
-2. delete DB row
-
-## 4. Schema + migration baseline
-
-Applied/expected migrations:
-
-- `20260304073000_lca_snapshot_phase1.sql`
-- `20260304103000_lca_snapshot_artifacts.sql`
-- `20260304120000_lca_drop_legacy_entry_tables.sql`
-- `20260305052000_lca_request_cache_and_factorization_registry.sql`
-- `20260305070000_lca_rls_lockdown.sql`
-- `20260305093000_lca_enqueue_job_rpc.sql`
-- `20260305094000_lca_enqueue_job_rpc_acl.sql`
-- `20260306090000_lca_results_s3_strict_and_retention.sql` (destructive for old results)
-- `20260308104000_lca_jobs_add_solve_all_unit.sql`
-- `20260319120000_tidas_package_job_tables.sql`
-- `20260319143000_tidas_package_export_items.sql`
-- `20260328170000_lca_snapshot_provider_rule_alignment.sql`
-
-Current runtime tables:
-
-- `lca_network_snapshots`
-- `lca_snapshot_artifacts`
-- `lca_jobs`
-- `lca_results`
-- `lca_active_snapshots`
-- `lca_result_cache`
-- `lca_factorization_registry` (schema ready, runtime usage limited)
-- `lca_package_jobs`
-- `lca_package_artifacts`
-- `lca_package_request_cache`
-- `lca_package_export_items`
-
-## 5. Security/permission baseline
-
-- `lca_*` tables have RLS enabled.
-- `anon` has no direct table access.
-- `authenticated` can read only own `lca_jobs` and associated `lca_results`.
-- enqueue path must use service-side RPC:
-  - `public.lca_enqueue_job(text, jsonb)`
-  - execute granted to `service_role` only.
-
-## 6. Cross-project contracts
-
-Authoritative docs in this repo:
-
-- `docs/lca-api-contract.md`
-- `docs/edge-function-integration.md`
-- `docs/frontend-integration.md`
-
-Current contract highlights:
-
-- queue payload uses `snapshot_id` (`model_version` accepted only as worker alias)
-- Edge submits jobs via RPC (`lca_enqueue_job`), not direct DB driver `pgmq.send`
-- result fetch contract is artifact metadata only (no inline result field)
-
-## 7. Runtime env expectations
-
-Required DB env:
-
-- `DATABASE_URL` (preferred) or `CONN`
-
-Required S3 env for worker/runtime:
-
-- `S3_ENDPOINT`
-- `S3_REGION`
-- `S3_BUCKET`
-- `S3_ACCESS_KEY_ID`
-- `S3_SECRET_ACCESS_KEY`
-
-Optional:
-
-- `S3_SESSION_TOKEN`
-- `S3_PREFIX` (default `lca-results`)
-
-Required runtime for package import validation:
-
-- `python3` available in worker runtime PATH
-- Python module `tidas_tools` installed (must support `python3 -m tidas_tools.validate --input-dir <dir> --format json`)
-- optional override: `TIDAS_VALIDATE_BIN` (custom validator command)
-
-Note:
-
-- Worker startup is expected to fail fast if required S3 config is missing.
-- package `import_package` job now executes validator-before-import:
-  - unzip source artifact to temp dir
-  - run structured validator JSON report
-  - if `summary.error_count > 0`, return import report `VALIDATION_FAILED` and skip both conflict checks and DB inserts
-  - import report payload always includes validation counters/details (`summary.validation_issue_count/error_count/warning_count` + `validation_issues`)
-
-## 8. Operations runbook
-
-Build/check:
-
-```bash
-make check
-```
-
-Export latest matrices (A/B/M + one-impact C/H from latest `solve_all_unit`):
-
-```bash
-./scripts/export_latest_matrices.sh --impact-id <impact_uuid>
-```
-
-Mandatory lint gate after every code edit:
-
-```bash
-cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
-```
-
-Mandatory format gate after every code edit:
-
-```bash
-cargo fmt --all -- --check
-```
-
-Run worker (local):
-
-```bash
-set -a && source .env && set +a
-cargo run -p solver-worker --release -- --mode worker
-```
-
-Recommended production mode:
-
-- `systemd` + release binary (multi-instance)
-- keep `WORKER_VT_SECONDS` above slow-job runtime
-
-Snapshot build:
-
-```bash
-./scripts/build_snapshot_from_ilcd.sh
-```
-
-Full compute debug:
-
-```bash
-./scripts/run_full_compute_debug.sh --snapshot-id <snapshot_id>
-```
-
-Result GC:
-
-```bash
-./scripts/gc_lca_results.sh
-./scripts/gc_lca_results.sh --dry-run
-```
-
-Manual Brightway validation:
-
-```bash
-./scripts/run_bw25_validation.sh --snapshot-id <snapshot_id>
-```
-
-## 9. Validation tool status
-
-`tools/bw25-validator` is manual-only and out-of-band.
-
-- validates `solve_one`
-- reads snapshot/result artifacts from S3 (`snapshot-hdf5:v1` + `hdf5:v1`)
-- compares Rust vs Brightway (`x/g/h`, residuals, timing)
-- Linux x64 installs `pypardiso` to remove warning and speed sparse solves
-
-## 10. Current TODO (priority)
-
-P0:
-
-- integrate snapshot build as queue job (`build_snapshot`) instead of CLI-only path
-- add integration tests for artifact-first end-to-end flow
-- add CI smoke for `bw25-validator` with fixture artifact pair
-- keep three-repo contract synced (calculator / edge / frontend)
-
-P1:
-
-- retry/backoff/dead-letter strategy for failed jobs
-- structured queue lag / throughput metrics
-- explicit diagnostics schema versioning
-- distributed factorization coordination if/when needed
-
-P2:
-
-- optional CHOLMOD/SPQR backend abstraction
-- richer contribution/post-processing outputs
-
-## 11. Known risks
-
-- Same-source snapshot reuse depends on source table `modified_at` triggers being reliable.
-- Factorization cache is process-local only; restart loses warm cache.
-- Internal HTTP endpoints are for trusted internal network only.
-- Snapshot artifact fallback to legacy `lca_*` tables is compatibility code path; those tables may not exist after cleanup migration.
-
-## 12. Done criteria for agent tasks
-
-A task is done only when:
-
-- code compiles
-- checks/tests for touched area pass (or failure is explicitly reported)
-- contracts/docs are synced (`AGENTS.md` + README + docs if affected)
-- no stale legacy behavior is left undocumented
+1. merge the child PR into `tiangong-lca-calculator`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated solver snapshot

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -72,6 +72,8 @@ The worker currently covers families such as:
 - `solve_one`
 - `solve_batch`
 - `solve_all_unit`
+- `invalidate_factorization`
+- `rebuild_factorization`
 - `analyze_contribution_path`
 - `build_snapshot`
 
@@ -93,6 +95,12 @@ It also owns package-job artifacts and diagnostics.
 ### Result persistence
 
 Result artifacts are persisted through the worker and supporting runtime storage flows instead of inlining heavy compute payloads into the API layer.
+
+## Operational Baseline
+
+- Solve result persistence is S3-only; treat `lca_results` as artifact metadata plus diagnostics, not as an inline result store.
+- Queue enqueue and protected writes stay on service-side runtime paths guarded by existing RLS and `service_role` boundaries.
+- Worker and snapshot paths require DB connectivity plus the required S3 env set before runtime validation is meaningful.
 
 ## Runtime SQL Boundary
 

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -99,6 +99,7 @@ Result artifacts are persisted through the worker and supporting runtime storage
 ## Operational Baseline
 
 - Solve result persistence is S3-only; treat `lca_results` as artifact metadata plus diagnostics, not as an inline result store.
+- The worker DB pool currently uses a 5-minute idle timeout and a 30-minute max lifetime; keep equivalent long-running job headroom if you retune the pool.
 - Queue enqueue and protected writes stay on service-side runtime paths guarded by existing RLS and `service_role` boundaries.
 - Worker and snapshot paths require DB connectivity plus the required S3 env set before runtime validation is meaningful.
 

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,116 @@
+---
+title: calculator Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: calculator
+language: en
+whenToUse:
+  - when you need a compact mental model of the solver stack before editing crates, workers, or runtime SQL expectations
+  - when deciding which crate or binary owns a behavior change
+  - when snapshot build, package flow, or contribution-path analysis is mentioned without exact paths
+whenToUpdate:
+  - when major crate boundaries or job families change
+  - when result persistence or runtime SQL boundaries move
+  - when the current map becomes misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - Cargo.toml
+  - crates/**
+  - scripts/**
+  - supabase/migrations/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../docs/lca-api-contract.md
+---
+
+## Repo Shape
+
+This repo is a Rust workspace with three core layers:
+
+- `crates/suitesparse-ffi`
+- `crates/solver-core`
+- `crates/solver-worker`
+
+The runtime solves sparse systems asynchronously and keeps heavy compute out of the API layer.
+
+## Core Solver Invariants
+
+Keep these constraints in mind before editing `crates/solver-core/**` or worker solve flows:
+
+- The runtime solves the sparse system `Mx = b` with `M = I - A`; preserve that modeling contract when reshaping matrix-build code.
+- Do not introduce explicit matrix inversion for solve paths. Reuse factorization or sparse-solve flows instead.
+- Heavy recomputation belongs in async worker jobs, not inline request handlers or API-edge adapters.
+- If a change affects factorization reuse, provider matching, or snapshot payload shape, review worker and persistence paths together.
+
+## Stable Path Map
+
+| Path group | Role |
+| --- | --- |
+| `crates/suitesparse-ffi/**` | CSC matrix representation and SuiteSparse bindings |
+| `crates/solver-core/**` | matrix build, factorization cache, solve orchestration, provider matching |
+| `crates/solver-worker/src/**` | queue workers, package worker, snapshot builder, result persistence |
+| `scripts/**` | manual validation, debug, diagnostics, and snapshot helpers |
+| `tools/bw25-validator/**` | manual Brightway comparison tooling |
+| `supabase/migrations/**` | local runtime-facing SQL expectations referenced by the calculator runtime |
+| `docs/**` | runtime-facing contract and investigation docs |
+
+## Current Runtime Families
+
+### Solve and queue jobs
+
+The worker currently covers families such as:
+
+- `prepare_factorization`
+- `solve_one`
+- `solve_batch`
+- `solve_all_unit`
+- `analyze_contribution_path`
+- `build_snapshot`
+
+These flows belong to the calculator runtime, not to the API repo.
+
+### Snapshot builder and provider matching
+
+The snapshot builder path owns sparse payload generation, provider matching, and snapshot artifact metadata.
+
+### Package worker
+
+The package worker handles:
+
+- `export_package`
+- `import_package`
+
+It also owns package-job artifacts and diagnostics.
+
+### Result persistence
+
+Result artifacts are persisted through the worker and supporting runtime storage flows instead of inlining heavy compute payloads into the API layer.
+
+## Runtime SQL Boundary
+
+This repo still documents and depends on runtime SQL expectations, but durable schema governance belongs in `database-engine`.
+
+Use this rule:
+
+- runtime compute truth here
+- durable schema, migration, RPC, and policy truth there
+
+## Cross-Repo Boundaries
+
+- `edge-functions` owns request normalization, auth, enqueue, and polling API behavior
+- `database-engine` owns durable schema governance
+- `lca-workspace` owns root delivery completion after a child PR merges
+
+## Common Misreads
+
+- API behavior does not belong in the solver repo
+- local migrations here are not the workspace-wide schema source of truth
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -186,6 +186,44 @@
         }
       ],
       "reason": "Manual validation, package flows, and diagnostics are part of the operator-facing calculator contract and should refresh the AI layer when they change."
+    },
+    {
+      "id": "calculator-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "calculator",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,191 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d",
+  "rules": [
+    {
+      "id": "calculator-bootstrap-contract",
+      "scope": "repo",
+      "repo": "calculator",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "docs/**",
+          "kind": "deep-doc"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "calculator-runtime-contract",
+      "scope": "repo",
+      "repo": "calculator",
+      "triggers": [
+        {
+          "path": "Cargo.toml",
+          "kind": "workspace-topology"
+        },
+        {
+          "path": "Makefile",
+          "kind": "validation-wrapper"
+        },
+        {
+          "path": "crates/**",
+          "kind": "runtime-code"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "ci"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/lca-api-contract.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Solver and worker code changes alter the executable runtime contract and should refresh both the AI layer and the main API contract doc."
+    },
+    {
+      "id": "calculator-runtime-sql-boundary-contract",
+      "scope": "repo",
+      "repo": "calculator",
+      "triggers": [
+        {
+          "path": "supabase/migrations/**",
+          "kind": "runtime-sql"
+        },
+        {
+          "path": "docs/edge-function-integration.md",
+          "kind": "runtime-contract"
+        },
+        {
+          "path": "docs/frontend-integration.md",
+          "kind": "runtime-contract"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Runtime-facing SQL expectation changes should refresh the AI layer because durable schema governance lives in another repo."
+    },
+    {
+      "id": "calculator-script-and-package-contract",
+      "scope": "repo",
+      "repo": "calculator",
+      "triggers": [
+        {
+          "path": "scripts/**",
+          "kind": "manual-helper"
+        },
+        {
+          "path": "tools/bw25-validator/**",
+          "kind": "manual-helper"
+        },
+        {
+          "path": "docs/tidas-package-contract.md",
+          "kind": "runtime-contract"
+        },
+        {
+          "path": "docs/provider-linking-current-state.md",
+          "kind": "diagnostic-doc"
+        },
+        {
+          "path": "docs/provider-link-problem-process-diagnostics.md",
+          "kind": "diagnostic-doc"
+        },
+        {
+          "path": "docs/result-query-optimization.md",
+          "kind": "diagnostic-doc"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Manual validation, package flows, and diagnostics are part of the operator-facing calculator contract and should refresh the AI layer when they change."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -145,7 +145,7 @@
       "notes": [
         "Use the manual helper scripts when the task touches snapshot building, BW25 parity, LCIA targets, or provider-link diagnostics.",
         "Record separately when a change also requires durable schema proof in database-engine.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,152 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d",
+  "repo": {
+    "id": "calculator",
+    "path": "tiangong-lca-calculator",
+    "canonicalRepo": "linancn/tiangong-lca-calculator",
+    "purpose": "Sparse-solver runtime and worker repository for TianGong LCA.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch solver snapshots when the workspace intends to ship the updated calculation runtime.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/linancn/tiangong-lca-calculator/issues/30"
+    },
+    "runtime": {
+      "language": "Rust workspace with helper scripts",
+      "baselineValidationCommands": [
+        "make check",
+        "cargo clippy -p solver-worker --all-targets --all-features -- -D warnings",
+        "cargo fmt --all -- --check"
+      ],
+      "manualValidationHelpers": [
+        "./scripts/validate_additive_migration.sh",
+        "./scripts/build_snapshot_from_ilcd.sh",
+        "./scripts/run_full_compute_debug.sh",
+        "./scripts/run_bw25_validation.sh",
+        "./scripts/validate_lcia_targets.sh",
+        "./scripts/gc_lca_results.sh",
+        "./scripts/export_latest_matrices.sh",
+        "./scripts/export_provider_link_diagnostics.sh",
+        "./scripts/export_unmatched_no_provider_diagnostics.sh"
+      ]
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "Cargo.toml",
+          "role": "workspace membership and crate topology"
+        },
+        {
+          "path": "crates/suitesparse-ffi/**",
+          "role": "CSC matrix representation and SuiteSparse bindings"
+        },
+        {
+          "path": "crates/solver-core/**",
+          "role": "matrix build, factorization cache, solve orchestration, and provider matching"
+        },
+        {
+          "path": "crates/solver-worker/**",
+          "role": "queue workers, package worker, snapshot builder, and persistence"
+        },
+        {
+          "path": "scripts/**",
+          "role": "manual validation, debug, snapshot, and diagnostics helpers"
+        },
+        {
+          "path": "tools/bw25-validator/**",
+          "role": "manual Brightway comparison tool"
+        },
+        {
+          "path": "docs/**",
+          "role": "runtime-facing contract and investigation docs"
+        },
+        {
+          "path": "supabase/migrations/**",
+          "role": "local runtime-facing SQL expectations still referenced by the calculator runtime"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "edge-functions",
+          "doesNotOwn": [
+            "request normalization",
+            "frontend-facing auth",
+            "enqueue and polling API behavior"
+          ]
+        },
+        {
+          "repo": "database-engine",
+          "doesNotOwn": [
+            "durable schema governance",
+            "migrations as workspace-wide source of truth",
+            "Supabase branch governance"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "solver runtime and queue behavior",
+        "paths": [
+          "crates/solver-core/**",
+          "crates/solver-worker/src/**"
+        ]
+      },
+      {
+        "topic": "snapshot build, provider matching, and contribution-path analysis",
+        "paths": [
+          "crates/solver-worker/src/bin/snapshot_builder.rs",
+          "crates/solver-worker/src/types.rs",
+          "scripts/build_snapshot_from_ilcd.sh",
+          "scripts/export_provider_link_diagnostics.sh"
+        ]
+      },
+      {
+        "topic": "package worker import or export flows",
+        "paths": [
+          "crates/solver-worker/src/bin/package_worker.rs",
+          "docs/tidas-package-contract.md"
+        ]
+      },
+      {
+        "topic": "runtime SQL expectations and additive migration checks",
+        "paths": [
+          "supabase/migrations/**",
+          "scripts/validate_additive_migration.sh",
+          "docs/edge-function-integration.md",
+          "docs/frontend-integration.md"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "make check",
+        "cargo clippy -p solver-worker --all-targets --all-features -- -D warnings",
+        "cargo fmt --all -- --check"
+      ],
+      "notes": [
+        "Use the manual helper scripts when the task touches snapshot building, BW25 parity, LCIA targets, or provider-link diagnostics.",
+        "Record separately when a change also requires durable schema proof in database-engine.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,91 @@
+---
+title: calculator Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: calculator
+language: en
+whenToUse:
+  - when you already know the task belongs in tiangong-lca-calculator but need the right next file or next doc
+  - when deciding whether a change belongs in one solver layer, one worker flow, runtime SQL expectations, or another repo
+  - when routing between calculator work and handoffs to edge-functions, database-engine, or lca-workspace
+whenToUpdate:
+  - when new job families or runtime hotspots appear
+  - when cross-repo boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - crates/**
+  - scripts/**
+  - docs/**
+  - supabase/migrations/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../docs/lca-api-contract.md
+  - ../docs/edge-function-integration.md
+  - ../docs/frontend-integration.md
+  - ../docs/tidas-package-contract.md
+---
+
+## Repo Load Order
+
+When working inside `tiangong-lca-calculator`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. the narrow contract doc that matches the task
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change sparse-matrix build, solve orchestration, or factorization cache behavior | `crates/solver-core/**` | `ai/validation.md`, `ai/architecture.md`, `docs/lca-api-contract.md` | Compute truth belongs here. |
+| Change queue worker, HTTP worker runtime, or result persistence behavior | `crates/solver-worker/src/**` | `ai/validation.md`, `ai/architecture.md`, `docs/lca-api-contract.md` | This includes solve job execution and artifact shaping. |
+| Change snapshot build or provider matching behavior | `crates/solver-worker/src/bin/snapshot_builder.rs`, nearby core modules | `ai/validation.md`, `ai/architecture.md` | Use snapshot and provider-diagnostics helpers when validating. |
+| Change package import or export worker behavior | `crates/solver-worker/src/bin/package_worker.rs`, related worker modules | `ai/validation.md`, `ai/architecture.md`, `docs/tidas-package-contract.md` | Package-job semantics belong here. |
+| Change contribution-path analysis behavior | `crates/solver-worker/src/types.rs` and nearby result handlers | `ai/validation.md`, `ai/architecture.md` | The current API docs understate this flow; rely on the architecture map first. |
+| Change runtime SQL expectations referenced by the calculator | `supabase/migrations/**`, `scripts/validate_additive_migration.sh` | `ai/validation.md`, `docs/edge-function-integration.md`, `docs/frontend-integration.md` | Durable schema governance still belongs in `database-engine`. |
+| Change manual debug or parity-validation helpers | `scripts/**`, `tools/bw25-validator/**` | `ai/validation.md`, `ai/architecture.md` | These scripts are part of the calculator operator surface. |
+| Change request normalization, auth, enqueue API, or polling API behavior | `edge-functions`, not this repo | root `ai/task-router.md`, `tiangong-lca-edge-functions/AGENTS.md` | Edge owns the API runtime surface. |
+| Change durable schema, migrations, RPCs, policies, or Supabase branch config | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | Calculator depends on that truth but does not own it. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Fixing API-runtime behavior in the solver repo
+
+If the bug is really request normalization, auth, enqueue, or polling API behavior, route it to `edge-functions`.
+
+### Treating local migrations as workspace-wide schema governance
+
+This repo still documents runtime SQL expectations, but durable schema truth belongs in `database-engine`.
+
+### Ignoring the hard Rust gates
+
+`cargo clippy -p solver-worker --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` are hard post-edit gates.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. solver/runtime change depends on new SQL or policy truth
+   - start here for runtime code
+   - coordinate with `database-engine`
+2. solve or package runtime change affects API request or response flow
+   - start here for runtime code
+   - coordinate with `edge-functions`
+3. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -60,6 +60,7 @@ When working inside `tiangong-lca-calculator`, load docs in this order:
 | Change manual debug or parity-validation helpers | `scripts/**`, `tools/bw25-validator/**` | `ai/validation.md`, `ai/architecture.md` | These scripts are part of the calculator operator surface. |
 | Change request normalization, auth, enqueue API, or polling API behavior | `edge-functions`, not this repo | root `ai/task-router.md`, `tiangong-lca-edge-functions/AGENTS.md` | Edge owns the API runtime surface. |
 | Change durable schema, migrations, RPCs, policies, or Supabase branch config | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | Calculator depends on that truth but does not own it. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -55,7 +55,7 @@ Treat the last two commands as non-negotiable hard gates after code changes.
 | package worker import or export flows | baseline gates | run the closest safe package-flow helper or record why live package proof is deferred | Package-job semantics are runtime-sensitive and may depend on storage or DB state. |
 | runtime SQL expectation docs or local migration helpers | baseline gates plus `./scripts/validate_additive_migration.sh` when the task touches migration expectations | record separately when durable schema proof is required in `database-engine` | Local migration files here are not the workspace-wide source of truth. |
 | manual debug, parity, or target-validation scripts | run the touched script with safe args or `--help` when available, plus baseline gates if code changed nearby | `./scripts/run_full_compute_debug.sh`, `./scripts/run_bw25_validation.sh`, or `./scripts/validate_lcia_targets.sh` as applicable | `bw25-validator` is manual-only and out-of-band. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Minimum PR Note Quality
 

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,66 @@
+---
+title: calculator Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: calculator
+language: en
+whenToUse:
+  - when a tiangong-lca-calculator change is ready for local validation
+  - when deciding the minimum proof required for solver, worker, script, or runtime-contract changes
+  - when writing PR validation notes for tiangong-lca-calculator work
+whenToUpdate:
+  - when the repo gains new canonical validation wrappers
+  - when change categories require different proof
+  - when runtime SQL or parity-validation expectations change
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - Cargo.toml
+  - Makefile
+  - crates/**
+  - scripts/**
+  - tools/bw25-validator/**
+  - supabase/migrations/**
+  - docs/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: a1d53203bd75a9c7b839e48d2a75fda5c8b4dc4d
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../docs/lca-api-contract.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only AI-contract work, the default baseline is:
+
+```bash
+make check
+cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Treat the last two commands as non-negotiable hard gates after code changes.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `crates/**` solver or worker code | `make check`; hard Clippy gate; hard format gate | run the narrow manual script that matches the touched area, such as snapshot build, full compute debug, or BW25 validation | Record which job family or worker path was exercised. |
+| snapshot-builder or provider-matching behavior | baseline gates plus `./scripts/build_snapshot_from_ilcd.sh` when safe | run provider-link diagnostics export helpers when the task changes matching logic | Snapshot and provider diagnostics often need a task-specific proof. |
+| package worker import or export flows | baseline gates | run the closest safe package-flow helper or record why live package proof is deferred | Package-job semantics are runtime-sensitive and may depend on storage or DB state. |
+| runtime SQL expectation docs or local migration helpers | baseline gates plus `./scripts/validate_additive_migration.sh` when the task touches migration expectations | record separately when durable schema proof is required in `database-engine` | Local migration files here are not the workspace-wide source of truth. |
+| manual debug, parity, or target-validation scripts | run the touched script with safe args or `--help` when available, plus baseline gates if code changed nearby | `./scripts/run_full_compute_debug.sh`, `./scripts/run_bw25_validation.sh`, or `./scripts/validate_lcia_targets.sh` as applicable | `bw25-validator` is manual-only and out-of-band. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which baseline gates ran
+2. which job family, script, or manual parity helper was exercised
+3. whether any required database-engine or edge-functions proof lives elsewhere

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -57,8 +57,8 @@ impl AppState {
             .max_connections(8)
             .min_connections(1)
             .acquire_timeout(Duration::from_secs(30))
-            .idle_timeout(Duration::from_secs(300))
-            .max_lifetime(Duration::from_secs(1_800))
+            .idle_timeout(Duration::from_mins(5))
+            .max_lifetime(Duration::from_mins(30))
             .test_before_acquire(true)
             .connect(config.resolved_database_url()?)
             .await?;

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -7,6 +7,7 @@
 - 数值核心固定为 `M = I - A`，只解 `M x = y`。
 - `snapshot_builder` 对 elementary flow 的 `B` 采用 `gross` 口径（`Input/Output` 均按原始 `amount` 入模，不做方向符号翻转）。
 - 计算入口是异步 `lca_jobs` + `pgmq`，不走前端直连队列。
+- worker 连接池当前默认采用 `idle_timeout = 5min` 与 `max_lifetime = 30min`，以保证长时求解与 artifact 落盘阶段有稳定连接窗口。
 - 主路径读取 `lca_snapshot_artifacts`（artifact-first），旧 `lca_*_entries` 仅兼容回退。
 - 所有写操作由服务端（Edge Function / worker，`service_role`）执行。
 


### PR DESCRIPTION
Closes linancn/tiangong-lca-calculator#30

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Expose core solver invariants in the English AI layer so agent edits do not miss matrix or worker constraints.

## Validation
- cargo check -q

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.