### PR TITLE
补充按 link 策略拆分的供应区域来源指标

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "3a2f742a147028c28e49b9f3f55094fb420237aa"
+lastReviewedCommit: "fa3e30458b7e20e6d7968b1185834acdb176ce93"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: 3a2f742a147028c28e49b9f3f55094fb420237aa
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -2494,8 +2494,13 @@ fn summarize_matching_diagnostics(compiled_graph: &CompiledGraph) -> MatchingDia
         summarize_provider_decision_diagnostics(&compiled_graph.provider_decisions);
     let mut candidate_count_histogram = BTreeMap::<String, i64>::new();
     let mut tier_counts_by_strategy = BTreeMap::<String, BTreeMap<String, i64>>::new();
+    let mut supply_region_source_counts_by_strategy =
+        BTreeMap::<String, BTreeMap<String, i64>>::new();
     let mut requested_location_granularity_counts = BTreeMap::<String, i64>::new();
+    let mut requested_location_granularity_counts_by_strategy =
+        BTreeMap::<String, BTreeMap<String, i64>>::new();
     let mut exchange_location_present_count = 0_i64;
+    let mut exchange_location_present_count_by_strategy = BTreeMap::<String, i64>::new();
     let mut unmatched_flow_counts = BTreeMap::<Uuid, i64>::new();
     let mut process_gap_counts = BTreeMap::<i32, ProcessGapAccumulator>::new();
     let mut volume_weight_summary = SnapshotVolumeWeightSummary::default();
@@ -2514,15 +2519,35 @@ fn summarize_matching_diagnostics(compiled_graph: &CompiledGraph) -> MatchingDia
             )
             .or_insert(0) += 1;
 
-        if let (Some(strategy), Some(tier)) =
-            (decision.resolution_strategy, decision.geography_tier)
-        {
-            let strategy = provider_resolution_strategy_label(strategy).to_owned();
-            let tier = provider_geography_tier_label(tier).to_owned();
-            *tier_counts_by_strategy
-                .entry(strategy)
+        if let Some(strategy) = decision.resolution_strategy {
+            let strategy_label = provider_resolution_strategy_label(strategy).to_owned();
+            if let Some(tier) = decision.geography_tier {
+                let tier = provider_geography_tier_label(tier).to_owned();
+                *tier_counts_by_strategy
+                    .entry(strategy_label.clone())
+                    .or_default()
+                    .entry(tier)
+                    .or_insert(0) += 1;
+            }
+            if let Some(source) = decision.supply_region_source {
+                let source = provider_supply_region_source_label(source).to_owned();
+                *supply_region_source_counts_by_strategy
+                    .entry(strategy_label.clone())
+                    .or_default()
+                    .entry(source)
+                    .or_insert(0) += 1;
+            }
+            if decision.exchange_location_present {
+                *exchange_location_present_count_by_strategy
+                    .entry(strategy_label.clone())
+                    .or_insert(0) += 1;
+            }
+            let granularity =
+                location_granularity_label(decision.supply_region_location.as_deref()).to_owned();
+            *requested_location_granularity_counts_by_strategy
+                .entry(strategy_label)
                 .or_default()
-                .entry(tier)
+                .entry(granularity)
                 .or_insert(0) += 1;
         }
 
@@ -2576,8 +2601,11 @@ fn summarize_matching_diagnostics(compiled_graph: &CompiledGraph) -> MatchingDia
             supply_region_source_counts: provider_decision_diagnostics
                 .supply_region_source_counts
                 .clone(),
+            supply_region_source_counts_by_strategy,
             exchange_location_present_count,
+            exchange_location_present_count_by_strategy,
             requested_location_granularity_counts,
+            requested_location_granularity_counts_by_strategy,
         },
         volume_weight_summary,
         gap_summary: SnapshotGapSummary {
@@ -4734,8 +4762,70 @@ mod tests {
             diagnostics
                 .geography_summary
                 .tier_counts_by_strategy
+                .get("unique_provider")
+                .and_then(|counts| counts.get("same_country")),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .tier_counts_by_strategy
                 .get("split_by_process_volume")
                 .and_then(|counts| counts.get("local_subnational")),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .supply_region_source_counts_by_strategy
+                .get("unique_provider")
+                .and_then(|counts| counts.get("consumer_process_location")),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .supply_region_source_counts_by_strategy
+                .get("split_by_process_volume")
+                .and_then(|counts| counts.get("exchange_location")),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .supply_region_source_counts_by_strategy
+                .get("unique_provider")
+                .and_then(|counts| counts.get("unspecified")),
+            None
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .exchange_location_present_count_by_strategy
+                .get("split_by_process_volume"),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .exchange_location_present_count_by_strategy
+                .get("unique_provider"),
+            None
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .requested_location_granularity_counts_by_strategy
+                .get("unique_provider")
+                .and_then(|counts| counts.get("country")),
+            Some(&1)
+        );
+        assert_eq!(
+            diagnostics
+                .geography_summary
+                .requested_location_granularity_counts_by_strategy
+                .get("split_by_process_volume")
+                .and_then(|counts| counts.get("subnational")),
             Some(&1)
         );
         assert_eq!(diagnostics.volume_weight_summary.candidate_total, 2);

--- a/crates/solver-worker/src/snapshot_artifacts.rs
+++ b/crates/solver-worker/src/snapshot_artifacts.rs
@@ -106,9 +106,15 @@ pub struct SnapshotGeographySummary {
     #[serde(default)]
     pub supply_region_source_counts: BTreeMap<String, i64>,
     #[serde(default)]
+    pub supply_region_source_counts_by_strategy: BTreeMap<String, BTreeMap<String, i64>>,
+    #[serde(default)]
     pub exchange_location_present_count: i64,
     #[serde(default)]
+    pub exchange_location_present_count_by_strategy: BTreeMap<String, i64>,
+    #[serde(default)]
     pub requested_location_granularity_counts: BTreeMap<String, i64>,
+    #[serde(default)]
+    pub requested_location_granularity_counts_by_strategy: BTreeMap<String, BTreeMap<String, i64>>,
 }
 
 /// Annual supply / production volume weight quality diagnostics.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: 3a2f742a147028c28e49b9f3f55094fb420237aa
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: 3a2f742a147028c28e49b9f3f55094fb420237aa
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -23,7 +23,7 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: 3a2f742a147028c28e49b9f3f55094fb420237aa
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -23,7 +23,7 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: 3a2f742a147028c28e49b9f3f55094fb420237aa
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -19,8 +19,8 @@ checkPaths:
   - supabase/migrations/**
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 20919db320e399b9c53f3dd3c03426e79c5b0d40
+lastReviewedAt: 2026-05-19
+lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -175,6 +175,17 @@ snapshot coverage diagnostics 会暴露 snapshot 构建阶段的 provider linkin
 - `geography_summary`：地理层级、strategy × geography tier、supply-region anchor 来源、exchange location 覆盖情况和 location 粒度分布。
 - `volume_weight_summary`：基于 `annualSupplyOrProductionVolume` 的权重数据可用性与 fallback-to-one 情况。
 - `gap_summary`：no-provider gap 的 top flows 与 top processes。
+
+`geography_summary` 中的 canonical 字段包括：
+
+- `tier_counts`：所有 resolved provider decision 的地理匹配层级总计。
+- `tier_counts_by_strategy`：按 resolved strategy 拆分的地理匹配层级，用于判断 `unique_provider` 或 `split_by_process_volume` 各自的本地匹配与地理 fallback 分布。
+- `supply_region_source_counts`：供应区域 anchor 来源总计，典型 key 为 `exchange_location`、`consumer_process_location`、`unspecified`。
+- `supply_region_source_counts_by_strategy`：按 resolved strategy 拆分的供应区域 anchor 来源，用于判断某个 link 策略实际使用 exchange-level location 还是 consumer process location。
+- `exchange_location_present_count`：input exchange 中存在 exchange-level `location` 的总数。
+- `exchange_location_present_count_by_strategy`：按 resolved strategy 拆分的 exchange-level `location` 覆盖数。
+- `requested_location_granularity_counts`：目标供应区域粒度总计，例如 `subnational`、`country`、`region`、`global`、`unspecified`。
+- `requested_location_granularity_counts_by_strategy`：按 resolved strategy 拆分的目标供应区域粒度。
 
 `build_snapshot` job 完成时，`lca_jobs.diagnostics.build_timing_sec` 会记录 snapshot builder 主要阶段耗时。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
 


### PR DESCRIPTION
## Summary

- 新增 `geography_summary` 的 by-strategy 诊断字段：`supply_region_source_counts_by_strategy`、`exchange_location_present_count_by_strategy`、`requested_location_granularity_counts_by_strategy`。
- 在 snapshot builder 聚合 `CompiledProviderDecision` 时按 resolved strategy 统计 supply-region anchor 来源、exchange location 覆盖和目标 location 粒度。
- 更新 coverage API contract 与 docpact review metadata，保持旧 coverage 反序列化默认兼容。

## Validation

- `cargo test -p solver-worker matching_diagnostics_aggregate_v2_summary_groups`
- `cargo fmt --all -- --check`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `docpact validate-config --root . --strict`
- `docpact lint --root . --worktree --mode enforce`
- `make check`

## Notes

- Branch is pushed from the `chukeaa` fork because the active account cannot push directly to `linancn/tiangong-lca-calculator`.
- Workspace integration is required after merge.

Closes #43