### PR TITLE
限制 build_snapshot 并发并参数化数据库连接池

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "fa3e30458b7e20e6d7968b1185834acdb176ce93"
+lastReviewedCommit: "a5cf624ebe294e40cb3d11377678b6020a362631"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -281,6 +281,18 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 - `PGMQ_QUEUE`（默认 `lca_jobs`）
 - `SOLVER_MODE`（`worker` / `http` / `both`）
 - `HTTP_ADDR`（默认 `0.0.0.0:8080`）
+- `WORKER_POLL_MS`（默认 `1000`）
+- `WORKER_VT_SECONDS`（默认 `30`；生产 `build_snapshot` 队列建议按最长任务耗时设置，例如 `1800`）
+
+数据库连接池与 `build_snapshot` 并发：
+
+- `DB_MAX_CONNECTIONS`（worker 进程连接池上限，默认 `8`）
+- `DB_MIN_CONNECTIONS`（worker 进程连接池保留连接数，默认 `1`）
+- `DB_ACQUIRE_TIMEOUT_SECONDS`（worker 获取连接超时，默认 `30`）
+- `BUILD_SNAPSHOT_MAX_CONCURRENCY`（跨 worker 实例的 `build_snapshot` 并发上限，默认 `1`）
+- `BUILD_SNAPSHOT_LOCK_POLL_MS`（等待 `build_snapshot` 并发槽位时的轮询间隔，默认 `5000`）
+- `SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS`（`snapshot_builder` 子进程连接池上限，默认 `4`）
+- `SNAPSHOT_BUILDER_DB_ACQUIRE_TIMEOUT_SECONDS`（`snapshot_builder` 获取连接超时，默认 `30`）
 
 对象存储（snapshot builder / solver-worker / result_gc 必需）：
 
@@ -546,7 +558,7 @@ Group=ubuntu
 WorkingDirectory=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator
 EnvironmentFile=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/.env
 Environment=RUST_LOG=info
-ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/release/solver-worker --mode worker --worker-vt-seconds 600 --worker-poll-ms 300
+ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/release/solver-worker --mode worker --worker-vt-seconds 1800 --worker-poll-ms 300
 Restart=always
 RestartSec=2
 TimeoutStopSec=30
@@ -581,7 +593,9 @@ sudo systemctl restart solver-worker@1 solver-worker@2
 建议：
 
 - 先从 2 个 worker 实例开始，再根据队列积压和 CPU 使用率调整。
-- `WORKER_VT_SECONDS` 需要大于慢任务耗时，避免消息重复消费。
+- `WORKER_VT_SECONDS` 需要大于“等待 `build_snapshot` 并发槽位 + 实际构建”的最慢耗时，避免消息重复消费。
+- 多台机器共享同一个数据库队列时，生产环境建议保持 `BUILD_SNAPSHOT_MAX_CONCURRENCY=1`，用全局 advisory lock 串行化全量快照构建；普通 solve 类任务仍可由多个 worker 实例并行消费。
+- 如 Supabase 连接数紧张，优先调低每个 worker 的 `DB_MAX_CONNECTIONS`，再结合 `SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS` 控制全量构建期间的连接峰值。
 
 ### 6.4 TIDAS Package Worker 常驻（systemd，推荐）
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4e04ac3c840390998ce4280a03c8a75829ba198a
+lastReviewedAt: 2026-05-19
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -14,7 +14,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use clap::Parser;
@@ -56,6 +56,18 @@ struct Cli {
     database_url: Option<String>,
     #[arg(long, env = "CONN")]
     conn: Option<String>,
+    #[arg(
+        long,
+        env = "SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS",
+        default_value_t = 4_u32
+    )]
+    db_max_connections: u32,
+    #[arg(
+        long,
+        env = "SNAPSHOT_BUILDER_DB_ACQUIRE_TIMEOUT_SECONDS",
+        default_value_t = 30_u64
+    )]
+    db_acquire_timeout_seconds: u64,
     #[arg(long, env = "S3_ENDPOINT")]
     s3_endpoint: Option<String>,
     #[arg(long, env = "S3_REGION")]
@@ -388,7 +400,8 @@ async fn main() -> anyhow::Result<()> {
         .or(cli.conn.as_deref())
         .ok_or_else(|| anyhow::anyhow!("missing DB connection: set DATABASE_URL or CONN"))?;
     let pool = PgPoolOptions::new()
-        .max_connections(4)
+        .max_connections(cli.db_max_connections.max(1))
+        .acquire_timeout(Duration::from_secs(cli.db_acquire_timeout_seconds.max(1)))
         .after_connect(|conn, _meta| {
             Box::pin(async move {
                 sqlx::query("SET statement_timeout = 0")

--- a/crates/solver-worker/src/config.rs
+++ b/crates/solver-worker/src/config.rs
@@ -35,6 +35,21 @@ pub struct AppConfig {
     /// Message visibility timeout for pgmq.read.
     #[arg(long, env = "WORKER_VT_SECONDS", default_value_t = 30_i32)]
     pub worker_vt_seconds: i32,
+    /// Maximum number of DB connections held by the worker process.
+    #[arg(long, env = "DB_MAX_CONNECTIONS", default_value_t = 8_u32)]
+    pub db_max_connections: u32,
+    /// Minimum number of DB connections kept by the worker process.
+    #[arg(long, env = "DB_MIN_CONNECTIONS", default_value_t = 1_u32)]
+    pub db_min_connections: u32,
+    /// DB connection acquire timeout for the worker process.
+    #[arg(long, env = "DB_ACQUIRE_TIMEOUT_SECONDS", default_value_t = 30_u64)]
+    pub db_acquire_timeout_seconds: u64,
+    /// Maximum number of concurrent `build_snapshot` jobs across worker instances.
+    #[arg(long, env = "BUILD_SNAPSHOT_MAX_CONCURRENCY", default_value_t = 1_u32)]
+    pub build_snapshot_max_concurrency: u32,
+    /// Poll interval while waiting for a `build_snapshot` concurrency slot.
+    #[arg(long, env = "BUILD_SNAPSHOT_LOCK_POLL_MS", default_value_t = 5_000_u64)]
+    pub build_snapshot_lock_poll_ms: u64,
     /// Internal HTTP bind address.
     #[arg(long, env = "HTTP_ADDR", default_value = "0.0.0.0:8080")]
     pub http_addr: String,
@@ -80,9 +95,92 @@ impl AppConfig {
         Duration::from_millis(self.worker_poll_ms)
     }
 
+    /// Sanitized maximum DB connections for the worker process.
+    #[must_use]
+    pub fn db_max_connections(&self) -> u32 {
+        self.db_max_connections.max(1)
+    }
+
+    /// Sanitized minimum DB connections for the worker process.
+    #[must_use]
+    pub fn db_min_connections(&self) -> u32 {
+        self.db_min_connections.min(self.db_max_connections())
+    }
+
+    /// DB connection acquire timeout.
+    #[must_use]
+    pub fn db_acquire_timeout(&self) -> Duration {
+        Duration::from_secs(self.db_acquire_timeout_seconds.max(1))
+    }
+
+    /// Sanitized maximum `build_snapshot` concurrency.
+    #[must_use]
+    pub fn build_snapshot_max_concurrency(&self) -> u32 {
+        self.build_snapshot_max_concurrency.max(1)
+    }
+
+    /// Poll interval used when all `build_snapshot` concurrency slots are busy.
+    #[must_use]
+    pub fn build_snapshot_lock_poll_interval(&self) -> Duration {
+        Duration::from_millis(self.build_snapshot_lock_poll_ms.max(100))
+    }
+
     /// Parsed http socket addr.
     pub fn http_socket_addr(&self) -> anyhow::Result<SocketAddr> {
         SocketAddr::from_str(&self.http_addr)
             .map_err(|err| anyhow::anyhow!("invalid HTTP_ADDR {}: {err}", self.http_addr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppConfig;
+    use clap::Parser;
+    use std::time::Duration;
+
+    #[test]
+    fn db_and_build_snapshot_config_defaults_match_previous_limits() {
+        let config = AppConfig::parse_from([
+            "solver-worker",
+            "--database-url",
+            "postgres://example.local/app",
+        ]);
+
+        assert_eq!(config.db_max_connections(), 8);
+        assert_eq!(config.db_min_connections(), 1);
+        assert_eq!(config.db_acquire_timeout(), Duration::from_secs(30));
+        assert_eq!(config.build_snapshot_max_concurrency(), 1);
+        assert_eq!(
+            config.build_snapshot_lock_poll_interval(),
+            Duration::from_millis(5_000)
+        );
+    }
+
+    #[test]
+    fn db_and_build_snapshot_config_clamps_invalid_low_values() {
+        let config = AppConfig::parse_from([
+            "solver-worker",
+            "--database-url",
+            "postgres://example.local/app",
+            "--db-max-connections",
+            "0",
+            "--db-min-connections",
+            "4",
+            "--db-acquire-timeout-seconds",
+            "0",
+            "--build-snapshot-max-concurrency",
+            "0",
+            "--build-snapshot-lock-poll-ms",
+            "1",
+        ]);
+
+        assert_eq!(config.db_max_connections(), 1);
+        assert_eq!(config.db_min_connections(), 1);
+        assert_eq!(config.db_acquire_timeout(), Duration::from_secs(1));
+        assert_eq!(config.build_snapshot_max_concurrency(), 1);
+        assert_eq!(
+            config.build_snapshot_lock_poll_interval(),
+            Duration::from_millis(100)
+        );
     }
 }

--- a/crates/solver-worker/src/config.rs
+++ b/crates/solver-worker/src/config.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(config.build_snapshot_max_concurrency(), 1);
         assert_eq!(
             config.build_snapshot_lock_poll_interval(),
-            Duration::from_millis(5_000)
+            Duration::from_secs(5)
         );
     }
 

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -10,8 +10,9 @@ use solver_core::{
     ModelSparseData, NumericOptions, PrepareResult, SolveBatchResult, SolveComputationTiming,
     SolveOptions, SolveResult, SolverService, SparseTriplet,
 };
-use sqlx::{PgPool, Row, postgres::PgPoolOptions};
-use tracing::{instrument, warn};
+use sqlx::{PgPool, Postgres, Row, pool::PoolConnection, postgres::PgPoolOptions};
+use tokio::time::sleep;
+use tracing::{info, instrument, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -45,18 +46,81 @@ pub struct AppState {
     pub solver: SolverService,
     /// Object storage for result/snapshot artifacts.
     pub object_store: ObjectStoreClient,
+    /// Maximum number of concurrent `build_snapshot` jobs across worker instances.
+    pub build_snapshot_max_concurrency: u32,
+    /// Poll interval while waiting for a `build_snapshot` concurrency slot.
+    pub build_snapshot_lock_poll_interval: Duration,
 }
 
 const DEFAULT_ALL_UNIT_BATCH_SIZE: usize = 128;
 const MAX_ALL_UNIT_BATCH_SIZE: usize = 2_048;
+const BUILD_SNAPSHOT_ADVISORY_LOCK_BASE: i64 = 0x5447_4c43_4253_4e50;
+
+struct BuildSnapshotLockGuard {
+    conn: Option<PoolConnection<Postgres>>,
+    key: i64,
+    slot: u32,
+    wait_sec: f64,
+    max_concurrency: u32,
+}
+
+impl BuildSnapshotLockGuard {
+    fn diagnostics(&self) -> Value {
+        serde_json::json!({
+            "enabled": true,
+            "strategy": "postgres_advisory_lock",
+            "max_concurrency": self.max_concurrency,
+            "slot": self.slot,
+            "wait_sec": self.wait_sec,
+        })
+    }
+
+    async fn release(mut self) -> anyhow::Result<()> {
+        let Some(mut conn) = self.conn.take() else {
+            return Ok(());
+        };
+
+        match sqlx::query_scalar::<_, bool>("SELECT pg_advisory_unlock($1)")
+            .bind(self.key)
+            .fetch_one(&mut *conn)
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                warn!(
+                    lock_key = self.key,
+                    slot = self.slot,
+                    "build_snapshot advisory lock was not held when releasing"
+                );
+                Ok(())
+            }
+            Err(err) => {
+                conn.close_on_drop();
+                Err(err.into())
+            }
+        }
+    }
+}
+
+impl Drop for BuildSnapshotLockGuard {
+    fn drop(&mut self) {
+        if self.conn.is_some() {
+            warn!(
+                lock_key = self.key,
+                slot = self.slot,
+                "build_snapshot advisory lock guard dropped before explicit release"
+            );
+        }
+    }
+}
 
 impl AppState {
     /// Creates app state with DB pool and required object storage.
     pub async fn new(config: &AppConfig) -> anyhow::Result<Self> {
         let pool = PgPoolOptions::new()
-            .max_connections(8)
-            .min_connections(1)
-            .acquire_timeout(Duration::from_secs(30))
+            .max_connections(config.db_max_connections())
+            .min_connections(config.db_min_connections())
+            .acquire_timeout(config.db_acquire_timeout())
             .idle_timeout(Duration::from_mins(5))
             .max_lifetime(Duration::from_mins(30))
             .test_before_acquire(true)
@@ -95,7 +159,46 @@ impl AppState {
             pool,
             solver: SolverService::new(),
             object_store,
+            build_snapshot_max_concurrency: config.build_snapshot_max_concurrency(),
+            build_snapshot_lock_poll_interval: config.build_snapshot_lock_poll_interval(),
         })
+    }
+}
+
+async fn acquire_build_snapshot_lock(
+    pool: &PgPool,
+    max_concurrency: u32,
+    poll_interval: Duration,
+) -> anyhow::Result<BuildSnapshotLockGuard> {
+    let started = Instant::now();
+    let max_concurrency = max_concurrency.max(1);
+    let poll_interval = poll_interval.max(Duration::from_millis(100));
+
+    loop {
+        for slot in 0..max_concurrency {
+            let key = BUILD_SNAPSHOT_ADVISORY_LOCK_BASE + i64::from(slot);
+            let mut conn = pool.acquire().await?;
+            let acquired = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+                .bind(key)
+                .fetch_one(&mut *conn)
+                .await?;
+            if acquired {
+                let wait_sec = started.elapsed().as_secs_f64();
+                info!(
+                    lock_key = key,
+                    slot, max_concurrency, wait_sec, "acquired build_snapshot advisory lock"
+                );
+                return Ok(BuildSnapshotLockGuard {
+                    conn: Some(conn),
+                    key,
+                    slot,
+                    wait_sec,
+                    max_concurrency,
+                });
+            }
+        }
+
+        sleep(poll_interval).await;
     }
 }
 
@@ -999,11 +1102,39 @@ pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow
                 serde_json::json!({
                     "phase": "build_snapshot",
                     "snapshot_id": snapshot_id,
+                    "build_snapshot_lock": {
+                        "enabled": true,
+                        "strategy": "postgres_advisory_lock",
+                        "max_concurrency": state.build_snapshot_max_concurrency,
+                        "waiting": true,
+                    },
                 }),
             )
             .await?;
 
-            let executed = run_snapshot_builder_job(
+            let lock_guard = acquire_build_snapshot_lock(
+                &state.pool,
+                state.build_snapshot_max_concurrency,
+                state.build_snapshot_lock_poll_interval,
+            )
+            .await?;
+            let mut build_snapshot_lock = lock_guard.diagnostics();
+            if let Some(lock_payload) = build_snapshot_lock.as_object_mut() {
+                lock_payload.insert("waiting".to_owned(), Value::Bool(false));
+            }
+            let _lock_running_db_write_sec = update_job_status(
+                &state.pool,
+                job_id,
+                "running",
+                serde_json::json!({
+                    "phase": "build_snapshot",
+                    "snapshot_id": snapshot_id,
+                    "build_snapshot_lock": build_snapshot_lock,
+                }),
+            )
+            .await?;
+
+            let executed_result = run_snapshot_builder_job(
                 snapshot_id,
                 process_states.as_deref(),
                 include_user_id,
@@ -1018,7 +1149,27 @@ pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow
                 method_version.as_deref(),
                 no_lcia.unwrap_or(false),
             )
-            .await?;
+            .await;
+            let release_result = lock_guard.release().await;
+            let executed = match executed_result {
+                Ok(executed) => {
+                    if let Err(err) = release_result {
+                        return Err(anyhow::anyhow!(
+                            "failed to release build_snapshot advisory lock: {err}"
+                        ));
+                    }
+                    executed
+                }
+                Err(err) => {
+                    if let Err(release_err) = release_result {
+                        warn!(
+                            error = %release_err,
+                            "failed to release build_snapshot advisory lock after builder failure"
+                        );
+                    }
+                    return Err(err);
+                }
+            };
 
             let resolved_snapshot_id = executed.resolved_snapshot_id;
             let build_timing_sec = executed.build_timing_sec.clone();
@@ -1044,6 +1195,7 @@ pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow
                 "requested_snapshot_id": snapshot_id,
                 "snapshot_id": resolved_snapshot_id,
                 "builder": executed,
+                "build_snapshot_lock": build_snapshot_lock,
                 "source_hash": source_hash,
             });
             if let (Some(build_timing_sec), Some(payload)) =

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -111,7 +111,8 @@ Result artifacts are persisted through the worker and supporting runtime storage
 ## Operational Baseline
 
 - Solve result persistence is S3-only; treat `lca_results` as artifact metadata plus diagnostics, not as an inline result store.
-- The worker DB pool currently uses a 5-minute idle timeout and a 30-minute max lifetime; keep equivalent long-running job headroom if you retune the pool.
+- The worker DB pool is configurable through `DB_MAX_CONNECTIONS`, `DB_MIN_CONNECTIONS`, and `DB_ACQUIRE_TIMEOUT_SECONDS`; it still keeps a 5-minute idle timeout and a 30-minute max lifetime by default, so preserve equivalent long-running job headroom if you retune the pool.
+- `build_snapshot` is globally throttled with a PostgreSQL advisory lock (`BUILD_SNAPSHOT_MAX_CONCURRENCY`, default `1`) across worker instances; keep `WORKER_VT_SECONDS` larger than the worst-case lock wait plus build time.
 - Queue enqueue and protected writes stay on service-side runtime paths guarded by existing RLS and `service_role` boundaries.
 - Worker and snapshot paths require DB connectivity plus the required S3 env set before runtime validation is meaningful.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -23,7 +23,7 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -23,7 +23,7 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -20,7 +20,7 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-05-19
-lastReviewedCommit: fa3e30458b7e20e6d7968b1185834acdb176ce93
+lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -38,7 +38,7 @@ related:
 - 数值核心固定为 `M = I - A`，只解 `M x = y`。
 - `snapshot_builder` 对 elementary flow 的 `B` 采用 `gross` 口径（`Input/Output` 均按原始 `amount` 入模，不做方向符号翻转）。
 - 计算入口是异步 `lca_jobs` + `pgmq`，不走前端直连队列。
-- worker 连接池当前默认采用 `idle_timeout = 5min` 与 `max_lifetime = 30min`，以保证长时求解与 artifact 落盘阶段有稳定连接窗口。
+- worker 连接池可通过 `DB_MAX_CONNECTIONS`、`DB_MIN_CONNECTIONS` 和 `DB_ACQUIRE_TIMEOUT_SECONDS` 调整；默认采用 `max_connections = 8`、`min_connections = 1`、`acquire_timeout = 30s`、`idle_timeout = 5min` 与 `max_lifetime = 30min`，以保证长时求解与 artifact 落盘阶段有稳定连接窗口。
 - 主路径读取 `lca_snapshot_artifacts`（artifact-first），旧 `lca_*_entries` 仅兼容回退。
 - 所有写操作由服务端（Edge Function / worker，`service_role`）执行。
 
@@ -187,7 +187,7 @@ snapshot coverage diagnostics 会暴露 snapshot 构建阶段的 provider linkin
 - `requested_location_granularity_counts`：目标供应区域粒度总计，例如 `subnational`、`country`、`region`、`global`、`unspecified`。
 - `requested_location_granularity_counts_by_strategy`：按 resolved strategy 拆分的目标供应区域粒度。
 
-`build_snapshot` job 完成时，`lca_jobs.diagnostics.build_timing_sec` 会记录 snapshot builder 主要阶段耗时。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
+`build_snapshot` job 运行和完成时，`lca_jobs.diagnostics.build_snapshot_lock` 会记录全局构建并发锁信息，包括 `strategy`、`max_concurrency`、`slot`、`waiting` 与 `wait_sec`；完成时 `lca_jobs.diagnostics.build_timing_sec` 会记录 snapshot builder 主要阶段耗时。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
 
 ## 6. 幂等与请求缓存（建议约束）
 


### PR DESCRIPTION
Closes #45

## Summary
- 将 worker DB 连接池上限、最小连接数和 acquire timeout 暴露为配置项。
- 将 snapshot_builder 子进程 DB 连接池上限和 acquire timeout 暴露为配置项。
- 通过 PostgreSQL advisory lock 限制跨 worker 实例的 build_snapshot 全局并发，并在 job diagnostics 中记录锁等待信息。
- 补充 README、API contract 与架构说明中的运行配置和诊断字段说明。

## Key Decisions
- 默认 BUILD_SNAPSHOT_MAX_CONCURRENCY=1，避免多台 worker 同时触发全量 snapshot 构建压满 Supabase 连接池。
- 锁等待期间不长期占用普通 DB 连接；只有获得 advisory lock 的连接会持有到 builder 结束并显式释放。

## Validation
- make check
- cargo test -p solver-worker
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- scripts/docpact-gate.sh --base origin/main

## Risks / Rollback
- 生产部署时需要同步设置较大的 WORKER_VT_SECONDS，例如 1800，覆盖锁等待时间加实际构建时间，避免 pgmq visibility timeout 导致重复消费。

## Workspace Integration
- 合并后需要在 lca-workspace 更新 tiangong-lca-calculator 子模块指针，并重新部署 worker 服务。