### PR TITLE
fix: make worker queries transaction pooler compatible

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "a5cf624ebe294e40cb3d11377678b6020a362631"
+lastReviewedAt: "2026-05-20"
+lastReviewedCommit: "f7c7d97e64dab987631281c3835eb7d2a343b94a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f23848d58634dbf6f77df741210476f8d7bf61a1
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -278,6 +278,7 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 最小必需：
 
 - `DATABASE_URL` 或 `CONN`
+- `QUEUE_DATABASE_URL` 或 `QUEUE_CONN`（可选；仅用于 pgmq read/archive，未设置时复用 `DATABASE_URL` / `CONN`）
 - `PGMQ_QUEUE`（默认 `lca_jobs`）
 - `SOLVER_MODE`（`worker` / `http` / `both`）
 - `HTTP_ADDR`（默认 `0.0.0.0:8080`）
@@ -289,10 +290,20 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 - `DB_MAX_CONNECTIONS`（worker 进程连接池上限，默认 `8`）
 - `DB_MIN_CONNECTIONS`（worker 进程连接池保留连接数，默认 `1`）
 - `DB_ACQUIRE_TIMEOUT_SECONDS`（worker 获取连接超时，默认 `30`）
+- `QUEUE_DB_MAX_CONNECTIONS`（队列轮询连接池上限，默认 `2`）
+- `QUEUE_DB_MIN_CONNECTIONS`（队列轮询连接池保留连接数，默认 `0`）
+- `QUEUE_DB_ACQUIRE_TIMEOUT_SECONDS`（队列轮询获取连接超时，默认 `30`）
 - `BUILD_SNAPSHOT_MAX_CONCURRENCY`（跨 worker 实例的 `build_snapshot` 并发上限，默认 `1`）
 - `BUILD_SNAPSHOT_LOCK_POLL_MS`（等待 `build_snapshot` 并发槽位时的轮询间隔，默认 `5000`）
 - `SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS`（`snapshot_builder` 子进程连接池上限，默认 `4`）
 - `SNAPSHOT_BUILDER_DB_ACQUIRE_TIMEOUT_SECONDS`（`snapshot_builder` 获取连接超时，默认 `30`）
+
+Supabase 连接说明：
+
+- worker / package worker 支持双连接池：`DATABASE_URL` / `CONN` 用于 solver、package、snapshot builder 与结果写入等主业务查询；`QUEUE_DATABASE_URL` / `QUEUE_CONN` 仅用于 pgmq polling / archive。
+- 推荐生产配置：主业务连接保留在 session/direct 连接或 session pooler；`QUEUE_DATABASE_URL` 使用 Supabase transaction pooler（通常是 `:6543`）。
+- 运行时 SQLx 查询使用非持久 prepared statement，以避免后端复用导致 `sqlx_s_*` 语句名冲突；高频 pgmq polling / archive 操作使用 `raw_sql` 简单查询协议与受限队列名字面量，避免 6543 transaction pooler 不支持 prepared statement 协议导致空轮询失败。
+- `build_snapshot` 全局并发控制使用 transaction-level advisory lock，适配 transaction pooler；生产环境仍建议保持 `BUILD_SNAPSHOT_MAX_CONCURRENCY=1`。
 
 对象存储（snapshot builder / solver-worker / result_gc 必需）：
 

--- a/crates/solver-worker/src/bin/package_worker.rs
+++ b/crates/solver-worker/src/bin/package_worker.rs
@@ -60,7 +60,7 @@ async fn run_package_worker_loop(
     poll_interval: std::time::Duration,
 ) -> anyhow::Result<()> {
     loop {
-        match read_one_queue_message(&state.pool, &queue_name, vt_seconds).await {
+        match read_one_queue_message(&state.queue_pool, &queue_name, vt_seconds).await {
             Ok(Some(message)) => {
                 let parsed = serde_json::from_value::<PackageJobPayload>(message.payload.clone());
                 match parsed {
@@ -151,7 +151,7 @@ async fn run_package_worker_loop(
                 }
 
                 if let Err(err) =
-                    archive_queue_message(&state.pool, &queue_name, message.msg_id).await
+                    archive_queue_message(&state.queue_pool, &queue_name, message.msg_id).await
                 {
                     error!(error = %err, msg_id = message.msg_id, "failed to archive queue message");
                 }

--- a/crates/solver-worker/src/bin/result_gc.rs
+++ b/crates/solver-worker/src/bin/result_gc.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
+use solver_worker::pgbouncer_sqlx::{self as sqlx, Row, postgres::PgPoolOptions};
 use solver_worker::storage::ObjectStoreClient;
-use sqlx::{Row, postgres::PgPoolOptions};
 use uuid::Uuid;
 
 #[derive(Debug, Parser)]

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -34,6 +34,7 @@ use solver_worker::compiled_graph::{
 use solver_worker::graph_types::{
     RequestRootProcess, ResolvedScopeProcess, ScopeProcessPartition, SnapshotSelectionMode,
 };
+use solver_worker::pgbouncer_sqlx::{self as sqlx, PgPool, Row, postgres::PgPoolOptions};
 use solver_worker::snapshot_artifacts::{
     SNAPSHOT_ARTIFACT_FORMAT, SnapshotAllocationCoverage, SnapshotBuildConfig,
     SnapshotCandidateSummary, SnapshotCoverageReport, SnapshotGapSummary, SnapshotGeographySummary,
@@ -46,7 +47,6 @@ use solver_worker::snapshot_index::{
     SnapshotImpactMapEntry, SnapshotIndexDocument, SnapshotProcessMapEntry,
 };
 use solver_worker::storage::ObjectStoreClient;
-use sqlx::{PgPool, Row, postgres::PgPoolOptions};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Parser)]
@@ -822,7 +822,7 @@ async fn resolve_method_identity(pool: &PgPool, cli: &Cli) -> anyhow::Result<Met
             .method_version
             .clone()
             .ok_or_else(|| anyhow::anyhow!("missing method version"))?;
-        let factor_count = sqlx::query_scalar::<_, i64>(
+        let factor_count = sqlx::query_scalar::<i64>(
             r#"
             SELECT
               CASE

--- a/crates/solver-worker/src/config.rs
+++ b/crates/solver-worker/src/config.rs
@@ -26,6 +26,13 @@ pub struct AppConfig {
     /// `PostgreSQL` URL fallback used by this project in local `.env`.
     #[arg(long, env = "CONN")]
     pub conn: Option<String>,
+    /// Optional queue-only `PostgreSQL` URL. Use this for transaction poolers
+    /// such as Supabase 6543 while keeping main compute queries on `DATABASE_URL`.
+    #[arg(long, env = "QUEUE_DATABASE_URL")]
+    pub queue_database_url: Option<String>,
+    /// Queue-only `PostgreSQL` URL fallback used by this project in local `.env`.
+    #[arg(long, env = "QUEUE_CONN")]
+    pub queue_conn: Option<String>,
     /// Queue name in pgmq.
     #[arg(long, env = "PGMQ_QUEUE", default_value = "lca_jobs")]
     pub pgmq_queue: String,
@@ -44,6 +51,19 @@ pub struct AppConfig {
     /// DB connection acquire timeout for the worker process.
     #[arg(long, env = "DB_ACQUIRE_TIMEOUT_SECONDS", default_value_t = 30_u64)]
     pub db_acquire_timeout_seconds: u64,
+    /// Maximum number of DB connections held by the queue polling pool.
+    #[arg(long, env = "QUEUE_DB_MAX_CONNECTIONS", default_value_t = 2_u32)]
+    pub queue_db_max_connections: u32,
+    /// Minimum number of DB connections kept by the queue polling pool.
+    #[arg(long, env = "QUEUE_DB_MIN_CONNECTIONS", default_value_t = 0_u32)]
+    pub queue_db_min_connections: u32,
+    /// DB connection acquire timeout for the queue polling pool.
+    #[arg(
+        long,
+        env = "QUEUE_DB_ACQUIRE_TIMEOUT_SECONDS",
+        default_value_t = 30_u64
+    )]
+    pub queue_db_acquire_timeout_seconds: u64,
     /// Maximum number of concurrent `build_snapshot` jobs across worker instances.
     #[arg(long, env = "BUILD_SNAPSHOT_MAX_CONCURRENCY", default_value_t = 1_u32)]
     pub build_snapshot_max_concurrency: u32,
@@ -89,6 +109,21 @@ impl AppConfig {
             })
     }
 
+    /// Returns queue-only database URL from `QUEUE_DATABASE_URL` / `QUEUE_CONN`,
+    /// falling back to the main runtime database URL.
+    pub fn resolved_queue_database_url(&self) -> anyhow::Result<&str> {
+        self.queue_database_url
+            .as_deref()
+            .or(self.queue_conn.as_deref())
+            .map_or_else(|| self.resolved_database_url(), Ok)
+    }
+
+    /// Returns whether queue DB URL was explicitly configured.
+    #[must_use]
+    pub fn has_explicit_queue_database_url(&self) -> bool {
+        self.queue_database_url.is_some() || self.queue_conn.is_some()
+    }
+
     /// Poll interval as Duration.
     #[must_use]
     pub fn poll_interval(&self) -> Duration {
@@ -111,6 +146,25 @@ impl AppConfig {
     #[must_use]
     pub fn db_acquire_timeout(&self) -> Duration {
         Duration::from_secs(self.db_acquire_timeout_seconds.max(1))
+    }
+
+    /// Sanitized maximum DB connections for the queue polling pool.
+    #[must_use]
+    pub fn queue_db_max_connections(&self) -> u32 {
+        self.queue_db_max_connections.max(1)
+    }
+
+    /// Sanitized minimum DB connections for the queue polling pool.
+    #[must_use]
+    pub fn queue_db_min_connections(&self) -> u32 {
+        self.queue_db_min_connections
+            .min(self.queue_db_max_connections())
+    }
+
+    /// Queue DB connection acquire timeout.
+    #[must_use]
+    pub fn queue_db_acquire_timeout(&self) -> Duration {
+        Duration::from_secs(self.queue_db_acquire_timeout_seconds.max(1))
     }
 
     /// Sanitized maximum `build_snapshot` concurrency.
@@ -149,6 +203,14 @@ mod tests {
         assert_eq!(config.db_max_connections(), 8);
         assert_eq!(config.db_min_connections(), 1);
         assert_eq!(config.db_acquire_timeout(), Duration::from_secs(30));
+        assert_eq!(
+            config.resolved_queue_database_url().unwrap(),
+            "postgres://example.local/app"
+        );
+        assert!(!config.has_explicit_queue_database_url());
+        assert_eq!(config.queue_db_max_connections(), 2);
+        assert_eq!(config.queue_db_min_connections(), 0);
+        assert_eq!(config.queue_db_acquire_timeout(), Duration::from_secs(30));
         assert_eq!(config.build_snapshot_max_concurrency(), 1);
         assert_eq!(
             config.build_snapshot_lock_poll_interval(),
@@ -168,6 +230,12 @@ mod tests {
             "4",
             "--db-acquire-timeout-seconds",
             "0",
+            "--queue-db-max-connections",
+            "0",
+            "--queue-db-min-connections",
+            "4",
+            "--queue-db-acquire-timeout-seconds",
+            "0",
             "--build-snapshot-max-concurrency",
             "0",
             "--build-snapshot-lock-poll-ms",
@@ -177,10 +245,30 @@ mod tests {
         assert_eq!(config.db_max_connections(), 1);
         assert_eq!(config.db_min_connections(), 1);
         assert_eq!(config.db_acquire_timeout(), Duration::from_secs(1));
+        assert_eq!(config.queue_db_max_connections(), 1);
+        assert_eq!(config.queue_db_min_connections(), 1);
+        assert_eq!(config.queue_db_acquire_timeout(), Duration::from_secs(1));
         assert_eq!(config.build_snapshot_max_concurrency(), 1);
         assert_eq!(
             config.build_snapshot_lock_poll_interval(),
             Duration::from_millis(100)
         );
+    }
+
+    #[test]
+    fn queue_database_url_overrides_main_database_url() {
+        let config = AppConfig::parse_from([
+            "solver-worker",
+            "--database-url",
+            "postgres://example.local/app",
+            "--queue-database-url",
+            "postgres://pooler.example.local/app",
+        ]);
+
+        assert_eq!(
+            config.resolved_queue_database_url().unwrap(),
+            "postgres://pooler.example.local/app"
+        );
+        assert!(config.has_explicit_queue_database_url());
     }
 }

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -5,12 +5,14 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::pgbouncer_sqlx::{
+    self as sqlx, PgPool, Postgres, Row, Transaction, postgres::PgPoolOptions,
+};
 use serde_json::{Map, Value};
 use solver_core::{
     ModelSparseData, NumericOptions, PrepareResult, SolveBatchResult, SolveComputationTiming,
     SolveOptions, SolveResult, SolverService, SparseTriplet,
 };
-use sqlx::{PgPool, Postgres, Row, pool::PoolConnection, postgres::PgPoolOptions};
 use tokio::time::sleep;
 use tracing::{info, instrument, warn};
 use uuid::Uuid;
@@ -40,8 +42,10 @@ pub struct QueueMessage {
 /// App state shared by worker and HTTP server.
 #[derive(Debug)]
 pub struct AppState {
-    /// DB pool.
+    /// Main DB pool for compute, package, snapshot, and result persistence queries.
     pub pool: PgPool,
+    /// Queue-only DB pool for pgmq read/archive operations.
+    pub queue_pool: PgPool,
     /// Core solver service.
     pub solver: SolverService,
     /// Object storage for result/snapshot artifacts.
@@ -56,8 +60,19 @@ const DEFAULT_ALL_UNIT_BATCH_SIZE: usize = 128;
 const MAX_ALL_UNIT_BATCH_SIZE: usize = 2_048;
 const BUILD_SNAPSHOT_ADVISORY_LOCK_BASE: i64 = 0x5447_4c43_4253_4e50;
 
+fn pgmq_queue_name_literal(queue_name: &str) -> anyhow::Result<String> {
+    if queue_name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        Ok(format!("'{queue_name}'"))
+    } else {
+        Err(anyhow::anyhow!("invalid pgmq queue name: {queue_name}"))
+    }
+}
+
 struct BuildSnapshotLockGuard {
-    conn: Option<PoolConnection<Postgres>>,
+    tx: Option<Transaction<'static, Postgres>>,
     key: i64,
     slot: u32,
     wait_sec: f64,
@@ -68,7 +83,7 @@ impl BuildSnapshotLockGuard {
     fn diagnostics(&self) -> Value {
         serde_json::json!({
             "enabled": true,
-            "strategy": "postgres_advisory_lock",
+            "strategy": "postgres_transaction_advisory_lock",
             "max_concurrency": self.max_concurrency,
             "slot": self.slot,
             "wait_sec": self.wait_sec,
@@ -76,39 +91,22 @@ impl BuildSnapshotLockGuard {
     }
 
     async fn release(mut self) -> anyhow::Result<()> {
-        let Some(mut conn) = self.conn.take() else {
+        let Some(tx) = self.tx.take() else {
             return Ok(());
         };
 
-        match sqlx::query_scalar::<_, bool>("SELECT pg_advisory_unlock($1)")
-            .bind(self.key)
-            .fetch_one(&mut *conn)
-            .await
-        {
-            Ok(true) => Ok(()),
-            Ok(false) => {
-                warn!(
-                    lock_key = self.key,
-                    slot = self.slot,
-                    "build_snapshot advisory lock was not held when releasing"
-                );
-                Ok(())
-            }
-            Err(err) => {
-                conn.close_on_drop();
-                Err(err.into())
-            }
-        }
+        tx.commit().await?;
+        Ok(())
     }
 }
 
 impl Drop for BuildSnapshotLockGuard {
     fn drop(&mut self) {
-        if self.conn.is_some() {
+        if self.tx.is_some() {
             warn!(
                 lock_key = self.key,
                 slot = self.slot,
-                "build_snapshot advisory lock guard dropped before explicit release"
+                "build_snapshot transaction advisory lock guard dropped before explicit release"
             );
         }
     }
@@ -117,15 +115,25 @@ impl Drop for BuildSnapshotLockGuard {
 impl AppState {
     /// Creates app state with DB pool and required object storage.
     pub async fn new(config: &AppConfig) -> anyhow::Result<Self> {
-        let pool = PgPoolOptions::new()
-            .max_connections(config.db_max_connections())
-            .min_connections(config.db_min_connections())
-            .acquire_timeout(config.db_acquire_timeout())
-            .idle_timeout(Duration::from_mins(5))
-            .max_lifetime(Duration::from_mins(30))
-            .test_before_acquire(true)
-            .connect(config.resolved_database_url()?)
-            .await?;
+        let pool = connect_pool(
+            config.resolved_database_url()?,
+            config.db_max_connections(),
+            config.db_min_connections(),
+            config.db_acquire_timeout(),
+        )
+        .await?;
+
+        let queue_pool = if config.has_explicit_queue_database_url() {
+            connect_pool(
+                config.resolved_queue_database_url()?,
+                config.queue_db_max_connections(),
+                config.queue_db_min_connections(),
+                config.queue_db_acquire_timeout(),
+            )
+            .await?
+        } else {
+            pool.clone()
+        };
 
         let endpoint = config
             .s3_endpoint
@@ -157,12 +165,30 @@ impl AppState {
 
         Ok(Self {
             pool,
+            queue_pool,
             solver: SolverService::new(),
             object_store,
             build_snapshot_max_concurrency: config.build_snapshot_max_concurrency(),
             build_snapshot_lock_poll_interval: config.build_snapshot_lock_poll_interval(),
         })
     }
+}
+
+async fn connect_pool(
+    database_url: &str,
+    max_connections: u32,
+    min_connections: u32,
+    acquire_timeout: Duration,
+) -> anyhow::Result<PgPool> {
+    Ok(PgPoolOptions::new()
+        .max_connections(max_connections)
+        .min_connections(min_connections)
+        .acquire_timeout(acquire_timeout)
+        .idle_timeout(Duration::from_mins(5))
+        .max_lifetime(Duration::from_mins(30))
+        .test_before_acquire(true)
+        .connect(database_url)
+        .await?)
 }
 
 async fn acquire_build_snapshot_lock(
@@ -177,25 +203,29 @@ async fn acquire_build_snapshot_lock(
     loop {
         for slot in 0..max_concurrency {
             let key = BUILD_SNAPSHOT_ADVISORY_LOCK_BASE + i64::from(slot);
-            let mut conn = pool.acquire().await?;
-            let acquired = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+            let mut tx = pool.begin().await?;
+            let acquired = sqlx::query_scalar::<bool>("SELECT pg_try_advisory_xact_lock($1)")
                 .bind(key)
-                .fetch_one(&mut *conn)
+                .fetch_one(&mut *tx)
                 .await?;
             if acquired {
                 let wait_sec = started.elapsed().as_secs_f64();
                 info!(
                     lock_key = key,
-                    slot, max_concurrency, wait_sec, "acquired build_snapshot advisory lock"
+                    slot,
+                    max_concurrency,
+                    wait_sec,
+                    "acquired build_snapshot transaction advisory lock"
                 );
                 return Ok(BuildSnapshotLockGuard {
-                    conn: Some(conn),
+                    tx: Some(tx),
                     key,
                     slot,
                     wait_sec,
                     max_concurrency,
                 });
             }
+            tx.rollback().await?;
         }
 
         sleep(poll_interval).await;
@@ -209,26 +239,26 @@ pub async fn read_one_queue_message(
     queue_name: &str,
     vt_seconds: i32,
 ) -> anyhow::Result<Option<QueueMessage>> {
-    let row = sqlx::query(
+    let queue_name = pgmq_queue_name_literal(queue_name)?;
+    let rows = sqlx::raw_sql(&format!(
         r"
         SELECT msg_id, message
-        FROM pgmq.read($1, $2, $3)
+        FROM pgmq.read({queue_name}, {vt_seconds}, 1)
         LIMIT 1
-        ",
-    )
-    .bind(queue_name)
-    .bind(vt_seconds)
-    .bind(1_i32)
-    .fetch_optional(pool)
+        "
+    ))
+    .fetch_all(pool)
     .await?;
 
-    row.map(|r| {
-        Ok(QueueMessage {
-            msg_id: r.try_get::<i64, _>("msg_id")?,
-            payload: r.try_get::<Value, _>("message")?,
+    rows.into_iter()
+        .next()
+        .map(|r| {
+            Ok(QueueMessage {
+                msg_id: r.try_get::<i64, _>("msg_id")?,
+                payload: r.try_get::<Value, _>("message")?,
+            })
         })
-    })
-    .transpose()
+        .transpose()
 }
 
 /// Archives processed message.
@@ -238,9 +268,8 @@ pub async fn archive_queue_message(
     queue_name: &str,
     msg_id: i64,
 ) -> anyhow::Result<()> {
-    let _ = sqlx::query("SELECT pgmq.archive($1, $2)")
-        .bind(queue_name)
-        .bind(msg_id)
+    let queue_name = pgmq_queue_name_literal(queue_name)?;
+    let _ = sqlx::raw_sql(&format!("SELECT pgmq.archive({queue_name}, {msg_id})"))
         .execute(pool)
         .await?;
     Ok(())
@@ -1104,7 +1133,7 @@ pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow
                     "snapshot_id": snapshot_id,
                     "build_snapshot_lock": {
                         "enabled": true,
-                        "strategy": "postgres_advisory_lock",
+                        "strategy": "postgres_transaction_advisory_lock",
                         "max_concurrency": state.build_snapshot_max_concurrency,
                         "waiting": true,
                     },

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -22,6 +22,7 @@ pub mod package_artifacts;
 pub mod package_db;
 pub mod package_execution;
 pub mod package_types;
+pub mod pgbouncer_sqlx;
 pub mod queue;
 pub mod snapshot_artifacts;
 pub mod snapshot_index;

--- a/crates/solver-worker/src/package_db.rs
+++ b/crates/solver-worker/src/package_db.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
+use crate::pgbouncer_sqlx::{self as sqlx, PgPool, Row};
 use serde_json::{Map, Value};
-use sqlx::{PgPool, Row};
 use tracing::{instrument, warn};
 use uuid::Uuid;
 

--- a/crates/solver-worker/src/package_execution.rs
+++ b/crates/solver-worker/src/package_execution.rs
@@ -9,10 +9,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::pgbouncer_sqlx::{self as sqlx, PgPool, Postgres, QueryBuilder, Row};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
-use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use tempfile::{Builder, NamedTempFile, TempDir};
 use uuid::Uuid;
 use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
@@ -955,7 +955,7 @@ async fn fetch_scope_seed_scan_batch_after_cursor(
     builder
         .push(" ORDER BY id ASC, version ASC LIMIT ")
         .push_bind(limit);
-    let rows = builder.build().fetch_all(pool).await?;
+    let rows = builder.build().persistent(false).fetch_all(pool).await?;
 
     rows.iter()
         .map(|row| parse_seed_scan_entry_row(table, row))
@@ -1005,7 +1005,7 @@ async fn insert_export_items(
                   refs_done = lca_package_export_items.refs_done OR EXCLUDED.refs_done, \
                   updated_at = NOW()",
         );
-        builder.build().execute(pool).await?;
+        builder.build().persistent(false).execute(pool).await?;
     }
 
     Ok(())

--- a/crates/solver-worker/src/pgbouncer_sqlx.rs
+++ b/crates/solver-worker/src/pgbouncer_sqlx.rs
@@ -1,0 +1,44 @@
+//! `SQLx` helpers for `PostgreSQL` transaction poolers.
+//!
+//! Supabase's 6543 pooler uses transaction pooling. Persistent `SQLx` prepared
+//! statements are named per client connection, but transaction poolers reuse
+//! backend sessions across clients, which can make names such as `sqlx_s_1`
+//! collide or point to the wrong statement. Keep runtime queries non-persistent
+//! so `SQLx` does not reuse named prepared statements across pooler sessions.
+//!
+//! `SQLx` still uses the prepared-statement protocol for bound `PostgreSQL`
+//! queries. Hot queue operations can use a queue-only pool pointed at the
+//! transaction pooler, then execute through `raw_sql` and validated queue-name
+//! literals so they run through the simple query protocol instead.
+
+pub use ::sqlx::*;
+
+pub fn query(
+    sql: &str,
+) -> ::sqlx::query::Query<'_, ::sqlx::Postgres, ::sqlx::postgres::PgArguments> {
+    ::sqlx::query::<::sqlx::Postgres>(sql).persistent(false)
+}
+
+pub fn query_scalar<'q, O>(
+    sql: &'q str,
+) -> ::sqlx::query::QueryScalar<'q, ::sqlx::Postgres, O, ::sqlx::postgres::PgArguments>
+where
+    O: Send,
+    (O,): for<'r> ::sqlx::FromRow<'r, ::sqlx::postgres::PgRow>,
+{
+    ::sqlx::query_scalar::<::sqlx::Postgres, O>(sql).persistent(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{query, query_scalar};
+
+    #[test]
+    fn query_helpers_disable_persistent_prepared_statements() {
+        let query = query("SELECT 1");
+        assert!(!::sqlx::Execute::persistent(&query));
+
+        let scalar = query_scalar::<i64>("SELECT 1");
+        assert!(!::sqlx::Execute::persistent(&scalar));
+    }
+}

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::pgbouncer_sqlx as sqlx;
 use serde_json::Value;
 use tokio::time::sleep;
 use tracing::{error, info, instrument, warn};
@@ -28,7 +29,7 @@ fn extract_snapshot_id(payload: &JobPayload) -> Option<Uuid> {
 
 /// Fetches snapshot coverage from `lca_snapshot_artifacts` for richer error diagnostics.
 async fn fetch_snapshot_coverage(pool: &sqlx::PgPool, snapshot_id: Uuid) -> Option<Value> {
-    sqlx::query_scalar::<_, Value>(
+    sqlx::query_scalar::<Value>(
         "SELECT coverage FROM public.lca_snapshot_artifacts \
          WHERE snapshot_id = $1 AND status = 'ready' \
          ORDER BY created_at DESC LIMIT 1",
@@ -48,7 +49,7 @@ async fn detect_duplicate_exchange_processes(
     pool: &sqlx::PgPool,
     snapshot_id: Uuid,
 ) -> Option<Value> {
-    let result = sqlx::query_scalar::<_, Value>(
+    let result = sqlx::query_scalar::<Value>(
         r"
         WITH snapshot_scope AS (
             SELECT
@@ -125,7 +126,7 @@ async fn detect_duplicate_exchange_processes(
 /// in the same process with identical amounts — the process "provides to itself".
 /// This creates numerical instability (negative activities) in the solver.
 async fn detect_service_loop_processes(pool: &sqlx::PgPool, snapshot_id: Uuid) -> Option<Value> {
-    let result = sqlx::query_scalar::<_, Value>(
+    let result = sqlx::query_scalar::<Value>(
         r"
         WITH snapshot_scope AS (
             SELECT
@@ -232,7 +233,7 @@ pub async fn run_worker_loop(
     poll_interval: std::time::Duration,
 ) -> anyhow::Result<()> {
     loop {
-        match read_one_queue_message(&state.pool, &queue_name, vt_seconds).await {
+        match read_one_queue_message(&state.queue_pool, &queue_name, vt_seconds).await {
             Ok(Some(message)) => {
                 let parsed = serde_json::from_value::<JobPayload>(message.payload.clone());
                 match parsed {
@@ -280,7 +281,7 @@ pub async fn run_worker_loop(
                 }
 
                 if let Err(err) =
-                    archive_queue_message(&state.pool, &queue_name, message.msg_id).await
+                    archive_queue_message(&state.queue_pool, &queue_name, message.msg_id).await
                 {
                     error!(error = %err, msg_id = message.msg_id, "failed to archive queue message");
                 }

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f23848d58634dbf6f77df741210476f8d7bf61a1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -111,8 +111,9 @@ Result artifacts are persisted through the worker and supporting runtime storage
 ## Operational Baseline
 
 - Solve result persistence is S3-only; treat `lca_results` as artifact metadata plus diagnostics, not as an inline result store.
-- The worker DB pool is configurable through `DB_MAX_CONNECTIONS`, `DB_MIN_CONNECTIONS`, and `DB_ACQUIRE_TIMEOUT_SECONDS`; it still keeps a 5-minute idle timeout and a 30-minute max lifetime by default, so preserve equivalent long-running job headroom if you retune the pool.
-- `build_snapshot` is globally throttled with a PostgreSQL advisory lock (`BUILD_SNAPSHOT_MAX_CONCURRENCY`, default `1`) across worker instances; keep `WORKER_VT_SECONDS` larger than the worst-case lock wait plus build time.
+- The worker uses a main DB pool plus an optional queue-only DB pool. The main pool is configured through `DATABASE_URL` / `CONN`, `DB_MAX_CONNECTIONS`, `DB_MIN_CONNECTIONS`, and `DB_ACQUIRE_TIMEOUT_SECONDS`; it should remain on a session/direct connection or session pooler when compute paths use SQLx bound queries. The queue-only pool is configured through `QUEUE_DATABASE_URL` / `QUEUE_CONN`, `QUEUE_DB_MAX_CONNECTIONS`, `QUEUE_DB_MIN_CONNECTIONS`, and `QUEUE_DB_ACQUIRE_TIMEOUT_SECONDS`; if no queue URL is set it reuses the main pool.
+- `build_snapshot` is globally throttled with a PostgreSQL transaction-level advisory lock (`BUILD_SNAPSHOT_MAX_CONCURRENCY`, default `1`) across worker instances; keep `WORKER_VT_SECONDS` larger than the worst-case lock wait plus build time.
+- Runtime SQLx queries use non-persistent prepared statements so the worker does not reuse named prepared statements across PostgreSQL session reuse boundaries. High-frequency pgmq polling and archive operations use the queue-only pool plus `raw_sql` with validated queue-name literals so they can run through the simple query protocol on Supabase's 6543 transaction pooler without moving compute/package/snapshot queries onto that pooler.
 - Queue enqueue and protected writes stay on service-side runtime paths guarded by existing RLS and `service_role` boundaries.
 - Worker and snapshot paths require DB connectivity plus the required S3 env set before runtime validation is meaningful.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f23848d58634dbf6f77df741210476f8d7bf61a1
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f23848d58634dbf6f77df741210476f8d7bf61a1
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -19,8 +19,8 @@ checkPaths:
   - supabase/migrations/**
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: a5cf624ebe294e40cb3d11377678b6020a362631
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -187,7 +187,7 @@ snapshot coverage diagnostics 会暴露 snapshot 构建阶段的 provider linkin
 - `requested_location_granularity_counts`：目标供应区域粒度总计，例如 `subnational`、`country`、`region`、`global`、`unspecified`。
 - `requested_location_granularity_counts_by_strategy`：按 resolved strategy 拆分的目标供应区域粒度。
 
-`build_snapshot` job 运行和完成时，`lca_jobs.diagnostics.build_snapshot_lock` 会记录全局构建并发锁信息，包括 `strategy`、`max_concurrency`、`slot`、`waiting` 与 `wait_sec`；完成时 `lca_jobs.diagnostics.build_timing_sec` 会记录 snapshot builder 主要阶段耗时。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
+`build_snapshot` job 运行和完成时，`lca_jobs.diagnostics.build_snapshot_lock` 会记录全局构建并发锁信息，包括 `strategy`、`max_concurrency`、`slot`、`waiting` 与 `wait_sec`；当前 `strategy` 为 `postgres_transaction_advisory_lock`。完成时 `lca_jobs.diagnostics.build_timing_sec` 会记录 snapshot builder 主要阶段耗时。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
 
 ## 6. 幂等与请求缓存（建议约束）
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - .docpact/config.yaml
   - crates/solver-worker/**
   - docs/agents/repo-validation.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4e04ac3c840390998ce4280a03c8a75829ba198a
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #47

## Summary
- Add a dual-pool worker DB model: `DATABASE_URL` / `CONN` stays as the main compute/package/snapshot pool, while optional `QUEUE_DATABASE_URL` / `QUEUE_CONN` is used only for pgmq read/archive.
- Disable persistent SQLx prepared statement reuse through a runtime query helper.
- Move pgmq read/archive polling to `raw_sql` simple query protocol with validated queue-name literals for Supabase 6543 transaction pooler compatibility.
- Switch build_snapshot concurrency locking to transaction-level advisory locks and document the recommended Supabase pooler setup.

## Validation
- cargo fmt --all -- --check
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo test -p solver-worker --all-features
- docpact lint --worktree --mode enforce

## Deployment note
Deployed commit `08fa199` to the three worker hosts for runtime verification. Runtime env now uses main `CONN` on `:5432` and queue-only `QUEUE_DATABASE_URL` on `:6543`. Queue polling is clean after the `2026-05-20 07:39 UTC` restart window.