### PR TITLE
docs: document matrix readiness report codes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-24"
-lastReviewedCommit: "b91dc5253939c88e32b9caafc48350e38fcc1bec"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "48a86e85dde828830d22d1de9ae9585ec1fec365"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.
@@ -27,6 +27,7 @@ ownership:
           - .docpact/**
           - docs/agents/**
           - docs/lca-api-contract.md
+          - docs/matrix-readiness-report-contract.md
           - docs/edge-function-integration.md
           - docs/frontend-integration.md
           - docs/implicit-regional-supply-mix-modeling.md
@@ -75,6 +76,7 @@ coverage:
     - docs/agents/repo-validation.md
     - docs/agents/repo-architecture.md
     - docs/lca-api-contract.md
+    - docs/matrix-readiness-report-contract.md
     - docs/edge-function-integration.md
     - docs/frontend-integration.md
     - docs/implicit-regional-supply-mix-modeling.md
@@ -116,6 +118,15 @@ routing:
         - crates/solver-core/**
         - crates/solver-worker/src/**
         - docs/lca-api-contract.md
+        - docs/matrix-readiness-report-contract.md
+    matrix-readiness:
+      paths:
+        - crates/solver-worker/src/readiness.rs
+        - crates/solver-worker/src/bin/matrix_readiness.rs
+        - crates/solver-worker/src/bin/snapshot_builder.rs
+        - crates/solver-worker/src/compiled_graph.rs
+        - docs/matrix-readiness-report-contract.md
+        - docs/agents/repo-validation.md
     snapshot-and-provider:
       paths:
         - crates/solver-worker/src/bin/snapshot_builder.rs
@@ -165,6 +176,7 @@ routing:
         - .docpact/**
         - docs/agents/**
         - docs/lca-api-contract.md
+        - docs/matrix-readiness-report-contract.md
         - docs/edge-function-integration.md
         - docs/frontend-integration.md
         - docs/implicit-regional-supply-mix-modeling.md
@@ -182,6 +194,7 @@ docInventory:
     - docs/agents/repo-validation.md
     - docs/agents/repo-architecture.md
     - docs/lca-api-contract.md
+    - docs/matrix-readiness-report-contract.md
     - docs/edge-function-integration.md
     - docs/frontend-integration.md
     - docs/implicit-regional-supply-mix-modeling.md
@@ -329,6 +342,30 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
     reason: Shared jobs, payload, and result semantics must stay aligned with repo runtime and proof guidance.
+  - id: calculator-matrix-readiness-report-contract
+    scope: repo
+    repo: calculator
+    triggers:
+      - path: docs/matrix-readiness-report-contract.md
+        kind: runtime-contract
+      - path: crates/solver-worker/src/readiness.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/bin/matrix_readiness.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/bin/snapshot_builder.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/compiled_graph.rs
+        kind: runtime-code
+    requiredDocs:
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: docs/matrix-readiness-report-contract.md
+        mode: review_or_update
+    reason: Calculator-owned matrix-readiness report semantics must stay aligned with the CLI, snapshot artifact output, provider evidence, and proof guidance.
   - id: calculator-edge-frontend-integration-contract
     scope: repo
     repo: calculator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ checkPaths:
   - .docpact/**/*.yaml
   - docs/agents/**
   - docs/lca-api-contract.md
+  - docs/matrix-readiness-report-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/implicit-regional-supply-mix-modeling.md
@@ -36,13 +37,14 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: b91dc5253939c88e32b9caafc48350e38fcc1bec
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
   - docs/lca-api-contract.md
+  - docs/matrix-readiness-report-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
@@ -64,6 +66,7 @@ Start here when the task may change what the compute stack does.
 | `docs/agents/repo-architecture.md` | compact repo mental model, stable path map, hotspot families, and common misreads | checklist-style proof guidance or current work queue |
 | `README.md` | repo landing context, operator setup, and runtime overview | machine-readable routing or lint semantics |
 | `docs/lca-api-contract.md` | shared jobs/results/payload/status contract for consumers | branch policy, proof matrix, or edge/frontend implementation details |
+| `docs/matrix-readiness-report-contract.md` | calculator-owned matrix-readiness CLI and report artifact schema, blocker/finding codes, next_action semantics, and policy surface | HTTP endpoint contract or edge request/auth behavior |
 | `docs/edge-function-integration.md` | edge-facing enqueue, polling, and service-role integration contract | solver internals or frontend UX rules |
 | `docs/frontend-integration.md` | frontend-facing solve/result interaction contract | edge auth implementation or solver internals |
 | `docs/implicit-regional-supply-mix-modeling.md` / `docs/implicit-regional-supply-mix-modeling.en.md` | Chinese and English modeling basis for implicit regional supply mix, exchange-location supply-region anchors, and annual-volume provider share semantics | implementation checklist or consumer API contract |
@@ -78,6 +81,7 @@ Read in this order:
 3. `docs/agents/repo-validation.md` or `docs/agents/repo-architecture.md`
 4. load only the narrow contract doc that matches the task:
    - `docs/lca-api-contract.md`
+   - `docs/matrix-readiness-report-contract.md`
    - `docs/edge-function-integration.md`
    - `docs/frontend-integration.md`
    - `docs/implicit-regional-supply-mix-modeling.md`
@@ -92,9 +96,9 @@ Do not start from the root workspace or the edge repo if the change is really ab
 - path-level ownership, routing intents, governed-doc inventory, and lint rules live in `.docpact/config.yaml`
 - minimum proof and manual helper expectations live in `docs/agents/repo-validation.md`
 - stable path groups and hotspot families live in `docs/agents/repo-architecture.md`
-- runtime-facing consumer contracts live in the narrow docs under `docs/*.md`
+- runtime-facing consumer contracts and report artifact contracts live in the narrow docs under `docs/*.md`
 - repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
-- the main routing intents are `solver-runtime`, `snapshot-and-provider`, `package-worker`, `runtime-sql-boundary`, `debug-and-parity`, `edge-api-boundary`, `frontend-integration`, `proof`, `repo-docs`, and `root-integration`
+- the main routing intents are `solver-runtime`, `matrix-readiness`, `snapshot-and-provider`, `package-worker`, `runtime-sql-boundary`, `debug-and-parity`, `edge-api-boundary`, `frontend-integration`, `proof`, `repo-docs`, and `root-integration`
 
 ## Minimal Execution Facts
 
@@ -122,7 +126,7 @@ At a human-readable level, this repo owns:
 - `Cargo.toml`, `Makefile`, and `crates/**` for solver topology, sparse-runtime behavior, queue workers, snapshot builder flows, and package workers
 - `scripts/**` and `tools/bw25-validator/**` for manual validation, parity, debug, snapshot, and diagnostics helpers
 - `supabase/migrations/**` for runtime SQL expectations still referenced by the calculator runtime
-- `README.md`, `docs/agents/**`, `docs/lca-api-contract.md`, `docs/edge-function-integration.md`, `docs/frontend-integration.md`, `docs/implicit-regional-supply-mix-modeling.md`, `docs/implicit-regional-supply-mix-modeling.en.md`, `docs/tidas-package-contract.md`, and repo-local governed docs
+- `README.md`, `docs/agents/**`, `docs/lca-api-contract.md`, `docs/matrix-readiness-report-contract.md`, `docs/edge-function-integration.md`, `docs/frontend-integration.md`, `docs/implicit-regional-supply-mix-modeling.md`, `docs/implicit-regional-supply-mix-modeling.en.md`, `docs/tidas-package-contract.md`, and repo-local governed docs
 
 This repo does not own:
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,6 +23,7 @@ checkPaths:
   - tools/bw25-validator/**
   - supabase/migrations/**
   - docs/lca-api-contract.md
+  - docs/matrix-readiness-report-contract.md
   - docs/implicit-regional-supply-mix-modeling.md
   - docs/implicit-regional-supply-mix-modeling.en.md
   - docs/tidas-package-contract.md
@@ -30,13 +31,14 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: f23848d58634dbf6f77df741210476f8d7bf61a1
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
   - ./repo-validation.md
   - ../../docs/lca-api-contract.md
+  - ../../docs/matrix-readiness-report-contract.md
 ---
 
 ## Repo Shape
@@ -96,7 +98,7 @@ These flows belong to the calculator runtime, not to the API repo.
 The snapshot builder path owns sparse payload generation, provider matching, and snapshot artifact metadata.
 The modeling basis for implicit regional supply mix, exchange-location supply-region anchors, and annual-volume provider shares lives in `docs/implicit-regional-supply-mix-modeling.md` and `docs/implicit-regional-supply-mix-modeling.en.md`.
 
-`crates/solver-worker/src/readiness.rs` owns the calculator-side verification gate for automated data production. It turns snapshot coverage, sparse payloads, and optional compiled provider decisions into a machine-readable matrix-readiness report. Foundry and CLI callers should consume that report instead of reimplementing provider closure, singular-risk, LCIA, or factorization checks outside calculator.
+`crates/solver-worker/src/readiness.rs` owns the calculator-side verification gate for automated data production. It turns snapshot coverage, sparse payloads, and optional compiled provider decisions into a machine-readable matrix-readiness report. Foundry and CLI callers should consume that report instead of reimplementing provider closure, singular-risk, LCIA, or factorization checks outside calculator. The stable report schema, blocker/finding codes, and next-action semantics live in `docs/matrix-readiness-report-contract.md`.
 
 ### Package worker
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -24,6 +24,7 @@ checkPaths:
   - tools/bw25-validator/**
   - supabase/migrations/**
   - docs/lca-api-contract.md
+  - docs/matrix-readiness-report-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/implicit-regional-supply-mix-modeling.md
@@ -34,13 +35,14 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
   - ./repo-architecture.md
   - ../../docs/lca-api-contract.md
+  - ../../docs/matrix-readiness-report-contract.md
   - ../../docs/tidas-package-contract.md
 ---
 
@@ -62,7 +64,7 @@ Treat the last two commands as non-negotiable hard gates after code changes.
 | --- | --- | --- | --- |
 | `crates/**` solver or worker code | `make check`; hard Clippy gate; hard format gate | run the narrow manual script that matches the touched area, such as snapshot build, full compute debug, or BW25 validation | Record which job family or worker path was exercised. |
 | snapshot-builder or provider-matching behavior | baseline gates plus `./scripts/build_snapshot_from_ilcd.sh` when safe | run provider-link diagnostics export helpers when the task changes matching logic | Snapshot and provider diagnostics often need task-specific proof. |
-| matrix-readiness / provider-closure gate | `cargo test -p solver-worker readiness`; `cargo check -p solver-worker --bin matrix_readiness`; hard Clippy gate for the touched binary/module | run `snapshot_builder` or `matrix_readiness --input <fixture> --out <report>` against the closest available target snapshot artifact | Use `PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig` on local Homebrew setups so SuiteSparse/UMFPACK link metadata is discoverable. |
+| matrix-readiness / provider-closure gate | `cargo test -p solver-worker readiness`; `cargo check -p solver-worker --bin matrix_readiness`; hard Clippy gate for the touched binary/module | run `snapshot_builder` or `matrix_readiness --input <fixture> --out <report>` against the closest available target snapshot artifact | Keep `docs/matrix-readiness-report-contract.md` aligned with blocker/finding code, policy, and next_action changes. Use `PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig` on local Homebrew setups so SuiteSparse/UMFPACK link metadata is discoverable. |
 | package worker import or export flows | baseline gates | run the closest safe package-flow helper or record why live package proof is deferred | Package-job semantics are runtime-sensitive and may depend on storage or DB state. |
 | runtime SQL expectation docs or local migration helpers | baseline gates plus `./scripts/validate_additive_migration.sh` when the task touches migration expectations | record separately when durable schema proof is required in `database-engine` | Local migration files here are not the workspace-wide source of truth. |
 | manual debug, parity, or target-validation scripts | run the touched script with safe args or `--help` when available, plus baseline gates if code changed nearby | `./scripts/run_full_compute_debug.sh`, `./scripts/run_bw25_validation.sh`, or `./scripts/validate_lcia_targets.sh` as applicable | `bw25-validator` is manual-only and out-of-band. |

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -17,13 +17,15 @@ checkPaths:
   - .docpact/config.yaml
   - crates/**
   - supabase/migrations/**
+  - docs/matrix-readiness-report-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
 related:
   - AGENTS.md
   - .docpact/config.yaml
+  - docs/matrix-readiness-report-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/repo-validation.md
@@ -217,6 +219,8 @@ fresh `snapshot_builder` run 也会在 `report_dir` 下写出 `matrix-readiness-
 - `metrics.compute_stability`: factorization readiness、matrix validation report、sample unit solves、non-finite count 和 negative LCIA count。
 - `provider_evidence`: 每条 input edge 的 consumer、flow、candidate providers、resolution strategy、failure reason、allocation weights、ambiguity 和 confidence。
 - `findings` / `blockers`: machine-readable issue codes、severity、message 和 detail payload。
+
+当前 matrix-readiness 只通过 calculator CLI 与 `snapshot_builder` report artifact 暴露；本节不表示 Edge/API 已提供 HTTP 调用入口。稳定 code、`blockers` / `findings` / `next_action` 规则、policy 默认值和调用方消费约束由 `docs/matrix-readiness-report-contract.md` 维护。
 
 Foundry、CLI 或 Edge adapter 只能消费该 report 的 `status`、`next_action`、`blockers`、`metrics` 和 `provider_evidence`；不应在外部复制 calculator 的 provider resolution、singular-risk 或 UMFPACK readiness 规则。
 

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -1,0 +1,120 @@
+---
+title: Matrix Readiness Report Contract
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: calculator
+language: zh-CN
+whenToUse:
+  - 当你需要消费或维护 matrix_readiness CLI 输出时
+  - 当 snapshot_builder 的 matrix-readiness report artifact 语义变化时
+  - 当 Foundry、CLI 或 Edge adapter 需要解释 readiness blockers、findings 或 next_action 时
+whenToUpdate:
+  - 当 crates/solver-worker/src/readiness.rs 的 report schema、policy、blocker、finding 或 next_action 规则变化时
+  - 当 crates/solver-worker/src/bin/matrix_readiness.rs 的 CLI contract 变化时
+  - 当 snapshot_builder 暴露 matrix-readiness artifact 的方式变化时
+checkPaths:
+  - docs/matrix-readiness-report-contract.md
+  - crates/solver-worker/src/readiness.rs
+  - crates/solver-worker/src/bin/matrix_readiness.rs
+  - crates/solver-worker/src/bin/snapshot_builder.rs
+  - crates/solver-worker/src/compiled_graph.rs
+  - docs/lca-api-contract.md
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+related:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - docs/lca-api-contract.md
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+---
+
+# Matrix Readiness Report Contract
+
+`matrix_readiness` 是 calculator 侧的 report/artifact contract，不是 Edge HTTP API contract。
+
+当前暴露方式只有两类：
+
+- CLI: `cargo run -p solver-worker --bin matrix_readiness -- --input <input.json> --out <report.json>`
+- fresh `snapshot_builder` run 在 `report_dir` 下写出的 `matrix-readiness-<snapshot_id>.json`
+
+Edge、Foundry、CLI 或其他调用方可以消费 report 字段，但不应在外部复制 calculator 的 provider resolution、singular-risk、LCIA 或 UMFPACK readiness 判断逻辑。
+
+## 输入
+
+输入 schema version 为 `matrix_readiness_input.v1`，核心字段为：
+
+- `coverage`: snapshot coverage report。
+- `payload`: `ModelSparseData` sparse payload。
+- `compiled_graph`（可选）：fresh build 时包含逐边 provider decision、candidate providers、allocation weights、geography tier 和 failure reason。没有该字段时仍可验证 coverage/compute，但 `provider_evidence` 会降级为空。
+- `policy`: provider write percentage、unmatched / unresolved provider 容忍度、singular risk、LCIA factor、factorization 和 negative LCIA anomaly 策略。
+
+## 输出
+
+输出 schema version 为 `matrix_readiness_report.v1`，核心字段为：
+
+- `status`: `passed` 或 `failed`。
+- `next_action`: calculator 给调用方的粗粒度下一步建议。
+- `metrics.provider_closure`: input edge、written edge、unmatched provider、multi-provider unresolved 和 equal-fallback 统计。
+- `metrics.graph_readiness`: process/flow/impact scale、A/B/C/M nnz、reference/allocation closure 和 singular risk。
+- `metrics.compute_stability`: factorization readiness、matrix validation report、sample unit solves、non-finite count 和 negative LCIA count。
+- `provider_evidence`: 每条 input edge 的 consumer、flow、candidate providers、resolution strategy、failure reason、allocation weights、ambiguity 和 confidence。
+- `findings` / `blockers`: machine-readable issue codes、severity、message 和 detail payload。
+
+## Blockers
+
+`blockers` 表示 gate 的硬失败，报告 `status` 会变为 `failed`。当前稳定 code 与默认触发条件如下：
+
+| Code | 触发条件 | 默认处置方向 | Policy 是否可放宽 |
+| --- | --- | --- | --- |
+| `provider_closure_write_pct_below_policy` | `coverage.matching.a_write_pct` 低于 `policy.min_provider_write_pct`，默认阈值为 `100.0` | 修复 provider closure 后重跑 | 是，调整 `min_provider_write_pct` |
+| `provider_closure_unmatched` | `coverage.matching.unmatched_no_provider` 超过 `policy.max_unmatched_no_provider`，默认 `0` | 修复无 provider 的 input edge 后重跑 | 是，调整 `max_unmatched_no_provider` |
+| `provider_closure_multi_unresolved` | `coverage.matching.matched_multi_unresolved` 超过 `policy.max_multi_unresolved`，默认 `0` | 修复多 provider 决策后重跑 | 是，调整 `max_multi_unresolved` |
+| `provider_closure_equal_fallback` | 存在 equal fallback，且 `policy.allow_equal_fallback = false` | 补充 provider volume / evidence 或显式允许 fallback | 是，设置 `allow_equal_fallback` |
+| `reference_normalization_not_closed` | quantitative reference 存在 missing 或 invalid 计数 | 修复 process reference 后重跑 | 否 |
+| `allocation_fraction_invalid` | allocation fraction 存在 invalid 计数 | 修复 allocation fraction 后重跑 | 否 |
+| `singular_risk_high` | singular risk 为 `high`，且 `allow_high_singular_risk = false` | 修复矩阵结构或人工确认风险 | 是，设置 `allow_high_singular_risk` |
+| `singular_risk_medium` | singular risk 为 `medium`，且 `allow_medium_singular_risk = false` | 复核矩阵结构或人工确认风险 | 是，设置 `allow_medium_singular_risk` |
+| `lcia_factors_missing` | `require_lcia_factors = true` 且 `coverage.matrix_scale.c_nnz = 0` | 补齐 LCIA factors 后重跑 | 是，设置 `require_lcia_factors = false` |
+| `factorization_not_ready` | `SolverService.prepare` 失败，包含结构校验或 UMFPACK factorization 失败 | 修复 compute stability 后重跑 | 否 |
+| `sample_unit_solve_failed` | sample unit demand solve 对某个 process index 失败 | 修复 compute stability 后重跑 | 否 |
+| `compute_non_finite_values` | sample solve 的 `x` / `g` / `h` 中存在 NaN 或 Infinity | 修复 compute stability 后重跑 | 否 |
+| `negative_lcia_values` | sample solve 的 LCIA 输出低于 `-policy.negative_lcia_epsilon`，且 `negative_lcia_policy = blocker` | 复核 LCIA / matrix sign / inventory 数据后重跑 | 是，调整 `negative_lcia_policy` 或 `negative_lcia_epsilon` |
+
+## Findings
+
+`findings` 表示非阻塞发现。存在 warning 但没有 blocker 时，报告仍可为 `passed`，但 `next_action` 会变为 `manual_review_warnings`。
+
+| Code | Severity | 触发条件 |
+| --- | --- | --- |
+| `provider_closure_no_input_edges` | `warning` | snapshot 没有 input edges 可检查 provider closure |
+| `allocation_fraction_missing` | `warning` | 存在 missing allocation fraction，但未达到 invalid blocker |
+| `singular_risk_observed` | `info` | singular risk level 不是 `low` / `medium` / `high` 中的已知值 |
+| `biosphere_entries_missing` | `warning` | `coverage.matrix_scale.b_nnz = 0`，结果可能缺少环境流信息 |
+| `matrix_validation_warning` | `warning` | factorization matrix validation 返回 near-singular warning |
+| `negative_lcia_values` | `info` / `warning` | 出现 negative LCIA，但 `negative_lcia_policy` 配置为 `ignore` 或 `warning` |
+
+## Next Action
+
+`next_action` 是 calculator 给调用方的粗粒度下一步建议。生成时按 blocker 优先级短路：
+
+| 条件 | `next_action` |
+| --- | --- |
+| 任一 blocker code 以 `provider_closure` 开头 | `repair_provider_closure_then_recheck` |
+| 任一 blocker code 以 `factorization` 或 `compute` 开头 | `repair_compute_stability_then_recheck` |
+| 任一 blocker code 以 `lcia` 开头 | `repair_lcia_factors_then_recheck` |
+| 存在其他 blocker | `repair_graph_readiness_then_recheck` |
+| 没有 blocker，但存在 warning finding | `manual_review_warnings` |
+| 没有 blocker 且没有 warning finding | `publish_ready` |
+
+调用方应把 `next_action` 当作路由提示，而不是唯一的判定来源；精确处置必须同时读取 `blockers[].code`、`findings[].code`、`severity` 和 `details`。
+
+## Compute Sampling
+
+Compute stability 当前按 `sample_solve_unit_limit` 采样 unit demand solve，默认上限为 `16`。
+
+如果调用方验证的是指定目标 process，应在输入或命令参数中把采样范围配置到覆盖目标 process；否则 report 只能说明已采样 process 的 compute stability。


### PR DESCRIPTION
## Summary
- Split the matrix-readiness report contract out of `docs/lca-api-contract.md` into `docs/matrix-readiness-report-contract.md` so it is documented as a calculator CLI/report artifact contract rather than an HTTP/API endpoint contract.
- Document stable blocker/finding codes, next_action mapping, compute sampling guidance, and caller consumption rules in the new contract.
- Add the new document to docpact coverage, routing, inventory, and a dedicated matrix-readiness governance rule.

## Validation
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- scripts/docpact route --root . --intent matrix-readiness --format json
- git diff --cached --check

## Notes
- Follow-up to #51 / issue #50 after the matrix-readiness gate landed.