### PR TITLE
feat: add review submit fast gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -28,6 +28,7 @@ ownership:
           - docs/agents/**
           - docs/lca-api-contract.md
           - docs/matrix-readiness-report-contract.md
+          - docs/review-submit-fast-gate-contract.md
           - docs/edge-function-integration.md
           - docs/frontend-integration.md
           - docs/implicit-regional-supply-mix-modeling.md
@@ -77,6 +78,7 @@ coverage:
     - docs/agents/repo-architecture.md
     - docs/lca-api-contract.md
     - docs/matrix-readiness-report-contract.md
+    - docs/review-submit-fast-gate-contract.md
     - docs/edge-function-integration.md
     - docs/frontend-integration.md
     - docs/implicit-regional-supply-mix-modeling.md
@@ -127,6 +129,14 @@ routing:
         - crates/solver-worker/src/compiled_graph.rs
         - docs/matrix-readiness-report-contract.md
         - docs/agents/repo-validation.md
+    review-submit-gate:
+      paths:
+        - crates/solver-worker/src/review_submit_gate.rs
+        - crates/solver-worker/src/bin/review_submit_gate.rs
+        - crates/solver-worker/src/readiness.rs
+        - crates/solver-worker/src/compiled_graph.rs
+        - docs/review-submit-fast-gate-contract.md
+        - docs/lca-api-contract.md
     snapshot-and-provider:
       paths:
         - crates/solver-worker/src/bin/snapshot_builder.rs
@@ -177,6 +187,7 @@ routing:
         - docs/agents/**
         - docs/lca-api-contract.md
         - docs/matrix-readiness-report-contract.md
+        - docs/review-submit-fast-gate-contract.md
         - docs/edge-function-integration.md
         - docs/frontend-integration.md
         - docs/implicit-regional-supply-mix-modeling.md
@@ -195,6 +206,7 @@ docInventory:
     - docs/agents/repo-architecture.md
     - docs/lca-api-contract.md
     - docs/matrix-readiness-report-contract.md
+    - docs/review-submit-fast-gate-contract.md
     - docs/edge-function-integration.md
     - docs/frontend-integration.md
     - docs/implicit-regional-supply-mix-modeling.md
@@ -366,6 +378,34 @@ rules:
       - path: docs/matrix-readiness-report-contract.md
         mode: review_or_update
     reason: Calculator-owned matrix-readiness report semantics must stay aligned with the CLI, snapshot artifact output, provider evidence, and proof guidance.
+  - id: calculator-review-submit-gate-contract
+    scope: repo
+    repo: calculator
+    triggers:
+      - path: docs/review-submit-fast-gate-contract.md
+        kind: runtime-contract
+      - path: crates/solver-worker/src/review_submit_gate.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/bin/review_submit_gate.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/readiness.rs
+        kind: runtime-code
+      - path: crates/solver-worker/src/compiled_graph.rs
+        kind: runtime-code
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: docs/lca-api-contract.md
+        mode: review_or_update
+      - path: docs/review-submit-fast-gate-contract.md
+        mode: review_or_update
+    reason: Dataset review-submit gate semantics must stay aligned with calculator-owned blocker codes, policy defaults, provider evidence, and targeted probe behavior.
   - id: calculator-edge-frontend-integration-contract
     scope: repo
     repo: calculator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ checkPaths:
   - docs/agents/**
   - docs/lca-api-contract.md
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/implicit-regional-supply-mix-modeling.md
@@ -45,6 +46,7 @@ related:
   - docs/agents/repo-architecture.md
   - docs/lca-api-contract.md
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
@@ -67,6 +69,7 @@ Start here when the task may change what the compute stack does.
 | `README.md` | repo landing context, operator setup, and runtime overview | machine-readable routing or lint semantics |
 | `docs/lca-api-contract.md` | shared jobs/results/payload/status contract for consumers | branch policy, proof matrix, or edge/frontend implementation details |
 | `docs/matrix-readiness-report-contract.md` | calculator-owned matrix-readiness CLI and report artifact schema, blocker/finding codes, next_action semantics, and policy surface | HTTP endpoint contract or edge request/auth behavior |
+| `docs/review-submit-fast-gate-contract.md` | calculator-owned review-submit fast gate schema, passed/blocked semantics, blocker codes, policy defaults, and targeted probe contract | Edge HTTP API, persistence schema, or Next submit-review UX |
 | `docs/edge-function-integration.md` | edge-facing enqueue, polling, and service-role integration contract | solver internals or frontend UX rules |
 | `docs/frontend-integration.md` | frontend-facing solve/result interaction contract | edge auth implementation or solver internals |
 | `docs/implicit-regional-supply-mix-modeling.md` / `docs/implicit-regional-supply-mix-modeling.en.md` | Chinese and English modeling basis for implicit regional supply mix, exchange-location supply-region anchors, and annual-volume provider share semantics | implementation checklist or consumer API contract |
@@ -82,6 +85,7 @@ Read in this order:
 4. load only the narrow contract doc that matches the task:
    - `docs/lca-api-contract.md`
    - `docs/matrix-readiness-report-contract.md`
+   - `docs/review-submit-fast-gate-contract.md`
    - `docs/edge-function-integration.md`
    - `docs/frontend-integration.md`
    - `docs/implicit-regional-supply-mix-modeling.md`
@@ -98,7 +102,7 @@ Do not start from the root workspace or the edge repo if the change is really ab
 - stable path groups and hotspot families live in `docs/agents/repo-architecture.md`
 - runtime-facing consumer contracts and report artifact contracts live in the narrow docs under `docs/*.md`
 - repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
-- the main routing intents are `solver-runtime`, `matrix-readiness`, `snapshot-and-provider`, `package-worker`, `runtime-sql-boundary`, `debug-and-parity`, `edge-api-boundary`, `frontend-integration`, `proof`, `repo-docs`, and `root-integration`
+- the main routing intents are `solver-runtime`, `matrix-readiness`, `snapshot-and-provider`, `review-submit-gate`, `package-worker`, `runtime-sql-boundary`, `debug-and-parity`, `edge-api-boundary`, `frontend-integration`, `proof`, `repo-docs`, and `root-integration`
 
 ## Minimal Execution Facts
 
@@ -126,7 +130,7 @@ At a human-readable level, this repo owns:
 - `Cargo.toml`, `Makefile`, and `crates/**` for solver topology, sparse-runtime behavior, queue workers, snapshot builder flows, and package workers
 - `scripts/**` and `tools/bw25-validator/**` for manual validation, parity, debug, snapshot, and diagnostics helpers
 - `supabase/migrations/**` for runtime SQL expectations still referenced by the calculator runtime
-- `README.md`, `docs/agents/**`, `docs/lca-api-contract.md`, `docs/matrix-readiness-report-contract.md`, `docs/edge-function-integration.md`, `docs/frontend-integration.md`, `docs/implicit-regional-supply-mix-modeling.md`, `docs/implicit-regional-supply-mix-modeling.en.md`, `docs/tidas-package-contract.md`, and repo-local governed docs
+- `README.md`, `docs/agents/**`, `docs/lca-api-contract.md`, `docs/matrix-readiness-report-contract.md`, `docs/review-submit-fast-gate-contract.md`, `docs/edge-function-integration.md`, `docs/frontend-integration.md`, `docs/implicit-regional-supply-mix-modeling.md`, `docs/implicit-regional-supply-mix-modeling.en.md`, `docs/tidas-package-contract.md`, and repo-local governed docs
 
 This repo does not own:
 
@@ -164,6 +168,8 @@ Route those tasks to:
 - if proof expectations or manual validation helper guidance change, update `docs/agents/repo-validation.md`
 - if repo shape, hotspot families, or path ownership explanation changes, update `docs/agents/repo-architecture.md`
 - if shared jobs/results/payload/status semantics change, update `docs/lca-api-contract.md`
+- if matrix-readiness report schema, blocker/finding codes, policy defaults, or next_action semantics change, update `docs/matrix-readiness-report-contract.md`
+- if review-submit fast gate schema, blocker codes, policy defaults, or targeted probe semantics change, update `docs/review-submit-fast-gate-contract.md`
 - if edge-facing enqueue, polling, or service-role integration guidance changes, update `docs/edge-function-integration.md`
 - if frontend-facing solve/result interaction guidance changes, update `docs/frontend-integration.md`
 - if implicit regional supply mix theory, exchange-location supply-region semantics, or annual-volume provider share semantics change, update both `docs/implicit-regional-supply-mix-modeling.md` and `docs/implicit-regional-supply-mix-modeling.en.md`

--- a/crates/solver-worker/src/bin/review_submit_gate.rs
+++ b/crates/solver-worker/src/bin/review_submit_gate.rs
@@ -1,0 +1,46 @@
+#![allow(clippy::struct_excessive_bools)]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use solver_worker::review_submit_gate::{
+    ReviewSubmitGateInput, ReviewSubmitGateStatus, verify_review_submit_gate,
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "review-submit-gate")]
+#[command(about = "Verify the fast review-submit numerical stability gate.")]
+struct Cli {
+    #[arg(long)]
+    input: PathBuf,
+    #[arg(long)]
+    out: PathBuf,
+    #[arg(long, default_value_t = false)]
+    fail_on_blocked: bool,
+}
+
+fn main() -> anyhow::Result<ExitCode> {
+    let cli = Cli::parse();
+    let input_bytes = fs::read(&cli.input)?;
+    let input: ReviewSubmitGateInput = serde_json::from_slice(&input_bytes)?;
+    let report = verify_review_submit_gate(&input);
+
+    if let Some(parent) = cli.out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&cli.out, serde_json::to_vec_pretty(&report)?)?;
+    println!(
+        "[review_submit_gate] status={:?} blockers={} out={}",
+        report.status,
+        report.blockers.len(),
+        cli.out.display()
+    );
+
+    if cli.fail_on_blocked && report.status == ReviewSubmitGateStatus::Blocked {
+        Ok(ExitCode::from(2))
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
+}

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -25,6 +25,7 @@ pub mod package_types;
 pub mod pgbouncer_sqlx;
 pub mod queue;
 pub mod readiness;
+pub mod review_submit_gate;
 pub mod snapshot_artifacts;
 pub mod snapshot_index;
 pub mod storage;

--- a/crates/solver-worker/src/review_submit_gate.rs
+++ b/crates/solver-worker/src/review_submit_gate.rs
@@ -1,0 +1,1627 @@
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::missing_const_for_fn,
+    clippy::module_name_repetitions,
+    clippy::struct_excessive_bools,
+    clippy::struct_field_names,
+    clippy::too_many_lines
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use solver_core::{
+    ModelSparseData, NumericOptions, SolveOptions, SolverError, SolverService, SparseTriplet,
+    ValidationReport,
+};
+use uuid::Uuid;
+
+use crate::compiled_graph::{CompiledFlowKind, CompiledGraph, CompiledProviderDecisionKind};
+use crate::readiness::{FindingSeverity, ReadinessFinding};
+use crate::snapshot_artifacts::{SnapshotBuildConfig, SnapshotCoverageReport};
+
+const INPUT_SCHEMA_VERSION: &str = "review_submit_gate_input.v1";
+const REPORT_SCHEMA_VERSION: &str = "review_submit_gate_report.v1";
+const DEFAULT_POLICY_PROFILE: &str = "review_submit_fast.v1";
+const DETAIL_LIMIT: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewSubmitGateStatus {
+    Passed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewSubmitGatePolicy {
+    #[serde(default = "default_policy_profile")]
+    pub policy_profile: String,
+    #[serde(default = "default_true")]
+    pub require_revision_checksum_match: bool,
+    #[serde(default = "default_allowed_scope_states")]
+    pub allowed_scope_states: Vec<i32>,
+    #[serde(default = "default_true")]
+    pub block_equal_fallback: bool,
+    #[serde(default = "default_true")]
+    pub block_provider_volume_fallback: bool,
+    #[serde(default = "default_true")]
+    pub require_lcia_for_impact_submit: bool,
+    #[serde(default = "default_true")]
+    pub require_target_process_probe: bool,
+    #[serde(default = "default_true")]
+    pub run_factorization_probe: bool,
+    #[serde(default = "default_target_probe_limit")]
+    pub target_probe_limit: usize,
+    #[serde(default = "default_zero_epsilon")]
+    pub zero_diagonal_epsilon: f64,
+    #[serde(default = "default_duplicate_value_epsilon")]
+    pub duplicate_value_epsilon: f64,
+    #[serde(default = "default_allocation_sum_epsilon")]
+    pub allocation_sum_epsilon: f64,
+    #[serde(default = "default_service_loop_epsilon")]
+    pub service_loop_epsilon: f64,
+}
+
+impl Default for ReviewSubmitGatePolicy {
+    fn default() -> Self {
+        Self {
+            policy_profile: default_policy_profile(),
+            require_revision_checksum_match: true,
+            allowed_scope_states: default_allowed_scope_states(),
+            block_equal_fallback: true,
+            block_provider_volume_fallback: true,
+            require_lcia_for_impact_submit: true,
+            require_target_process_probe: true,
+            run_factorization_probe: true,
+            target_probe_limit: default_target_probe_limit(),
+            zero_diagonal_epsilon: default_zero_epsilon(),
+            duplicate_value_epsilon: default_duplicate_value_epsilon(),
+            allocation_sum_epsilon: default_allocation_sum_epsilon(),
+            service_loop_epsilon: default_service_loop_epsilon(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewSubmitGateInput {
+    #[serde(default = "default_input_schema_version")]
+    pub schema_version: String,
+    #[serde(default)]
+    pub dataset_revision_id: Option<Uuid>,
+    #[serde(default)]
+    pub expected_revision_checksum: Option<String>,
+    #[serde(default)]
+    pub actual_revision_checksum: Option<String>,
+    #[serde(default)]
+    pub snapshot_id: Option<Uuid>,
+    #[serde(default)]
+    pub config: Option<SnapshotBuildConfig>,
+    pub coverage: SnapshotCoverageReport,
+    pub payload: ModelSparseData,
+    #[serde(default)]
+    pub compiled_graph: Option<CompiledGraph>,
+    #[serde(default)]
+    pub target_process_indices: Vec<i32>,
+    #[serde(default)]
+    pub process_records: Vec<ReviewProcessRecord>,
+    #[serde(default)]
+    pub policy: ReviewSubmitGatePolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewProcessRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_idx: Option<i32>,
+    pub process_id: Uuid,
+    pub process_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference_exchange_id: Option<String>,
+    #[serde(default)]
+    pub exchanges: Vec<ReviewExchangeRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewExchangeRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exchange_id: Option<String>,
+    pub flow_id: Uuid,
+    pub direction: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allocation_fraction: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReviewSubmitGateReport {
+    pub schema_version: String,
+    pub generated_at_utc: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset_revision_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<Uuid>,
+    pub status: ReviewSubmitGateStatus,
+    pub policy: ReviewSubmitGatePolicy,
+    pub metrics: ReviewSubmitGateMetrics,
+    pub blockers: Vec<ReadinessFinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ReviewSubmitGateMetrics {
+    pub revision: RevisionGateMetrics,
+    pub process_scan: ProcessScanMetrics,
+    pub provider_scan: ProviderScanMetrics,
+    pub sparse_scan: SparseScanMetrics,
+    pub probe: ProbeMetrics,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct RevisionGateMetrics {
+    pub checksum_checked: bool,
+    pub checksum_matched: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ProcessScanMetrics {
+    pub process_records_total: usize,
+    pub invalid_scope_state_count: usize,
+    pub duplicate_process_version_groups: usize,
+    pub invalid_exchange_amount_count: usize,
+    pub invalid_allocation_fraction_count: usize,
+    pub missing_or_zero_reference_count: usize,
+    pub duplicate_exchange_fingerprint_groups: usize,
+    pub service_loop_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ProviderScanMetrics {
+    pub provider_decisions_total: usize,
+    pub provider_missing_count: i64,
+    pub provider_unresolved_count: i64,
+    pub equal_fallback_count: i64,
+    pub allocation_not_conserved_count: usize,
+    pub volume_evidence_invalid_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct SparseScanMetrics {
+    pub zero_or_near_zero_diagonal_count: usize,
+    pub duplicate_sparse_column_groups: usize,
+    pub flow_lcia_semantic_mismatch_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ProbeMetrics {
+    pub factorization_checked: bool,
+    pub factorization_ready: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation: Option<ValidationReport>,
+    pub target_indices_requested: usize,
+    pub target_indices_probed: usize,
+    pub non_finite_value_count: usize,
+}
+
+#[must_use]
+pub fn verify_review_submit_gate(input: &ReviewSubmitGateInput) -> ReviewSubmitGateReport {
+    let mut blockers = Vec::new();
+    let mut metrics = ReviewSubmitGateMetrics::default();
+
+    check_revision_freshness(input, &mut metrics, &mut blockers);
+    check_process_records(input, &mut metrics, &mut blockers);
+    check_provider_closure(input, &mut metrics, &mut blockers);
+    check_flow_semantics(input, &mut metrics, &mut blockers);
+    check_sparse_structure(input, &mut metrics, &mut blockers);
+    check_lcia_requirement(input, &mut blockers);
+    check_target_probe_coverage(input, &mut metrics, &mut blockers);
+
+    if blockers.is_empty() && input.policy.run_factorization_probe {
+        run_target_probe(input, &mut metrics, &mut blockers);
+    }
+
+    let status = if blockers.is_empty() {
+        ReviewSubmitGateStatus::Passed
+    } else {
+        ReviewSubmitGateStatus::Blocked
+    };
+
+    ReviewSubmitGateReport {
+        schema_version: REPORT_SCHEMA_VERSION.to_owned(),
+        generated_at_utc: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        dataset_revision_id: input.dataset_revision_id,
+        snapshot_id: input.snapshot_id,
+        status,
+        policy: input.policy.clone(),
+        metrics,
+        blockers,
+    }
+}
+
+fn check_revision_freshness(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    if !input.policy.require_revision_checksum_match {
+        return;
+    }
+    metrics.revision.checksum_checked = true;
+    metrics.revision.checksum_matched = input.expected_revision_checksum
+        == input.actual_revision_checksum
+        && input.expected_revision_checksum.is_some();
+    if !metrics.revision.checksum_matched {
+        push_blocker(
+            blockers,
+            "revision_report_stale",
+            "review-submit gate input is not tied to the current dataset revision checksum",
+            json!({
+                "dataset_revision_id": input.dataset_revision_id,
+                "expected_revision_checksum": input.expected_revision_checksum,
+                "actual_revision_checksum": input.actual_revision_checksum
+            }),
+        );
+    }
+}
+
+fn check_process_records(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    metrics.process_scan.process_records_total = input.process_records.len();
+    check_scope_states(input, metrics, blockers);
+    check_duplicate_process_versions(input, metrics, blockers);
+    check_exchanges(input, metrics, blockers);
+    check_duplicate_exchange_fingerprints(input, metrics, blockers);
+    check_service_loops(input, metrics, blockers);
+}
+
+fn check_scope_states(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    if input.policy.allowed_scope_states.is_empty() {
+        return;
+    }
+    let allowed = input
+        .policy
+        .allowed_scope_states
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let invalid = input
+        .process_records
+        .iter()
+        .filter(|record| {
+            record
+                .state_code
+                .is_none_or(|state_code| !allowed.contains(&state_code))
+        })
+        .take(DETAIL_LIMIT)
+        .map(process_detail)
+        .collect::<Vec<_>>();
+
+    metrics.process_scan.invalid_scope_state_count = input
+        .process_records
+        .iter()
+        .filter(|record| {
+            record
+                .state_code
+                .is_none_or(|state_code| !allowed.contains(&state_code))
+        })
+        .count();
+
+    if metrics.process_scan.invalid_scope_state_count > 0 {
+        push_blocker(
+            blockers,
+            "invalid_scope_state",
+            "dataset revision contains processes outside the review-submit scope states",
+            json!({
+                "invalid_scope_state_count": metrics.process_scan.invalid_scope_state_count,
+                "allowed_scope_states": input.policy.allowed_scope_states,
+                "examples": invalid
+            }),
+        );
+    }
+}
+
+fn check_duplicate_process_versions(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let mut by_id = BTreeMap::<Uuid, Vec<&ReviewProcessRecord>>::new();
+    for record in &input.process_records {
+        by_id.entry(record.process_id).or_default().push(record);
+    }
+
+    let duplicate_groups = by_id
+        .into_iter()
+        .filter_map(|(process_id, records)| {
+            (records.len() > 1).then(|| {
+                json!({
+                    "process_id": process_id,
+                    "versions": records.iter().map(|record| record.process_version.clone()).collect::<Vec<_>>()
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    metrics.process_scan.duplicate_process_version_groups = duplicate_groups.len();
+    if !duplicate_groups.is_empty() {
+        push_blocker(
+            blockers,
+            "duplicate_process_version",
+            "multiple versions of the same process are present in the review-submit scope",
+            json!({
+                "duplicate_process_version_groups": duplicate_groups.len(),
+                "examples": duplicate_groups.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_exchanges(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let mut invalid_amounts = Vec::new();
+    let mut invalid_allocations = Vec::new();
+    let mut invalid_references = Vec::new();
+
+    for process in &input.process_records {
+        for exchange in &process.exchanges {
+            if parse_numeric_text(exchange.amount.as_deref()).is_err() {
+                invalid_amounts.push(exchange_detail(process, exchange));
+            }
+            if let Some(fraction) = exchange.allocation_fraction.as_deref() {
+                match parse_numeric_text(Some(fraction)) {
+                    Ok(value) if (0.0..=100.0).contains(&value) => {}
+                    _ => invalid_allocations.push(exchange_detail(process, exchange)),
+                }
+            }
+        }
+
+        if !reference_is_valid(process, input.policy.zero_diagonal_epsilon) {
+            invalid_references.push(process_detail(process));
+        }
+    }
+
+    metrics.process_scan.invalid_exchange_amount_count = invalid_amounts.len();
+    metrics.process_scan.invalid_allocation_fraction_count = invalid_allocations.len();
+    metrics.process_scan.missing_or_zero_reference_count = invalid_references.len();
+
+    if !invalid_amounts.is_empty() || sparse_values_have_non_finite(&input.payload) {
+        push_blocker(
+            blockers,
+            "invalid_exchange_amount",
+            "review-submit scope contains missing, invalid, or non-finite exchange amounts",
+            json!({
+                "invalid_exchange_amount_count": invalid_amounts.len(),
+                "examples": invalid_amounts.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if !invalid_allocations.is_empty() {
+        push_blocker(
+            blockers,
+            "invalid_allocation_fraction",
+            "review-submit scope contains invalid allocation fractions",
+            json!({
+                "invalid_allocation_fraction_count": invalid_allocations.len(),
+                "examples": invalid_allocations.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if !invalid_references.is_empty()
+        || input.coverage.reference.missing_reference_count > 0
+        || input.coverage.reference.invalid_reference_count > 0
+    {
+        push_blocker(
+            blockers,
+            "missing_or_zero_reference",
+            "quantitative reference is missing, invalid, or has a zero amount",
+            json!({
+                "process_record_reference_failures": invalid_references.len(),
+                "coverage_missing_reference_count": input.coverage.reference.missing_reference_count,
+                "coverage_invalid_reference_count": input.coverage.reference.invalid_reference_count,
+                "examples": invalid_references.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_duplicate_exchange_fingerprints(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let mut by_fingerprint = BTreeMap::<String, Vec<&ReviewProcessRecord>>::new();
+    for record in &input.process_records {
+        let fingerprint = exchange_fingerprint(record);
+        by_fingerprint.entry(fingerprint).or_default().push(record);
+    }
+
+    let duplicate_groups = by_fingerprint
+        .into_iter()
+        .filter_map(|(fingerprint, records)| {
+            (records.len() > 1).then(|| {
+                json!({
+                    "fingerprint": fingerprint,
+                    "processes": records.iter().map(|record| process_detail(record)).collect::<Vec<_>>()
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    metrics.process_scan.duplicate_exchange_fingerprint_groups = duplicate_groups.len();
+    if !duplicate_groups.is_empty() {
+        push_blocker(
+            blockers,
+            "duplicate_exchange_fingerprint",
+            "different processes have identical exchange fingerprints in the review-submit scope",
+            json!({
+                "duplicate_exchange_fingerprint_groups": duplicate_groups.len(),
+                "examples": duplicate_groups.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_service_loops(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let mut loops = Vec::new();
+    for process in &input.process_records {
+        let mut inputs = BTreeMap::<Uuid, Vec<(&ReviewExchangeRecord, f64)>>::new();
+        let mut outputs = BTreeMap::<Uuid, Vec<(&ReviewExchangeRecord, f64)>>::new();
+        for exchange in &process.exchanges {
+            let Ok(amount) = parse_numeric_text(exchange.amount.as_deref()) else {
+                continue;
+            };
+            match normalized_direction(&exchange.direction).as_deref() {
+                Some("input") => inputs
+                    .entry(exchange.flow_id)
+                    .or_default()
+                    .push((exchange, amount)),
+                Some("output") => outputs
+                    .entry(exchange.flow_id)
+                    .or_default()
+                    .push((exchange, amount)),
+                _ => {}
+            }
+        }
+
+        for (flow_id, input_edges) in inputs {
+            let Some(output_edges) = outputs.get(&flow_id) else {
+                continue;
+            };
+            for (input_edge, input_amount) in &input_edges {
+                for (output_edge, output_amount) in output_edges {
+                    if (*input_amount - *output_amount).abs() <= input.policy.service_loop_epsilon {
+                        loops.push(json!({
+                            "process": process_detail(process),
+                            "flow_id": flow_id,
+                            "input_exchange_id": input_edge.exchange_id,
+                            "output_exchange_id": output_edge.exchange_id,
+                            "amount": input_amount
+                        }));
+                    }
+                }
+            }
+        }
+    }
+
+    metrics.process_scan.service_loop_count = loops.len();
+    if !loops.is_empty() {
+        push_blocker(
+            blockers,
+            "service_loop_detected",
+            "same process has matching input and output amounts for the same flow",
+            json!({
+                "service_loop_count": loops.len(),
+                "examples": loops.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_provider_closure(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let matching = &input.coverage.matching;
+    metrics.provider_scan.provider_missing_count = matching.unmatched_no_provider;
+    metrics.provider_scan.provider_unresolved_count = matching.matched_multi_unresolved;
+    metrics.provider_scan.equal_fallback_count = matching.matched_multi_fallback_equal;
+    metrics.provider_scan.volume_evidence_invalid_count =
+        matching.volume_weight_summary.fallback_to_one_count
+            + matching
+                .volume_weight_summary
+                .decisions_partial_missing_count
+            + matching.volume_weight_summary.decisions_all_missing_count;
+
+    let mut missing_examples = Vec::new();
+    let mut unresolved_examples = Vec::new();
+    let mut fallback_examples = Vec::new();
+    let mut unconserved_examples = Vec::new();
+    let mut volume_examples = Vec::new();
+
+    if let Some(graph) = &input.compiled_graph {
+        metrics.provider_scan.provider_decisions_total = graph.provider_decisions.len();
+        for decision in &graph.provider_decisions {
+            match decision.decision_kind {
+                Some(CompiledProviderDecisionKind::NoProvider) => {
+                    missing_examples.push(provider_decision_detail(decision));
+                }
+                Some(CompiledProviderDecisionKind::MultiUnresolved) => {
+                    unresolved_examples.push(provider_decision_detail(decision));
+                }
+                _ => {}
+            }
+            if decision.used_equal_fallback {
+                fallback_examples.push(provider_decision_detail(decision));
+            }
+            if decision.volume_fallback_to_one_count > 0 {
+                volume_examples.push(provider_decision_detail(decision));
+            }
+            if !provider_allocation_is_conserved(decision, input.policy.allocation_sum_epsilon) {
+                unconserved_examples.push(provider_decision_detail(decision));
+            }
+        }
+    }
+
+    metrics.provider_scan.allocation_not_conserved_count = unconserved_examples.len();
+
+    if metrics.provider_scan.provider_missing_count > 0 || !missing_examples.is_empty() {
+        push_blocker(
+            blockers,
+            "provider_missing",
+            "product input edges have no provider candidates",
+            json!({
+                "coverage_unmatched_no_provider": matching.unmatched_no_provider,
+                "examples": missing_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if metrics.provider_scan.provider_unresolved_count > 0 || !unresolved_examples.is_empty() {
+        push_blocker(
+            blockers,
+            "provider_unresolved",
+            "multi-provider product input edges are unresolved",
+            json!({
+                "coverage_matched_multi_unresolved": matching.matched_multi_unresolved,
+                "examples": unresolved_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if input.policy.block_equal_fallback
+        && (metrics.provider_scan.equal_fallback_count > 0 || !fallback_examples.is_empty())
+    {
+        push_blocker(
+            blockers,
+            "provider_equal_fallback",
+            "provider resolution used equal fallback in a review-submit gate",
+            json!({
+                "coverage_matched_multi_fallback_equal": matching.matched_multi_fallback_equal,
+                "examples": fallback_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if !unconserved_examples.is_empty() {
+        push_blocker(
+            blockers,
+            "provider_allocation_not_conserved",
+            "provider allocation weights are invalid or do not sum to 1",
+            json!({
+                "allocation_not_conserved_count": metrics.provider_scan.allocation_not_conserved_count,
+                "examples": unconserved_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+    if input.policy.block_provider_volume_fallback
+        && (metrics.provider_scan.volume_evidence_invalid_count > 0 || !volume_examples.is_empty())
+    {
+        push_blocker(
+            blockers,
+            "provider_volume_evidence_invalid",
+            "provider volume evidence fell back to default weights in a review-submit gate",
+            json!({
+                "volume_evidence_invalid_count": metrics.provider_scan.volume_evidence_invalid_count,
+                "examples": volume_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_flow_semantics(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let Some(graph) = &input.compiled_graph else {
+        return;
+    };
+    let by_flow_id = graph
+        .flows
+        .iter()
+        .map(|flow| (flow.flow_id, flow.kind))
+        .collect::<BTreeMap<_, _>>();
+    let by_flow_idx = graph
+        .flows
+        .iter()
+        .map(|flow| (flow.flow_idx, flow.kind))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut mismatches = Vec::new();
+    for decision in &graph.provider_decisions {
+        if by_flow_id.get(&decision.flow_id) != Some(&CompiledFlowKind::Product) {
+            mismatches.push(json!({
+                "kind": "provider_decision_non_product_flow",
+                "consumer_idx": decision.consumer_idx,
+                "flow_id": decision.flow_id
+            }));
+        }
+    }
+    for edge in &graph.technosphere_edges {
+        if by_flow_id.get(&edge.flow_id) != Some(&CompiledFlowKind::Product) {
+            mismatches.push(json!({
+                "kind": "technosphere_non_product_flow",
+                "provider_idx": edge.provider_idx,
+                "consumer_idx": edge.consumer_idx,
+                "flow_id": edge.flow_id
+            }));
+        }
+    }
+    for edge in &graph.biosphere_edges {
+        if by_flow_idx.get(&edge.flow_idx) != Some(&CompiledFlowKind::Elementary) {
+            mismatches.push(json!({
+                "kind": "biosphere_non_elementary_flow",
+                "process_idx": edge.process_idx,
+                "flow_idx": edge.flow_idx
+            }));
+        }
+    }
+    for factor in &input.payload.characterization_factors {
+        if by_flow_idx.get(&factor.col) == Some(&CompiledFlowKind::Product) {
+            mismatches.push(json!({
+                "kind": "lcia_factor_on_product_flow",
+                "impact_idx": factor.row,
+                "flow_idx": factor.col
+            }));
+        }
+    }
+
+    metrics.sparse_scan.flow_lcia_semantic_mismatch_count = mismatches.len();
+    if !mismatches.is_empty() {
+        push_blocker(
+            blockers,
+            "flow_lcia_semantic_mismatch",
+            "product, elementary, or LCIA flow semantics are inconsistent",
+            json!({
+                "flow_lcia_semantic_mismatch_count": mismatches.len(),
+                "examples": mismatches.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_sparse_structure(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let Some(process_count) = valid_process_count(input.payload.process_count) else {
+        push_blocker(
+            blockers,
+            "sparse_matrix_zero_or_near_zero_diagonal",
+            "sparse payload has an invalid process count",
+            json!({ "process_count": input.payload.process_count }),
+        );
+        return;
+    };
+
+    let a_map = aggregate_sparse_entries(&input.payload.technosphere_entries);
+    let near_zero_diagonal = (0..process_count)
+        .filter_map(|idx| {
+            let idx_i32 = i32::try_from(idx).ok()?;
+            let a_diag = a_map.get(&(idx_i32, idx_i32)).copied().unwrap_or(0.0);
+            let m_diag = 1.0 - a_diag;
+            (m_diag.abs() <= input.policy.zero_diagonal_epsilon).then_some(json!({
+                "process_idx": idx_i32,
+                "a_diagonal": a_diag,
+                "m_diagonal": m_diag
+            }))
+        })
+        .collect::<Vec<_>>();
+
+    metrics.sparse_scan.zero_or_near_zero_diagonal_count = near_zero_diagonal.len();
+    if !near_zero_diagonal.is_empty()
+        || matches!(
+            input.coverage.singular_risk.risk_level.as_str(),
+            "medium" | "high"
+        )
+    {
+        push_blocker(
+            blockers,
+            "sparse_matrix_zero_or_near_zero_diagonal",
+            "M = I - A has zero/near-zero diagonal or elevated singular risk",
+            json!({
+                "zero_or_near_zero_diagonal_count": near_zero_diagonal.len(),
+                "singular_risk_level": input.coverage.singular_risk.risk_level,
+                "m_zero_diagonal_count": input.coverage.singular_risk.m_zero_diagonal_count,
+                "m_min_abs_diagonal": input.coverage.singular_risk.m_min_abs_diagonal,
+                "examples": near_zero_diagonal.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+        if matches!(
+            input.coverage.singular_risk.risk_level.as_str(),
+            "medium" | "high"
+        ) {
+            push_blocker(
+                blockers,
+                "singular_risk_medium_or_high",
+                "review-submit gate blocks medium or high singular risk",
+                json!({
+                    "singular_risk_level": input.coverage.singular_risk.risk_level,
+                    "m_zero_diagonal_count": input.coverage.singular_risk.m_zero_diagonal_count,
+                    "m_min_abs_diagonal": input.coverage.singular_risk.m_min_abs_diagonal
+                }),
+            );
+        }
+    }
+
+    let duplicate_columns =
+        duplicate_m_columns(process_count, &a_map, input.policy.duplicate_value_epsilon);
+    metrics.sparse_scan.duplicate_sparse_column_groups = duplicate_columns.len();
+    if !duplicate_columns.is_empty() {
+        push_blocker(
+            blockers,
+            "duplicate_sparse_columns",
+            "M = I - A contains duplicate sparse columns",
+            json!({
+                "duplicate_sparse_column_groups": duplicate_columns.len(),
+                "examples": duplicate_columns.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
+            }),
+        );
+    }
+}
+
+fn check_lcia_requirement(input: &ReviewSubmitGateInput, blockers: &mut Vec<ReadinessFinding>) {
+    if input.policy.require_lcia_for_impact_submit && input.coverage.matrix_scale.c_nnz == 0 {
+        push_blocker(
+            blockers,
+            "lcia_factor_missing_for_impact_submit",
+            "impact-ready review submission requires LCIA factors",
+            json!({
+                "impact_count": input.coverage.matrix_scale.impact_count,
+                "c_nnz": input.coverage.matrix_scale.c_nnz
+            }),
+        );
+    }
+}
+
+fn check_target_probe_coverage(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    let requested = unique_target_indices(&input.target_process_indices);
+    metrics.probe.target_indices_requested = requested.len();
+
+    if !input.policy.require_target_process_probe {
+        return;
+    }
+
+    let process_count = valid_process_count(input.payload.process_count).unwrap_or_default();
+    let invalid = requested
+        .iter()
+        .copied()
+        .filter(|idx| usize::try_from(*idx).map_or(true, |idx| idx >= process_count))
+        .collect::<Vec<_>>();
+
+    let not_covered = requested.is_empty()
+        || !invalid.is_empty()
+        || requested.len() > input.policy.target_probe_limit;
+
+    if not_covered {
+        push_blocker(
+            blockers,
+            "target_process_not_covered_by_probe",
+            "target process probe coverage is missing or incomplete",
+            json!({
+                "target_indices_requested": requested,
+                "invalid_target_indices": invalid,
+                "target_probe_limit": input.policy.target_probe_limit
+            }),
+        );
+    }
+}
+
+fn run_target_probe(
+    input: &ReviewSubmitGateInput,
+    metrics: &mut ReviewSubmitGateMetrics,
+    blockers: &mut Vec<ReadinessFinding>,
+) {
+    metrics.probe.factorization_checked = true;
+    let service = SolverService::new();
+    match service.prepare(&input.payload, NumericOptions::default()) {
+        Ok(result) => {
+            metrics.probe.factorization_ready = true;
+            metrics.probe.validation = Some(result.diagnostics.validation);
+        }
+        Err(error) => {
+            if let SolverError::ValidationFailed(report) = &error {
+                metrics.probe.validation = Some(report.clone());
+            }
+            push_blocker(
+                blockers,
+                "factorization_probe_failed",
+                "targeted sparse factorization probe failed",
+                json!({ "error": error.to_string() }),
+            );
+            return;
+        }
+    }
+
+    let Some(process_count) = valid_process_count(input.payload.process_count) else {
+        return;
+    };
+    for process_idx in unique_target_indices(&input.target_process_indices)
+        .into_iter()
+        .take(input.policy.target_probe_limit)
+    {
+        let Ok(process_idx_usize) = usize::try_from(process_idx) else {
+            continue;
+        };
+        if process_idx_usize >= process_count {
+            continue;
+        }
+        let mut rhs = vec![0.0_f64; process_count];
+        rhs[process_idx_usize] = 1.0;
+        match service.solve_one(
+            input.payload.model_version,
+            NumericOptions::default(),
+            &rhs,
+            SolveOptions {
+                return_x: true,
+                return_g: true,
+                return_h: true,
+            },
+        ) {
+            Ok(result) => {
+                metrics.probe.target_indices_probed += 1;
+                metrics.probe.non_finite_value_count += non_finite_count(result.x.as_deref());
+                metrics.probe.non_finite_value_count += non_finite_count(result.g.as_deref());
+                metrics.probe.non_finite_value_count += non_finite_count(result.h.as_deref());
+            }
+            Err(error) => push_blocker(
+                blockers,
+                "target_probe_non_finite_result",
+                "targeted process probe failed during solve",
+                json!({
+                    "process_idx": process_idx,
+                    "error": error.to_string()
+                }),
+            ),
+        }
+    }
+
+    if metrics.probe.non_finite_value_count > 0 {
+        push_blocker(
+            blockers,
+            "target_probe_non_finite_result",
+            "targeted process probe produced NaN or Infinity values",
+            json!({ "non_finite_value_count": metrics.probe.non_finite_value_count }),
+        );
+    }
+}
+
+fn reference_is_valid(process: &ReviewProcessRecord, epsilon: f64) -> bool {
+    let Some(reference_exchange_id) = process.reference_exchange_id.as_deref() else {
+        return false;
+    };
+    let Some(exchange) = process
+        .exchanges
+        .iter()
+        .find(|exchange| exchange.exchange_id.as_deref() == Some(reference_exchange_id))
+    else {
+        return false;
+    };
+    parse_numeric_text(exchange.amount.as_deref()).is_ok_and(|amount| amount.abs() > epsilon)
+}
+
+fn parse_numeric_text(value: Option<&str>) -> Result<f64, ()> {
+    let Some(raw) = value else {
+        return Err(());
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.contains('%') {
+        return Err(());
+    }
+    let parsed = trimmed.parse::<f64>().map_err(|_| ())?;
+    parsed.is_finite().then_some(parsed).ok_or(())
+}
+
+fn normalized_direction(direction: &str) -> Option<String> {
+    match direction.trim().to_ascii_lowercase().as_str() {
+        "input" | "in" => Some("input".to_owned()),
+        "output" | "out" => Some("output".to_owned()),
+        _ => None,
+    }
+}
+
+fn exchange_fingerprint(process: &ReviewProcessRecord) -> String {
+    let mut parts = process
+        .exchanges
+        .iter()
+        .map(|exchange| {
+            let amount = parse_numeric_text(exchange.amount.as_deref()).map_or_else(
+                |()| exchange.amount.clone().unwrap_or_default(),
+                format_numeric,
+            );
+            format!(
+                "{}:{}:{}",
+                exchange.flow_id,
+                normalized_direction(&exchange.direction)
+                    .unwrap_or_else(|| exchange.direction.clone()),
+                amount
+            )
+        })
+        .collect::<Vec<_>>();
+    parts.sort();
+    parts.join("|")
+}
+
+fn sparse_values_have_non_finite(payload: &ModelSparseData) -> bool {
+    payload
+        .technosphere_entries
+        .iter()
+        .chain(payload.biosphere_entries.iter())
+        .chain(payload.characterization_factors.iter())
+        .any(|entry| !entry.value.is_finite())
+}
+
+fn provider_allocation_is_conserved(
+    decision: &crate::compiled_graph::CompiledProviderDecision,
+    epsilon: f64,
+) -> bool {
+    if decision.allocations.is_empty() {
+        return decision.matched_provider_count == 0;
+    }
+    let mut sum = 0.0_f64;
+    for allocation in &decision.allocations {
+        if !allocation.weight.is_finite() || allocation.weight < 0.0 {
+            return false;
+        }
+        sum += allocation.weight;
+    }
+    (sum - 1.0).abs() <= epsilon
+}
+
+fn aggregate_sparse_entries(entries: &[SparseTriplet]) -> BTreeMap<(i32, i32), f64> {
+    let mut out = BTreeMap::<(i32, i32), f64>::new();
+    for entry in entries {
+        *out.entry((entry.row, entry.col)).or_insert(0.0) += entry.value;
+    }
+    out
+}
+
+fn duplicate_m_columns(
+    process_count: usize,
+    a_map: &BTreeMap<(i32, i32), f64>,
+    epsilon: f64,
+) -> Vec<Value> {
+    let mut m_map = BTreeMap::<(i32, i32), f64>::new();
+    for (&(row, col), &value) in a_map {
+        if value.abs() > epsilon {
+            *m_map.entry((row, col)).or_insert(0.0) -= value;
+        }
+    }
+    for idx in 0..process_count {
+        let Ok(idx_i32) = i32::try_from(idx) else {
+            continue;
+        };
+        *m_map.entry((idx_i32, idx_i32)).or_insert(0.0) += 1.0;
+    }
+
+    let mut columns = vec![Vec::<(i32, String)>::new(); process_count];
+    for ((row, col), value) in m_map {
+        let Ok(col_idx) = usize::try_from(col) else {
+            continue;
+        };
+        if col_idx < process_count && value.abs() > epsilon {
+            columns[col_idx].push((row, format_numeric(value)));
+        }
+    }
+    for column in &mut columns {
+        column.sort();
+    }
+
+    let mut by_signature = BTreeMap::<String, Vec<i32>>::new();
+    for (idx, column) in columns.into_iter().enumerate() {
+        let signature = column
+            .into_iter()
+            .map(|(row, value)| format!("{row}:{value}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        if let Ok(idx_i32) = i32::try_from(idx) {
+            by_signature.entry(signature).or_default().push(idx_i32);
+        }
+    }
+
+    by_signature
+        .into_iter()
+        .filter_map(|(signature, process_indices)| {
+            (process_indices.len() > 1).then(|| {
+                json!({
+                    "process_indices": process_indices,
+                    "signature": signature
+                })
+            })
+        })
+        .collect()
+}
+
+fn valid_process_count(process_count: i32) -> Option<usize> {
+    usize::try_from(process_count)
+        .ok()
+        .filter(|count| *count > 0)
+}
+
+fn unique_target_indices(target_process_indices: &[i32]) -> Vec<i32> {
+    target_process_indices
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn non_finite_count(values: Option<&[f64]>) -> usize {
+    values
+        .unwrap_or_default()
+        .iter()
+        .filter(|value| !value.is_finite())
+        .count()
+}
+
+fn process_detail(process: &ReviewProcessRecord) -> Value {
+    json!({
+        "process_idx": process.process_idx,
+        "process_id": process.process_id,
+        "process_version": process.process_version,
+        "process_name": process.process_name,
+        "state_code": process.state_code
+    })
+}
+
+fn exchange_detail(process: &ReviewProcessRecord, exchange: &ReviewExchangeRecord) -> Value {
+    json!({
+        "process": process_detail(process),
+        "exchange_id": exchange.exchange_id,
+        "flow_id": exchange.flow_id,
+        "direction": exchange.direction,
+        "amount": exchange.amount,
+        "allocation_fraction": exchange.allocation_fraction
+    })
+}
+
+fn provider_decision_detail(decision: &crate::compiled_graph::CompiledProviderDecision) -> Value {
+    json!({
+        "consumer_idx": decision.consumer_idx,
+        "flow_id": decision.flow_id,
+        "candidate_provider_count": decision.candidate_provider_count,
+        "matched_provider_count": decision.matched_provider_count,
+        "decision_kind": decision.decision_kind,
+        "resolution_strategy": decision.resolution_strategy,
+        "failure_reason": decision.failure_reason,
+        "used_equal_fallback": decision.used_equal_fallback,
+        "volume_fallback_to_one_count": decision.volume_fallback_to_one_count,
+        "allocation_weight_sum": decision.allocations.iter().map(|allocation| allocation.weight).sum::<f64>()
+    })
+}
+
+fn format_numeric(value: f64) -> String {
+    if value == 0.0 {
+        "0.000000000000e0".to_owned()
+    } else {
+        format!("{value:.12e}")
+    }
+}
+
+fn push_blocker(
+    blockers: &mut Vec<ReadinessFinding>,
+    code: &str,
+    message: impl Into<String>,
+    details: Value,
+) {
+    blockers.push(ReadinessFinding {
+        code: code.to_owned(),
+        severity: FindingSeverity::Blocker,
+        message: message.into(),
+        details,
+    });
+}
+
+fn default_input_schema_version() -> String {
+    INPUT_SCHEMA_VERSION.to_owned()
+}
+
+fn default_policy_profile() -> String {
+    DEFAULT_POLICY_PROFILE.to_owned()
+}
+
+fn default_allowed_scope_states() -> Vec<i32> {
+    (100..=199).collect()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_target_probe_limit() -> usize {
+    32
+}
+
+fn default_zero_epsilon() -> f64 {
+    1e-12
+}
+
+fn default_duplicate_value_epsilon() -> f64 {
+    1e-12
+}
+
+fn default_allocation_sum_epsilon() -> f64 {
+    1e-9
+}
+
+fn default_service_loop_epsilon() -> f64 {
+    1e-12
+}
+
+#[cfg(test)]
+mod tests {
+    use solver_core::SparseTriplet;
+
+    use super::*;
+    use crate::compiled_graph::{
+        CompiledAllocationStats, CompiledFlow, CompiledMatchingStats, CompiledProcess,
+        CompiledProviderAllocation, CompiledProviderDecision, CompiledProviderResolutionStrategy,
+        CompiledReferenceStats,
+    };
+    use crate::graph_types::ScopeProcessPartition;
+    use crate::snapshot_artifacts::{
+        SNAPSHOT_COVERAGE_SCHEMA_VERSION, SnapshotAllocationCoverage, SnapshotCandidateSummary,
+        SnapshotGapSummary, SnapshotGeographySummary, SnapshotMatchingCoverage,
+        SnapshotMatrixScale, SnapshotProviderDecisionDiagnostics, SnapshotReferenceCoverage,
+        SnapshotResolutionSummary, SnapshotSingularRisk, SnapshotVolumeWeightSummary,
+    };
+
+    #[test]
+    fn passes_clean_review_submit_fixture_with_target_probe() {
+        let input = clean_input();
+
+        let report = verify_review_submit_gate(&input);
+
+        assert_eq!(report.status, ReviewSubmitGateStatus::Passed);
+        assert!(report.blockers.is_empty());
+        assert!(report.metrics.probe.factorization_checked);
+        assert!(report.metrics.probe.factorization_ready);
+        assert_eq!(report.metrics.probe.target_indices_probed, 1);
+    }
+
+    #[test]
+    fn blocks_historical_process_scan_failures_before_probe() {
+        let mut input = clean_input();
+        input.process_records.push(ReviewProcessRecord {
+            process_idx: Some(2),
+            process_id: input.process_records[1].process_id,
+            process_version: "01.01.001".to_owned(),
+            process_name: Some("consumer duplicate version".to_owned()),
+            state_code: Some(0),
+            reference_exchange_id: Some("ref".to_owned()),
+            exchanges: vec![
+                exchange(
+                    "ref",
+                    input.process_records[1].exchanges[0].flow_id,
+                    "Output",
+                    "0",
+                ),
+                ReviewExchangeRecord {
+                    exchange_id: Some("bad_alloc".to_owned()),
+                    flow_id: Uuid::new_v4(),
+                    direction: "Input".to_owned(),
+                    amount: Some("2.0".to_owned()),
+                    allocation_fraction: Some("100%".to_owned()),
+                },
+            ],
+        });
+
+        let report = verify_review_submit_gate(&input);
+
+        assert_eq!(report.status, ReviewSubmitGateStatus::Blocked);
+        assert!(has_blocker(&report, "invalid_scope_state"));
+        assert!(has_blocker(&report, "duplicate_process_version"));
+        assert!(has_blocker(&report, "missing_or_zero_reference"));
+        assert!(has_blocker(&report, "invalid_allocation_fraction"));
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn blocks_invalid_exchange_amount_text() {
+        let mut input = clean_input();
+        input.process_records[1].exchanges[1].amount = Some("not-a-number".to_owned());
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "invalid_exchange_amount"));
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn blocks_duplicate_exchange_fingerprint_and_service_loop() {
+        let mut input = clean_input();
+        let product_flow = input.process_records[0].exchanges[0].flow_id;
+        let duplicate_a = ReviewProcessRecord {
+            process_idx: Some(2),
+            process_id: Uuid::new_v4(),
+            process_version: "01.00.000".to_owned(),
+            process_name: Some("duplicate a".to_owned()),
+            state_code: Some(100),
+            reference_exchange_id: Some("out".to_owned()),
+            exchanges: vec![
+                exchange("out", product_flow, "Output", "1.0"),
+                exchange("in", product_flow, "Input", "1.0"),
+            ],
+        };
+        let duplicate_b = ReviewProcessRecord {
+            process_idx: Some(3),
+            process_id: Uuid::new_v4(),
+            process_version: "01.00.000".to_owned(),
+            process_name: Some("duplicate b".to_owned()),
+            state_code: Some(100),
+            reference_exchange_id: Some("out".to_owned()),
+            exchanges: duplicate_a.exchanges.clone(),
+        };
+        input.process_records = vec![duplicate_a, duplicate_b];
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "duplicate_exchange_fingerprint"));
+        assert!(has_blocker(&report, "service_loop_detected"));
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn blocks_provider_and_semantic_failures() {
+        let mut input = clean_input();
+        let flow_id = input.compiled_graph.as_ref().unwrap().flows[0].flow_id;
+        let graph = input.compiled_graph.as_mut().unwrap();
+        graph.flows[0].kind = CompiledFlowKind::Elementary;
+        graph.provider_decisions[0].decision_kind = Some(CompiledProviderDecisionKind::NoProvider);
+        graph.provider_decisions[0].matched_provider_count = 0;
+        graph.provider_decisions[0].allocations.clear();
+        graph.provider_decisions[0].used_equal_fallback = true;
+        graph.provider_decisions[0].volume_fallback_to_one_count = 1;
+        input.coverage.matching.unmatched_no_provider = 1;
+        input.coverage.matching.matched_multi_fallback_equal = 1;
+        input
+            .coverage
+            .matching
+            .volume_weight_summary
+            .fallback_to_one_count = 1;
+        graph.technosphere_edges[0].flow_id = flow_id;
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "provider_missing"));
+        assert!(has_blocker(&report, "provider_equal_fallback"));
+        assert!(has_blocker(&report, "provider_volume_evidence_invalid"));
+        assert!(has_blocker(&report, "flow_lcia_semantic_mismatch"));
+    }
+
+    #[test]
+    fn blocks_unresolved_multi_provider_decisions() {
+        let mut input = clean_input();
+        let graph = input.compiled_graph.as_mut().unwrap();
+        graph.provider_decisions[0].decision_kind =
+            Some(CompiledProviderDecisionKind::MultiUnresolved);
+        graph.provider_decisions[0].matched_provider_count = 2;
+        graph.provider_decisions[0].allocations.clear();
+        input.coverage.matching.matched_multi_unresolved = 1;
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "provider_unresolved"));
+    }
+
+    #[test]
+    fn blocks_sparse_and_probe_coverage_failures() {
+        let mut input = clean_input();
+        input.target_process_indices.clear();
+        input.coverage.singular_risk.risk_level = "medium".to_owned();
+        input.payload.technosphere_entries.push(SparseTriplet {
+            row: 0,
+            col: 0,
+            value: 1.0,
+        });
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(
+            &report,
+            "sparse_matrix_zero_or_near_zero_diagonal"
+        ));
+        assert!(has_blocker(&report, "singular_risk_medium_or_high"));
+        assert!(has_blocker(&report, "target_process_not_covered_by_probe"));
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn blocks_duplicate_sparse_columns() {
+        let mut input = clean_input();
+        input.payload.technosphere_entries = vec![
+            SparseTriplet {
+                row: 0,
+                col: 0,
+                value: 1.0,
+            },
+            SparseTriplet {
+                row: 1,
+                col: 1,
+                value: 1.0,
+            },
+        ];
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "duplicate_sparse_columns"));
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn blocks_factorization_probe_failure_without_full_solve_all_unit() {
+        let mut input = clean_input();
+        input.payload.technosphere_entries = vec![
+            SparseTriplet {
+                row: 0,
+                col: 1,
+                value: 1.0,
+            },
+            SparseTriplet {
+                row: 1,
+                col: 0,
+                value: 1.0,
+            },
+        ];
+
+        let report = verify_review_submit_gate(&input);
+
+        assert!(has_blocker(&report, "factorization_probe_failed"));
+        assert!(report.metrics.probe.factorization_checked);
+        assert!(!report.metrics.probe.factorization_ready);
+    }
+
+    fn clean_input() -> ReviewSubmitGateInput {
+        let snapshot_id = Uuid::new_v4();
+        let provider_id = Uuid::new_v4();
+        let consumer_id = Uuid::new_v4();
+        let product_flow_id = Uuid::new_v4();
+        let elementary_flow_id = Uuid::new_v4();
+        ReviewSubmitGateInput {
+            schema_version: INPUT_SCHEMA_VERSION.to_owned(),
+            dataset_revision_id: Some(Uuid::new_v4()),
+            expected_revision_checksum: Some("sha256:abc".to_owned()),
+            actual_revision_checksum: Some("sha256:abc".to_owned()),
+            snapshot_id: Some(snapshot_id),
+            config: None,
+            coverage: coverage(true),
+            payload: ModelSparseData {
+                model_version: snapshot_id,
+                process_count: 2,
+                flow_count: 2,
+                impact_count: 1,
+                technosphere_entries: vec![SparseTriplet {
+                    row: 0,
+                    col: 1,
+                    value: 0.1,
+                }],
+                biosphere_entries: vec![
+                    SparseTriplet {
+                        row: 1,
+                        col: 0,
+                        value: 1.0,
+                    },
+                    SparseTriplet {
+                        row: 1,
+                        col: 1,
+                        value: 2.0,
+                    },
+                ],
+                characterization_factors: vec![SparseTriplet {
+                    row: 0,
+                    col: 1,
+                    value: 0.5,
+                }],
+            },
+            compiled_graph: Some(CompiledGraph {
+                processes: vec![
+                    process(0, provider_id, "provider"),
+                    process(1, consumer_id, "consumer"),
+                ],
+                flows: vec![
+                    CompiledFlow {
+                        flow_idx: 0,
+                        flow_id: product_flow_id,
+                        kind: CompiledFlowKind::Product,
+                    },
+                    CompiledFlow {
+                        flow_idx: 1,
+                        flow_id: elementary_flow_id,
+                        kind: CompiledFlowKind::Elementary,
+                    },
+                ],
+                provider_decisions: vec![CompiledProviderDecision {
+                    consumer_idx: 1,
+                    flow_id: product_flow_id,
+                    candidate_provider_count: 1,
+                    matched_provider_count: 1,
+                    candidates: Vec::new(),
+                    decision_kind: Some(CompiledProviderDecisionKind::UniqueProvider),
+                    resolution_strategy: Some(CompiledProviderResolutionStrategy::UniqueProvider),
+                    failure_reason: None,
+                    used_equal_fallback: false,
+                    volume_fallback_to_one_count: 0,
+                    geography_tier: None,
+                    supply_region_source: None,
+                    supply_region_location: None,
+                    exchange_location_present: false,
+                    allocations: vec![CompiledProviderAllocation {
+                        provider_idx: 0,
+                        weight: 1.0,
+                    }],
+                }],
+                technosphere_edges: vec![crate::compiled_graph::CompiledTechnosphereEdge {
+                    provider_idx: 0,
+                    consumer_idx: 1,
+                    flow_id: product_flow_id,
+                    amount: 0.1,
+                    provider_partition: ScopeProcessPartition::Public,
+                    consumer_partition: ScopeProcessPartition::Private,
+                    partition: crate::compiled_graph::CompiledEdgePartition::PublicToPrivate,
+                }],
+                biosphere_edges: vec![crate::compiled_graph::CompiledBiosphereEdge {
+                    process_idx: 1,
+                    flow_idx: 1,
+                    amount: 2.0,
+                    process_partition: ScopeProcessPartition::Private,
+                }],
+                reference_stats: CompiledReferenceStats::default(),
+                allocation_stats: CompiledAllocationStats::default(),
+                matching_stats: CompiledMatchingStats::default(),
+            }),
+            target_process_indices: vec![1],
+            process_records: vec![
+                ReviewProcessRecord {
+                    process_idx: Some(0),
+                    process_id: provider_id,
+                    process_version: "01.00.000".to_owned(),
+                    process_name: Some("provider".to_owned()),
+                    state_code: Some(100),
+                    reference_exchange_id: Some("ref".to_owned()),
+                    exchanges: vec![exchange("ref", product_flow_id, "Output", "1.0")],
+                },
+                ReviewProcessRecord {
+                    process_idx: Some(1),
+                    process_id: consumer_id,
+                    process_version: "01.00.000".to_owned(),
+                    process_name: Some("consumer".to_owned()),
+                    state_code: Some(100),
+                    reference_exchange_id: Some("ref".to_owned()),
+                    exchanges: vec![
+                        exchange("ref", product_flow_id, "Output", "1.0"),
+                        exchange("in", product_flow_id, "Input", "0.1"),
+                    ],
+                },
+            ],
+            policy: ReviewSubmitGatePolicy::default(),
+        }
+    }
+
+    fn coverage(provider_closed: bool) -> SnapshotCoverageReport {
+        SnapshotCoverageReport {
+            schema_version: SNAPSHOT_COVERAGE_SCHEMA_VERSION.to_owned(),
+            matching: SnapshotMatchingCoverage {
+                input_edges_total: 1,
+                matched_unique_provider: i64::from(provider_closed),
+                matched_multi_provider: 0,
+                unmatched_no_provider: i64::from(!provider_closed),
+                matched_multi_resolved: 0,
+                matched_multi_unresolved: 0,
+                matched_multi_fallback_equal: 0,
+                a_input_edges_written: i64::from(provider_closed),
+                a_write_pct: if provider_closed { 100.0 } else { 0.0 },
+                provider_present_resolved_pct: if provider_closed { 100.0 } else { 0.0 },
+                unique_provider_match_pct: if provider_closed { 100.0 } else { 0.0 },
+                any_provider_match_pct: if provider_closed { 100.0 } else { 0.0 },
+                provider_decision_diagnostics: SnapshotProviderDecisionDiagnostics::default(),
+                candidate_summary: SnapshotCandidateSummary::default(),
+                resolution_summary: SnapshotResolutionSummary::default(),
+                geography_summary: SnapshotGeographySummary::default(),
+                volume_weight_summary: SnapshotVolumeWeightSummary::default(),
+                gap_summary: SnapshotGapSummary::default(),
+            },
+            reference: SnapshotReferenceCoverage {
+                process_total: 2,
+                normalized_process_count: 2,
+                missing_reference_count: 0,
+                invalid_reference_count: 0,
+            },
+            allocation: SnapshotAllocationCoverage {
+                exchange_total: 2,
+                allocation_fraction_present_pct: 100.0,
+                allocation_fraction_missing_count: 0,
+                allocation_fraction_invalid_count: 0,
+            },
+            singular_risk: SnapshotSingularRisk {
+                risk_level: "low".to_owned(),
+                prefilter_diag_abs_ge_cutoff: 0,
+                postfilter_a_diag_abs_ge_cutoff: 0,
+                m_zero_diagonal_count: 0,
+                m_min_abs_diagonal: 1.0,
+            },
+            matrix_scale: SnapshotMatrixScale {
+                process_count: 2,
+                flow_count: 2,
+                impact_count: 1,
+                a_nnz: i64::from(provider_closed),
+                b_nnz: 2,
+                c_nnz: 1,
+                m_nnz_estimated: 3,
+                m_sparsity_estimated: 0.25,
+            },
+        }
+    }
+
+    fn process(process_idx: i32, process_id: Uuid, process_name: &str) -> CompiledProcess {
+        CompiledProcess {
+            process_idx,
+            process_id,
+            process_version: "01.00.000".to_owned(),
+            process_name: Some(process_name.to_owned()),
+            model_id: None,
+            location: Some("CN".to_owned()),
+            reference_year: Some(2024),
+            partition: ScopeProcessPartition::Private,
+        }
+    }
+
+    fn exchange(
+        exchange_id: &str,
+        flow_id: Uuid,
+        direction: &str,
+        amount: &str,
+    ) -> ReviewExchangeRecord {
+        ReviewExchangeRecord {
+            exchange_id: Some(exchange_id.to_owned()),
+            flow_id,
+            direction: direction.to_owned(),
+            amount: Some(amount.to_owned()),
+            allocation_fraction: None,
+        }
+    }
+
+    fn has_blocker(report: &ReviewSubmitGateReport, code: &str) -> bool {
+        report.blockers.iter().any(|blocker| blocker.code == code)
+    }
+}

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,6 +24,7 @@ checkPaths:
   - supabase/migrations/**
   - docs/lca-api-contract.md
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/implicit-regional-supply-mix-modeling.md
   - docs/implicit-regional-supply-mix-modeling.en.md
   - docs/tidas-package-contract.md
@@ -39,6 +40,7 @@ related:
   - ./repo-validation.md
   - ../../docs/lca-api-contract.md
   - ../../docs/matrix-readiness-report-contract.md
+  - ../../docs/review-submit-fast-gate-contract.md
 ---
 
 ## Repo Shape
@@ -71,6 +73,8 @@ Keep these constraints in mind before editing `crates/solver-core/**` or worker 
 | `tools/bw25-validator/**` | manual Brightway comparison tooling |
 | `supabase/migrations/**` | local runtime-facing SQL expectations referenced by the calculator runtime |
 | `docs/lca-api-contract.md` | shared jobs/results/payload/status contract for edge and frontend consumers |
+| `docs/matrix-readiness-report-contract.md` | calculator-owned matrix-readiness report schema, blocker/finding codes, and next-action contract |
+| `docs/review-submit-fast-gate-contract.md` | calculator-owned review-submit fast gate schema, blocker codes, and targeted probe contract |
 | `docs/edge-function-integration.md` | edge-facing enqueue, polling, and service-role integration contract |
 | `docs/frontend-integration.md` | frontend-side solve/result interaction contract |
 | `docs/implicit-regional-supply-mix-modeling.md` / `docs/implicit-regional-supply-mix-modeling.en.md` | Chinese and English modeling notes for implicit regional supply mix, exchange-location supply-region anchors, and annual-volume provider share semantics |
@@ -99,6 +103,8 @@ The snapshot builder path owns sparse payload generation, provider matching, and
 The modeling basis for implicit regional supply mix, exchange-location supply-region anchors, and annual-volume provider shares lives in `docs/implicit-regional-supply-mix-modeling.md` and `docs/implicit-regional-supply-mix-modeling.en.md`.
 
 `crates/solver-worker/src/readiness.rs` owns the calculator-side verification gate for automated data production. It turns snapshot coverage, sparse payloads, and optional compiled provider decisions into a machine-readable matrix-readiness report. Foundry and CLI callers should consume that report instead of reimplementing provider closure, singular-risk, LCIA, or factorization checks outside calculator. The stable report schema, blocker/finding codes, and next-action semantics live in `docs/matrix-readiness-report-contract.md`.
+
+`crates/solver-worker/src/review_submit_gate.rs` owns the calculator-side fast gate for dataset revision review submission. It layers revision freshness, process/exchange scans, provider evidence, sparse structural checks, and targeted RHS probes into a binary `passed` / `blocked` report without full matrix inversion or full `solve_all_unit`.
 
 ### Package worker
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,6 +25,7 @@ checkPaths:
   - supabase/migrations/**
   - docs/lca-api-contract.md
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/implicit-regional-supply-mix-modeling.md
@@ -43,6 +44,7 @@ related:
   - ./repo-architecture.md
   - ../../docs/lca-api-contract.md
   - ../../docs/matrix-readiness-report-contract.md
+  - ../../docs/review-submit-fast-gate-contract.md
   - ../../docs/tidas-package-contract.md
 ---
 
@@ -65,6 +67,7 @@ Treat the last two commands as non-negotiable hard gates after code changes.
 | `crates/**` solver or worker code | `make check`; hard Clippy gate; hard format gate | run the narrow manual script that matches the touched area, such as snapshot build, full compute debug, or BW25 validation | Record which job family or worker path was exercised. |
 | snapshot-builder or provider-matching behavior | baseline gates plus `./scripts/build_snapshot_from_ilcd.sh` when safe | run provider-link diagnostics export helpers when the task changes matching logic | Snapshot and provider diagnostics often need task-specific proof. |
 | matrix-readiness / provider-closure gate | `cargo test -p solver-worker readiness`; `cargo check -p solver-worker --bin matrix_readiness`; hard Clippy gate for the touched binary/module | run `snapshot_builder` or `matrix_readiness --input <fixture> --out <report>` against the closest available target snapshot artifact | Keep `docs/matrix-readiness-report-contract.md` aligned with blocker/finding code, policy, and next_action changes. Use `PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig` on local Homebrew setups so SuiteSparse/UMFPACK link metadata is discoverable. |
+| review-submit fast gate | `cargo test -p solver-worker review_submit_gate`; `cargo check -p solver-worker --bin review_submit_gate`; hard Clippy gate for the touched binary/module | run `review_submit_gate --input <fixture> --out <report> --fail-on-blocked` against a representative dataset revision artifact | Keep `docs/review-submit-fast-gate-contract.md` aligned with blocker codes, policy defaults, and targeted probe behavior. |
 | package worker import or export flows | baseline gates | run the closest safe package-flow helper or record why live package proof is deferred | Package-job semantics are runtime-sensitive and may depend on storage or DB state. |
 | runtime SQL expectation docs or local migration helpers | baseline gates plus `./scripts/validate_additive_migration.sh` when the task touches migration expectations | record separately when durable schema proof is required in `database-engine` | Local migration files here are not the workspace-wide source of truth. |
 | manual debug, parity, or target-validation scripts | run the touched script with safe args or `--help` when available, plus baseline gates if code changed nearby | `./scripts/run_full_compute_debug.sh`, `./scripts/run_bw25_validation.sh`, or `./scripts/validate_lcia_targets.sh` as applicable | `bw25-validator` is manual-only and out-of-band. |

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -18,6 +18,7 @@ checkPaths:
   - crates/**
   - supabase/migrations/**
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-05-25
@@ -26,6 +27,7 @@ related:
   - AGENTS.md
   - .docpact/config.yaml
   - docs/matrix-readiness-report-contract.md
+  - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/repo-validation.md
@@ -223,6 +225,29 @@ fresh `snapshot_builder` run 也会在 `report_dir` 下写出 `matrix-readiness-
 当前 matrix-readiness 只通过 calculator CLI 与 `snapshot_builder` report artifact 暴露；本节不表示 Edge/API 已提供 HTTP 调用入口。稳定 code、`blockers` / `findings` / `next_action` 规则、policy 默认值和调用方消费约束由 `docs/matrix-readiness-report-contract.md` 维护。
 
 Foundry、CLI 或 Edge adapter 只能消费该 report 的 `status`、`next_action`、`blockers`、`metrics` 和 `provider_evidence`；不应在外部复制 calculator 的 provider resolution、singular-risk 或 UMFPACK readiness 规则。
+
+### 5.2 Review-submit fast gate report
+
+dataset revision 提交审核前使用 calculator 侧 `review_submit_gate` 判断当前 revision 是否可进入审核流程。该 gate 输出二元结果：`passed` 或 `blocked`，不产生 `manual_review_required` 状态。
+
+可调用入口：
+
+```bash
+cargo run -p solver-worker --bin review_submit_gate -- \
+  --input review-submit-gate-input.json \
+  --out review-submit-gate-report.json
+```
+
+输入 `review_submit_gate_input.v1` 复用 snapshot coverage、`ModelSparseData` sparse payload、compiled provider graph，并可附加 dataset revision checksum、target process indices 和 process/exchange scan records。输出 `review_submit_gate_report.v1` 包含：
+
+- `status`: `passed` 或 `blocked`。
+- `policy`: 默认 profile 为 `review_submit_fast.v1`。
+- `metrics`: revision、process_scan、provider_scan、sparse_scan 和 targeted probe 统计。
+- `blockers`: 提交审核硬失败 code、message 和 detail payload。
+
+该 gate 先执行 revision/process/provider/flow/sparse 结构检查；只有没有结构 blocker 时才执行 sparse factorization readiness 与 targeted RHS solve。它不 materialize inverse，也不要求 full `solve_all_unit`。
+
+稳定 blocker code、policy 默认值、快速验证顺序和 caller consumption 约束由 `docs/review-submit-fast-gate-contract.md` 维护。Edge 或 Next 在提交审核链路中应消费该 report 或由服务端封装后的等价 gate result，不应直接把 `matrix_readiness_report.v1` 的 blocker 当成提交审核结论。
 
 ## 6. 幂等与请求缓存（建议约束）
 

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -1,0 +1,148 @@
+---
+title: Review Submit Fast Gate Contract
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: calculator
+language: zh-CN
+whenToUse:
+  - 当 dataset revision 提交审核前需要 calculator 侧数值稳定性快速 gate 时
+  - 当 Edge、Foundry 或 Next 需要消费 review-submit gate report 时
+  - 当 review_submit_gate 的 schema、policy、blocker 或 probe 规则变化时
+whenToUpdate:
+  - 当 crates/solver-worker/src/review_submit_gate.rs 的 report schema、policy 或 blocker code 变化时
+  - 当 crates/solver-worker/src/bin/review_submit_gate.rs 的 CLI contract 变化时
+  - 当提交审核前的 calculator-owned gate 与 matrix-readiness 的边界变化时
+checkPaths:
+  - docs/review-submit-fast-gate-contract.md
+  - crates/solver-worker/src/review_submit_gate.rs
+  - crates/solver-worker/src/bin/review_submit_gate.rs
+  - crates/solver-worker/src/readiness.rs
+  - crates/solver-worker/src/compiled_graph.rs
+  - docs/lca-api-contract.md
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+related:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - docs/lca-api-contract.md
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+---
+
+# Review Submit Fast Gate Contract
+
+`review_submit_gate` 是 calculator 侧的 dataset revision 提交审核前快速 gate。它输出二元结果：`passed` 或 `blocked`。
+
+该 gate 不属于 Edge HTTP API，也不属于 Next UI 行为。Edge、Foundry 和 Next 可以消费 report，但不应复制 calculator 的 provider、sparse-structure、factorization probe 或 target solve 判断逻辑。
+
+## 调用入口
+
+当前 calculator 暴露 CLI 与 library function：
+
+```bash
+cargo run -p solver-worker --bin review_submit_gate -- \
+  --input review-submit-gate-input.json \
+  --out review-submit-gate-report.json
+```
+
+CLI 默认总是写出 report。调用方需要命令行级失败时，可以传 `--fail-on-blocked`，blocked report 会以 exit code `2` 返回。
+
+## 输入
+
+输入 schema version 为 `review_submit_gate_input.v1`，核心字段为：
+
+- `dataset_revision_id`: 被提交审核的 dataset revision。
+- `expected_revision_checksum` / `actual_revision_checksum`: 用于判断 report 是否绑定当前 revision。
+- `coverage`: snapshot coverage report。
+- `payload`: `ModelSparseData` sparse payload。
+- `compiled_graph`: provider decision、flow kind、technosphere/biosphere edge 与 process metadata。
+- `target_process_indices`: 本次提交审核必须覆盖的 target / changed process index。
+- `process_records`: calculator 可解释的 process/exchange scan record，用于 reference、allocation、duplicate fingerprint 和 service-loop 快速检查。
+- `policy`: `review_submit_fast.v1` policy surface。
+
+`process_records` 是提交审核快速 gate 的可选增强输入。没有它时，gate 仍可根据 `coverage`、`payload` 与 `compiled_graph` 执行 provider、sparse structure 和 probe 检查，但无法发现所有 JSON/process-level 历史事故模式。
+
+## 输出
+
+输出 schema version 为 `review_submit_gate_report.v1`，核心字段为：
+
+- `status`: `passed` 或 `blocked`。
+- `policy`: 实际使用的 review-submit policy。
+- `metrics.revision`: revision checksum freshness 结果。
+- `metrics.process_scan`: process record、reference、exchange amount、allocation、duplicate fingerprint 和 service-loop 统计。
+- `metrics.provider_scan`: provider missing、unresolved、equal fallback、allocation conservation 和 volume evidence 统计。
+- `metrics.sparse_scan`: diagonal、duplicate column 和 flow/LCIA semantic 统计。
+- `metrics.probe`: sparse factorization 与 targeted RHS solve probe 结果。
+- `blockers`: stable blocker code、message 和 detail payload。
+
+调用方必须以 `status` 和 `blockers[].code` 为准。`metrics` 用于展示、诊断和后续数据修复，不应被外部调用方重新解释成另一套 gate 规则。
+
+## Policy 默认值
+
+默认 profile 为 `review_submit_fast.v1`。
+
+默认策略：
+
+- 要求 `expected_revision_checksum == actual_revision_checksum`。
+- `allowed_scope_states = 100..199`；不在该范围的 process record 会触发 `invalid_scope_state`。
+- 阻断 provider equal fallback。
+- 阻断 provider volume fallback evidence。
+- impact-ready 提交要求 LCIA factors。
+- 要求 target process probe。
+- target probe 默认最多覆盖 `32` 个 process。
+- 默认执行 sparse factorization probe 和 targeted RHS solve。
+- 不执行完整矩阵求逆，不要求 full `solve_all_unit`。
+
+## Blockers
+
+`blockers` 表示提交审核硬失败。当前稳定 code 如下：
+
+| Code | 触发条件 | 主要修复方向 |
+| --- | --- | --- |
+| `revision_report_stale` | revision checksum 缺失或不匹配 | 基于当前 revision 重跑 gate |
+| `invalid_scope_state` | process record 的 `state_code` 不在 policy 允许范围 | 修正计算 scope 或 process lifecycle state |
+| `duplicate_process_version` | 同一 process ID 多个版本同时进入 gate scope | 去重或明确只纳入目标版本 |
+| `missing_or_zero_reference` | quantitative reference 缺失、指向不存在 exchange、amount 为 0，或 coverage 有 reference failure | 修复 reference exchange 和非零 reference amount |
+| `invalid_exchange_amount` | exchange amount 缺失、不可解析、带非法文本、NaN 或 Infinity | 修复 exchange amount / 单位转换 |
+| `invalid_allocation_fraction` | allocation fraction 不可解析、带 `%` 或超出允许数值范围 | 统一 allocation fraction 表达 |
+| `duplicate_exchange_fingerprint` | 不同 process 的 flow/direction/amount fingerprint 完全一致 | 合并重复 process 或补充可区分 exchange |
+| `service_loop_detected` | 同一 process 中同一 flow 的 input/output amount 相同或近似相同 | 修正自供给、循环或拆分 process |
+| `provider_missing` | product input edge 无 provider | 补 provider 数据或修正 product/reference flow |
+| `provider_unresolved` | multi-provider input edge 未解析 | 补 provider evidence 或缩小候选集 |
+| `provider_equal_fallback` | provider resolution 使用 equal fallback 且 policy 阻断 | 补 annual volume / evidence，避免等权兜底 |
+| `provider_allocation_not_conserved` | provider allocation weight 非有限、负数、为空或 sum 不为 1 | 修复 provider allocation |
+| `provider_volume_evidence_invalid` | provider volume evidence fallback-to-one 或缺失超过 policy 容忍 | 补充可比较 annual volume evidence |
+| `flow_lcia_semantic_mismatch` | product/elementary flow 或 LCIA factor 语义错配 | 修复 flow kind、biosphere edge 或 LCIA factor mapping |
+| `lcia_factor_missing_for_impact_submit` | impact-ready 提交要求 LCIA factors，但 `c_nnz = 0` | 补齐 LCIA factors 或改用非 impact 提交策略 |
+| `sparse_matrix_zero_or_near_zero_diagonal` | `M = I - A` 对角线为 0 / near-zero，或 payload process count 无效 | 修复自环、reference 或 matrix structure |
+| `duplicate_sparse_columns` | `M = I - A` 存在重复 sparse column signature | 排查重复结构和线性相关 process |
+| `singular_risk_medium_or_high` | coverage singular risk 为 `medium` 或 `high` | 修复 matrix structure 后重跑 |
+| `target_process_not_covered_by_probe` | target process list 缺失、越界或超过 probe limit | 明确 submitted / changed process list，或拆分 gate |
+| `factorization_probe_failed` | sparse factorization readiness probe 失败 | 修复 matrix structure 后重跑 |
+| `target_probe_non_finite_result` | targeted RHS solve 失败或产生 NaN / Infinity | 修复 compute stability / flow / LCIA 数据 |
+
+## 快速验证顺序
+
+Gate 按便宜到昂贵的顺序执行：
+
+1. revision freshness。
+2. process record scan：scope state、reference、exchange amount、allocation、duplicate fingerprint、service-loop。
+3. provider scan：missing、unresolved、equal fallback、allocation conservation、volume evidence。
+4. flow / LCIA semantic scan。
+5. sparse structure scan：diagonal、duplicate sparse column、singular risk。
+6. target process coverage check。
+7. 仅当以上没有 blocker 时，执行 sparse factorization readiness 与 targeted RHS solve。
+
+这个顺序让历史事故模式在 full solve 之前被挡住。它不会 materialize inverse，也不会默认跑 full `solve_all_unit`。
+
+## 与 Matrix Readiness 的关系
+
+`matrix_readiness` 面向 snapshot / matrix report artifact，回答“这个 snapshot 是否具备 provider closure、graph readiness 和基本 compute stability”。
+
+`review_submit_gate` 面向 dataset revision 提交审核，回答“这个 revision 是否允许进入审核流程”。
+
+两者共享 coverage、payload、compiled provider evidence 和 sparse solver 语义，但 blocker code 不相同。Edge 和 Next 在提交审核流程中应消费 `review_submit_gate_report.v1`，不应直接把 `matrix_readiness_report.v1` 的 blocker 当成提交审核结论。


### PR DESCRIPTION
Closes linancn/tiangong-lca-calculator#53

## Summary
- Add a calculator-owned review_submit_gate library module and CLI that emits review_submit_gate_report.v1 with passed/blocked status.
- Implement fast blockers for revision freshness, scope state, reference/exchange/allocation quality, duplicate exchange fingerprints, service loops, provider closure/evidence, flow/LCIA semantics, sparse structure, target probe coverage, factorization probe, and targeted RHS non-finite results.
- Document the new review_submit_fast.v1 contract and add docpact routing/coverage for the gate.

## Key Decisions
- Keep this as a calculator report/CLI contract; edge-functions and next integration remain in their own child issues.
- Run cheap structural checks before sparse factorization and targeted RHS solve; do not materialize a full inverse or require full solve_all_unit.

## Validation
- make check
- cargo test -p solver-worker review_submit_gate
- cargo check -p solver-worker --bin review_submit_gate
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- scripts/docpact route --root . --intent review-submit-gate --format json

## Risks / Rollback
- Medium: introduces a new gate contract and conservative default blockers such as equal fallback and 100..199 scope-state policy; edge/next should consume policy/profile metadata rather than reinterpreting blockers.

## Follow-ups
- Implement edge-functions API/job orchestration in linancn/tiangong-lca-edge-functions#113.
- Implement next submit-review UI gating in linancn/tiangong-lca-next#437.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after merge.