### PR TITLE
Fix review-submit gate draft state and missing-provider policy

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "48a86e85dde828830d22d1de9ae9585ec1fec365"
+lastReviewedAt: "2026-05-26"
+lastReviewedCommit: "877f8318a1716786beb32bc86ac208c57a9168d9"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/review_submit_gate.rs
+++ b/crates/solver-worker/src/review_submit_gate.rs
@@ -550,7 +550,6 @@ fn check_provider_closure(
                 .decisions_partial_missing_count
             + matching.volume_weight_summary.decisions_all_missing_count;
 
-    let mut missing_examples = Vec::new();
     let mut unresolved_examples = Vec::new();
     let mut fallback_examples = Vec::new();
     let mut unconserved_examples = Vec::new();
@@ -559,14 +558,11 @@ fn check_provider_closure(
     if let Some(graph) = &input.compiled_graph {
         metrics.provider_scan.provider_decisions_total = graph.provider_decisions.len();
         for decision in &graph.provider_decisions {
-            match decision.decision_kind {
-                Some(CompiledProviderDecisionKind::NoProvider) => {
-                    missing_examples.push(provider_decision_detail(decision));
-                }
-                Some(CompiledProviderDecisionKind::MultiUnresolved) => {
-                    unresolved_examples.push(provider_decision_detail(decision));
-                }
-                _ => {}
+            if matches!(
+                decision.decision_kind,
+                Some(CompiledProviderDecisionKind::MultiUnresolved)
+            ) {
+                unresolved_examples.push(provider_decision_detail(decision));
             }
             if decision.used_equal_fallback {
                 fallback_examples.push(provider_decision_detail(decision));
@@ -582,17 +578,6 @@ fn check_provider_closure(
 
     metrics.provider_scan.allocation_not_conserved_count = unconserved_examples.len();
 
-    if metrics.provider_scan.provider_missing_count > 0 || !missing_examples.is_empty() {
-        push_blocker(
-            blockers,
-            "provider_missing",
-            "product input edges have no provider candidates",
-            json!({
-                "coverage_unmatched_no_provider": matching.unmatched_no_provider,
-                "examples": missing_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
-            }),
-        );
-    }
     if metrics.provider_scan.provider_unresolved_count > 0 || !unresolved_examples.is_empty() {
         push_blocker(
             blockers,
@@ -1162,7 +1147,7 @@ fn default_policy_profile() -> String {
 }
 
 fn default_allowed_scope_states() -> Vec<i32> {
-    (100..=199).collect()
+    std::iter::once(0).chain(100..=199).collect()
 }
 
 fn default_true() -> bool {
@@ -1221,6 +1206,32 @@ mod tests {
     }
 
     #[test]
+    fn default_policy_allows_draft_and_reviewed_scope_states() {
+        let mut input = clean_input();
+        input.process_records[0].state_code = Some(0);
+        input.process_records[1].state_code = Some(100);
+
+        let report = verify_review_submit_gate(&input);
+
+        assert_eq!(report.status, ReviewSubmitGateStatus::Passed);
+        assert!(!has_blocker(&report, "invalid_scope_state"));
+        assert_eq!(report.metrics.process_scan.invalid_scope_state_count, 0);
+    }
+
+    #[test]
+    fn default_policy_blocks_under_review_scope_state() {
+        let mut input = clean_input();
+        input.process_records[0].state_code = Some(20);
+
+        let report = verify_review_submit_gate(&input);
+
+        assert_eq!(report.status, ReviewSubmitGateStatus::Blocked);
+        assert!(has_blocker(&report, "invalid_scope_state"));
+        assert_eq!(report.metrics.process_scan.invalid_scope_state_count, 1);
+        assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
     fn blocks_historical_process_scan_failures_before_probe() {
         let mut input = clean_input();
         input.process_records.push(ReviewProcessRecord {
@@ -1228,7 +1239,7 @@ mod tests {
             process_id: input.process_records[1].process_id,
             process_version: "01.01.001".to_owned(),
             process_name: Some("consumer duplicate version".to_owned()),
-            state_code: Some(0),
+            state_code: Some(20),
             reference_exchange_id: Some("ref".to_owned()),
             exchanges: vec![
                 exchange(
@@ -1324,7 +1335,8 @@ mod tests {
 
         let report = verify_review_submit_gate(&input);
 
-        assert!(has_blocker(&report, "provider_missing"));
+        assert_eq!(report.metrics.provider_scan.provider_missing_count, 1);
+        assert!(!has_blocker(&report, "provider_missing"));
         assert!(has_blocker(&report, "provider_equal_fallback"));
         assert!(has_blocker(&report, "provider_volume_evidence_invalid"));
         assert!(has_blocker(&report, "flow_lcia_semantic_mismatch"));

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -21,8 +21,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -26,8 +26,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 48a86e85dde828830d22d1de9ae9585ec1fec365
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -120,9 +120,10 @@ DB runner 写回数据库时：
 默认策略：
 
 - 要求 `expected_revision_checksum == actual_revision_checksum`。
-- `allowed_scope_states = 100..199`；不在该范围的 process record 会触发 `invalid_scope_state`。
+- `allowed_scope_states = [0] + 100..=199`；`0` 表示提交审核前 draft root，`100..=199` 用于已审核 / 可用依赖数据兼容；`20` 等审核中状态不允许，仍会触发 `invalid_scope_state`。
 - 阻断 provider equal fallback。
 - 阻断 provider volume fallback evidence。
+- provider missing 只记录在 `metrics.provider_scan.provider_missing_count`，不作为提交审核 blocker。
 - impact-ready 提交要求 LCIA factors。
 - 要求 target process probe。
 - target probe 默认最多覆盖 `32` 个 process。
@@ -143,7 +144,6 @@ DB runner 写回数据库时：
 | `invalid_allocation_fraction` | allocation fraction 不可解析、带 `%` 或超出允许数值范围 | 统一 allocation fraction 表达 |
 | `duplicate_exchange_fingerprint` | 不同 process 的 flow/direction/amount fingerprint 完全一致 | 合并重复 process 或补充可区分 exchange |
 | `service_loop_detected` | 同一 process 中同一 flow 的 input/output amount 相同或近似相同 | 修正自供给、循环或拆分 process |
-| `provider_missing` | product input edge 无 provider | 补 provider 数据或修正 product/reference flow |
 | `provider_unresolved` | multi-provider input edge 未解析 | 补 provider evidence 或缩小候选集 |
 | `provider_equal_fallback` | provider resolution 使用 equal fallback 且 policy 阻断 | 补 annual volume / evidence，避免等权兜底 |
 | `provider_allocation_not_conserved` | provider allocation weight 非有限、负数、为空或 sum 不为 1 | 修复 provider allocation |
@@ -163,7 +163,7 @@ Gate 按便宜到昂贵的顺序执行：
 
 1. revision freshness。
 2. process record scan：scope state、reference、exchange amount、allocation、duplicate fingerprint、service-loop。
-3. provider scan：missing、unresolved、equal fallback、allocation conservation、volume evidence。
+3. provider scan：missing metric、unresolved、equal fallback、allocation conservation、volume evidence。
 4. flow / LCIA semantic scan。
 5. sparse structure scan：diagonal、duplicate sparse column、singular risk。
 6. target process coverage check。


### PR DESCRIPTION
## Summary
- Allow default review-submit gate scope states `[0] + 100..=199`, while keeping state `20` blocked.
- Stop treating `provider_missing` as a blocker while preserving `metrics.provider_scan.provider_missing_count`.
- Update the review-submit fast gate contract and docpact review evidence for the new policy.

Closes #57

## Validation
- `cargo test -p solver-worker review_submit_gate`
- `cargo check -p solver-worker --bin review_submit_gate`
- `cargo test -p solver-worker review_submit_gate_runner`
- `cargo check -p solver-worker --bin review_submit_gate_runner`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/docpact-gate.sh --base origin/main`