### PR TITLE
Fix review-submit gate blocker semantics

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "877f8318a1716786beb32bc86ac208c57a9168d9"
+lastReviewedCommit: "b6137656059cb16531e2d97e2bbdbacbfdf0fff6"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
+lastReviewedCommit: b6137656059cb16531e2d97e2bbdbacbfdf0fff6
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/review_submit_gate.rs
+++ b/crates/solver-worker/src/review_submit_gate.rs
@@ -17,7 +17,7 @@ use solver_core::{
 };
 use uuid::Uuid;
 
-use crate::compiled_graph::{CompiledFlowKind, CompiledGraph, CompiledProviderDecisionKind};
+use crate::compiled_graph::{CompiledFlowKind, CompiledGraph};
 use crate::readiness::{FindingSeverity, ReadinessFinding};
 use crate::snapshot_artifacts::{SnapshotBuildConfig, SnapshotCoverageReport};
 
@@ -41,9 +41,9 @@ pub struct ReviewSubmitGatePolicy {
     pub require_revision_checksum_match: bool,
     #[serde(default = "default_allowed_scope_states")]
     pub allowed_scope_states: Vec<i32>,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_false")]
     pub block_equal_fallback: bool,
-    #[serde(default = "default_true")]
+    #[serde(default = "default_false")]
     pub block_provider_volume_fallback: bool,
     #[serde(default = "default_true")]
     pub require_lcia_for_impact_submit: bool,
@@ -69,8 +69,8 @@ impl Default for ReviewSubmitGatePolicy {
             policy_profile: default_policy_profile(),
             require_revision_checksum_match: true,
             allowed_scope_states: default_allowed_scope_states(),
-            block_equal_fallback: true,
-            block_provider_volume_fallback: true,
+            block_equal_fallback: false,
+            block_provider_volume_fallback: false,
             require_lcia_for_impact_submit: true,
             require_target_process_probe: true,
             run_factorization_probe: true,
@@ -213,7 +213,7 @@ pub fn verify_review_submit_gate(input: &ReviewSubmitGateInput) -> ReviewSubmitG
 
     check_revision_freshness(input, &mut metrics, &mut blockers);
     check_process_records(input, &mut metrics, &mut blockers);
-    check_provider_closure(input, &mut metrics, &mut blockers);
+    check_provider_closure(input, &mut metrics);
     check_flow_semantics(input, &mut metrics, &mut blockers);
     check_sparse_structure(input, &mut metrics, &mut blockers);
     check_lcia_requirement(input, &mut blockers);
@@ -534,11 +534,7 @@ fn check_service_loops(
     }
 }
 
-fn check_provider_closure(
-    input: &ReviewSubmitGateInput,
-    metrics: &mut ReviewSubmitGateMetrics,
-    blockers: &mut Vec<ReadinessFinding>,
-) {
+fn check_provider_closure(input: &ReviewSubmitGateInput, metrics: &mut ReviewSubmitGateMetrics) {
     let matching = &input.coverage.matching;
     metrics.provider_scan.provider_missing_count = matching.unmatched_no_provider;
     metrics.provider_scan.provider_unresolved_count = matching.matched_multi_unresolved;
@@ -550,81 +546,13 @@ fn check_provider_closure(
                 .decisions_partial_missing_count
             + matching.volume_weight_summary.decisions_all_missing_count;
 
-    let mut unresolved_examples = Vec::new();
-    let mut fallback_examples = Vec::new();
-    let mut unconserved_examples = Vec::new();
-    let mut volume_examples = Vec::new();
-
     if let Some(graph) = &input.compiled_graph {
         metrics.provider_scan.provider_decisions_total = graph.provider_decisions.len();
         for decision in &graph.provider_decisions {
-            if matches!(
-                decision.decision_kind,
-                Some(CompiledProviderDecisionKind::MultiUnresolved)
-            ) {
-                unresolved_examples.push(provider_decision_detail(decision));
-            }
-            if decision.used_equal_fallback {
-                fallback_examples.push(provider_decision_detail(decision));
-            }
-            if decision.volume_fallback_to_one_count > 0 {
-                volume_examples.push(provider_decision_detail(decision));
-            }
             if !provider_allocation_is_conserved(decision, input.policy.allocation_sum_epsilon) {
-                unconserved_examples.push(provider_decision_detail(decision));
+                metrics.provider_scan.allocation_not_conserved_count += 1;
             }
         }
-    }
-
-    metrics.provider_scan.allocation_not_conserved_count = unconserved_examples.len();
-
-    if metrics.provider_scan.provider_unresolved_count > 0 || !unresolved_examples.is_empty() {
-        push_blocker(
-            blockers,
-            "provider_unresolved",
-            "multi-provider product input edges are unresolved",
-            json!({
-                "coverage_matched_multi_unresolved": matching.matched_multi_unresolved,
-                "examples": unresolved_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
-            }),
-        );
-    }
-    if input.policy.block_equal_fallback
-        && (metrics.provider_scan.equal_fallback_count > 0 || !fallback_examples.is_empty())
-    {
-        push_blocker(
-            blockers,
-            "provider_equal_fallback",
-            "provider resolution used equal fallback in a review-submit gate",
-            json!({
-                "coverage_matched_multi_fallback_equal": matching.matched_multi_fallback_equal,
-                "examples": fallback_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
-            }),
-        );
-    }
-    if !unconserved_examples.is_empty() {
-        push_blocker(
-            blockers,
-            "provider_allocation_not_conserved",
-            "provider allocation weights are invalid or do not sum to 1",
-            json!({
-                "allocation_not_conserved_count": metrics.provider_scan.allocation_not_conserved_count,
-                "examples": unconserved_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
-            }),
-        );
-    }
-    if input.policy.block_provider_volume_fallback
-        && (metrics.provider_scan.volume_evidence_invalid_count > 0 || !volume_examples.is_empty())
-    {
-        push_blocker(
-            blockers,
-            "provider_volume_evidence_invalid",
-            "provider volume evidence fell back to default weights in a review-submit gate",
-            json!({
-                "volume_evidence_invalid_count": metrics.provider_scan.volume_evidence_invalid_count,
-                "examples": volume_examples.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
-            }),
-        );
     }
 }
 
@@ -730,39 +658,16 @@ fn check_sparse_structure(
         .collect::<Vec<_>>();
 
     metrics.sparse_scan.zero_or_near_zero_diagonal_count = near_zero_diagonal.len();
-    if !near_zero_diagonal.is_empty()
-        || matches!(
-            input.coverage.singular_risk.risk_level.as_str(),
-            "medium" | "high"
-        )
-    {
+    if !near_zero_diagonal.is_empty() {
         push_blocker(
             blockers,
             "sparse_matrix_zero_or_near_zero_diagonal",
-            "M = I - A has zero/near-zero diagonal or elevated singular risk",
+            "M = I - A has a zero or near-zero diagonal",
             json!({
                 "zero_or_near_zero_diagonal_count": near_zero_diagonal.len(),
-                "singular_risk_level": input.coverage.singular_risk.risk_level,
-                "m_zero_diagonal_count": input.coverage.singular_risk.m_zero_diagonal_count,
-                "m_min_abs_diagonal": input.coverage.singular_risk.m_min_abs_diagonal,
                 "examples": near_zero_diagonal.into_iter().take(DETAIL_LIMIT).collect::<Vec<_>>()
             }),
         );
-        if matches!(
-            input.coverage.singular_risk.risk_level.as_str(),
-            "medium" | "high"
-        ) {
-            push_blocker(
-                blockers,
-                "singular_risk_medium_or_high",
-                "review-submit gate blocks medium or high singular risk",
-                json!({
-                    "singular_risk_level": input.coverage.singular_risk.risk_level,
-                    "m_zero_diagonal_count": input.coverage.singular_risk.m_zero_diagonal_count,
-                    "m_min_abs_diagonal": input.coverage.singular_risk.m_min_abs_diagonal
-                }),
-            );
-        }
     }
 
     let duplicate_columns =
@@ -1101,21 +1006,6 @@ fn exchange_detail(process: &ReviewProcessRecord, exchange: &ReviewExchangeRecor
     })
 }
 
-fn provider_decision_detail(decision: &crate::compiled_graph::CompiledProviderDecision) -> Value {
-    json!({
-        "consumer_idx": decision.consumer_idx,
-        "flow_id": decision.flow_id,
-        "candidate_provider_count": decision.candidate_provider_count,
-        "matched_provider_count": decision.matched_provider_count,
-        "decision_kind": decision.decision_kind,
-        "resolution_strategy": decision.resolution_strategy,
-        "failure_reason": decision.failure_reason,
-        "used_equal_fallback": decision.used_equal_fallback,
-        "volume_fallback_to_one_count": decision.volume_fallback_to_one_count,
-        "allocation_weight_sum": decision.allocations.iter().map(|allocation| allocation.weight).sum::<f64>()
-    })
-}
-
 fn format_numeric(value: f64) -> String {
     if value == 0.0 {
         "0.000000000000e0".to_owned()
@@ -1154,6 +1044,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_false() -> bool {
+    false
+}
+
 fn default_target_probe_limit() -> usize {
     32
 }
@@ -1181,8 +1075,8 @@ mod tests {
     use super::*;
     use crate::compiled_graph::{
         CompiledAllocationStats, CompiledFlow, CompiledMatchingStats, CompiledProcess,
-        CompiledProviderAllocation, CompiledProviderDecision, CompiledProviderResolutionStrategy,
-        CompiledReferenceStats,
+        CompiledProviderAllocation, CompiledProviderDecision, CompiledProviderDecisionKind,
+        CompiledProviderResolutionStrategy, CompiledReferenceStats,
     };
     use crate::graph_types::ScopeProcessPartition;
     use crate::snapshot_artifacts::{
@@ -1314,7 +1208,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_provider_and_semantic_failures() {
+    fn records_provider_diagnostics_without_blocking() {
         let mut input = clean_input();
         let flow_id = input.compiled_graph.as_ref().unwrap().flows[0].flow_id;
         let graph = input.compiled_graph.as_mut().unwrap();
@@ -1336,14 +1230,24 @@ mod tests {
         let report = verify_review_submit_gate(&input);
 
         assert_eq!(report.metrics.provider_scan.provider_missing_count, 1);
+        assert_eq!(report.metrics.provider_scan.equal_fallback_count, 1);
+        assert_eq!(
+            report.metrics.provider_scan.volume_evidence_invalid_count,
+            1
+        );
+        assert_eq!(
+            report.metrics.provider_scan.allocation_not_conserved_count,
+            0
+        );
         assert!(!has_blocker(&report, "provider_missing"));
-        assert!(has_blocker(&report, "provider_equal_fallback"));
-        assert!(has_blocker(&report, "provider_volume_evidence_invalid"));
+        assert!(!has_blocker(&report, "provider_equal_fallback"));
+        assert!(!has_blocker(&report, "provider_allocation_not_conserved"));
+        assert!(!has_blocker(&report, "provider_volume_evidence_invalid"));
         assert!(has_blocker(&report, "flow_lcia_semantic_mismatch"));
     }
 
     #[test]
-    fn blocks_unresolved_multi_provider_decisions() {
+    fn records_unresolved_multi_provider_without_blocking() {
         let mut input = clean_input();
         let graph = input.compiled_graph.as_mut().unwrap();
         graph.provider_decisions[0].decision_kind =
@@ -1354,7 +1258,14 @@ mod tests {
 
         let report = verify_review_submit_gate(&input);
 
-        assert!(has_blocker(&report, "provider_unresolved"));
+        assert_eq!(report.status, ReviewSubmitGateStatus::Passed);
+        assert_eq!(report.metrics.provider_scan.provider_unresolved_count, 1);
+        assert_eq!(
+            report.metrics.provider_scan.allocation_not_conserved_count,
+            1
+        );
+        assert!(!has_blocker(&report, "provider_unresolved"));
+        assert!(!has_blocker(&report, "provider_allocation_not_conserved"));
     }
 
     #[test]
@@ -1374,9 +1285,24 @@ mod tests {
             &report,
             "sparse_matrix_zero_or_near_zero_diagonal"
         ));
-        assert!(has_blocker(&report, "singular_risk_medium_or_high"));
+        assert!(!has_blocker(&report, "singular_risk_medium_or_high"));
         assert!(has_blocker(&report, "target_process_not_covered_by_probe"));
         assert!(!report.metrics.probe.factorization_checked);
+    }
+
+    #[test]
+    fn does_not_block_medium_singular_risk_without_structural_symptom() {
+        let mut input = clean_input();
+        input.coverage.singular_risk.risk_level = "medium".to_owned();
+
+        let report = verify_review_submit_gate(&input);
+
+        assert_eq!(report.status, ReviewSubmitGateStatus::Passed);
+        assert!(!has_blocker(
+            &report,
+            "sparse_matrix_zero_or_near_zero_diagonal"
+        ));
+        assert!(!has_blocker(&report, "singular_risk_medium_or_high"));
     }
 
     #[test]

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
+lastReviewedCommit: b6137656059cb16531e2d97e2bbdbacbfdf0fff6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
+lastReviewedCommit: b6137656059cb16531e2d97e2bbdbacbfdf0fff6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,7 +22,7 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 877f8318a1716786beb32bc86ac208c57a9168d9
+lastReviewedCommit: b6137656059cb16531e2d97e2bbdbacbfdf0fff6
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -121,9 +121,8 @@ DB runner 写回数据库时：
 
 - 要求 `expected_revision_checksum == actual_revision_checksum`。
 - `allowed_scope_states = [0] + 100..=199`；`0` 表示提交审核前 draft root，`100..=199` 用于已审核 / 可用依赖数据兼容；`20` 等审核中状态不允许，仍会触发 `invalid_scope_state`。
-- 阻断 provider equal fallback。
-- 阻断 provider volume fallback evidence。
-- provider missing 只记录在 `metrics.provider_scan.provider_missing_count`，不作为提交审核 blocker。
+- provider missing、unresolved、equal fallback、allocation conservation 和 volume evidence 只记录在 `metrics.provider_scan`，不作为提交审核 blocker。
+- legacy provider policy 字段 `block_equal_fallback` / `block_provider_volume_fallback` 默认为 `false`；即使旧请求传入 `true`，review-submit gate 也不再据此产生 provider blocker。
 - impact-ready 提交要求 LCIA factors。
 - 要求 target process probe。
 - target probe 默认最多覆盖 `32` 个 process。
@@ -144,18 +143,17 @@ DB runner 写回数据库时：
 | `invalid_allocation_fraction` | allocation fraction 不可解析、带 `%` 或超出允许数值范围 | 统一 allocation fraction 表达 |
 | `duplicate_exchange_fingerprint` | 不同 process 的 flow/direction/amount fingerprint 完全一致 | 合并重复 process 或补充可区分 exchange |
 | `service_loop_detected` | 同一 process 中同一 flow 的 input/output amount 相同或近似相同 | 修正自供给、循环或拆分 process |
-| `provider_unresolved` | multi-provider input edge 未解析 | 补 provider evidence 或缩小候选集 |
-| `provider_equal_fallback` | provider resolution 使用 equal fallback 且 policy 阻断 | 补 annual volume / evidence，避免等权兜底 |
-| `provider_allocation_not_conserved` | provider allocation weight 非有限、负数、为空或 sum 不为 1 | 修复 provider allocation |
-| `provider_volume_evidence_invalid` | provider volume evidence fallback-to-one 或缺失超过 policy 容忍 | 补充可比较 annual volume evidence |
 | `flow_lcia_semantic_mismatch` | product/elementary flow 或 LCIA factor 语义错配 | 修复 flow kind、biosphere edge 或 LCIA factor mapping |
 | `lcia_factor_missing_for_impact_submit` | impact-ready 提交要求 LCIA factors，但 `c_nnz = 0` | 补齐 LCIA factors 或改用非 impact 提交策略 |
 | `sparse_matrix_zero_or_near_zero_diagonal` | `M = I - A` 对角线为 0 / near-zero，或 payload process count 无效 | 修复自环、reference 或 matrix structure |
 | `duplicate_sparse_columns` | `M = I - A` 存在重复 sparse column signature | 排查重复结构和线性相关 process |
-| `singular_risk_medium_or_high` | coverage singular risk 为 `medium` 或 `high` | 修复 matrix structure 后重跑 |
 | `target_process_not_covered_by_probe` | target process list 缺失、越界或超过 probe limit | 明确 submitted / changed process list，或拆分 gate |
 | `factorization_probe_failed` | sparse factorization readiness probe 失败 | 修复 matrix structure 后重跑 |
 | `target_probe_non_finite_result` | targeted RHS solve 失败或产生 NaN / Infinity | 修复 compute stability / flow / LCIA 数据 |
+
+Provider 相关信号仍会保留在 `metrics.provider_scan` 中，供 UI 展示和后续数据治理使用，但不进入 `blockers`。当前提交审核 gate 的 provider 语义不是“全库 provider 证据完整性验收”，而是避免把历史依赖或库级 provider 质量问题转嫁为当前数据集提交阻断。
+
+数值不稳定的快速结构表象优先由 `service_loop_detected` 表达：同一 process 中相同 flow 同量同时出现在 input 和 output。`singular_risk = medium/high` 是 coverage diagnostic，不单独产生 blocker；只有真实 zero / near-zero diagonal、重复 sparse column、factorization/probe 失败或 non-finite 结果才会阻断。
 
 ## 快速验证顺序
 
@@ -163,9 +161,9 @@ Gate 按便宜到昂贵的顺序执行：
 
 1. revision freshness。
 2. process record scan：scope state、reference、exchange amount、allocation、duplicate fingerprint、service-loop。
-3. provider scan：missing metric、unresolved、equal fallback、allocation conservation、volume evidence。
+3. provider scan：missing metric、unresolved、equal fallback、allocation conservation、volume evidence，仅记录 metrics。
 4. flow / LCIA semantic scan。
-5. sparse structure scan：diagonal、duplicate sparse column、singular risk。
+5. sparse structure scan：diagonal、duplicate sparse column。
 6. target process coverage check。
 7. 仅当以上没有 blocker 时，执行 sparse factorization readiness 与 targeted RHS solve。
 


### PR DESCRIPTION
Closes #59

## Summary
- Keep provider closure signals in provider_scan metrics without emitting provider-related blocker findings.
- Restrict sparse diagonal blocking to actual zero or near-zero diagonal structure instead of medium/high singular-risk diagnostics.
- Document service_loop_detected as the prominent equal input/output same-flow instability symptom for review submit.

## Key Decisions
- Do not change cmd_dataset_save_draft timestamp or checksum behavior in this PR.
- Legacy provider policy fields remain accepted for compatibility but default to false and no longer drive blockers.

## Validation
- cargo test -p solver-worker review_submit_gate
- cargo check -p solver-worker --bin review_submit_gate
- cargo check -p solver-worker --bin review_submit_gate_runner
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- scripts/docpact lint --root . --worktree
- make check

## Risks / Rollback
- This relaxes review-submit blocking for provider diagnostics; metrics remain available for UI/data-quality follow-up.

## Workspace Integration
- Workspace submodule pointer must be bumped after merge before delivery is complete.