### PR TITLE
Move ai-doc-lint to the local gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "4825474f906832a8ab9b2e93ce13b64fa42ef8f0"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "f7d0299e21709182ee0f51016c5c3c8808ebd7d8"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   ai-doc-lint:
@@ -12,19 +12,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint
-          --root .
-          --base "${{ github.event.pull_request.base.sha }}"
-          --head "${{ github.event.pull_request.head.sha }}"
-          --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Do not start from the root workspace or the edge repo if the change is really ab
 - minimum proof and manual helper expectations live in `docs/agents/repo-validation.md`
 - stable path groups and hotspot families live in `docs/agents/repo-architecture.md`
 - runtime-facing consumer contracts and report artifact contracts live in the narrow docs under `docs/*.md`
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - the main routing intents are `solver-runtime`, `matrix-readiness`, `snapshot-and-provider`, `review-submit-gate`, `package-worker`, `runtime-sql-boundary`, `debug-and-parity`, `edge-api-boundary`, `frontend-integration`, `proof`, `repo-docs`, and `root-integration`
 
 ## Minimal Execution Facts

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: ab530bbb10c283bd1379d674c24554173610d654
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: f7d0299e21709182ee0f51016c5c3c8808ebd7d8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -90,7 +90,7 @@ The repo's machine-readable governance source is `.docpact/config.yaml`.
 That means:
 
 - governed-doc rules, routing intents, ownership boundaries, and freshness live in `.docpact/config.yaml`
-- `.github/workflows/ai-doc-lint.yml` should validate config and run `docpact lint`
+- `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback and should delegate to the same local docpact gate
 - retained explanatory docs stay in `AGENTS.md`, this file, `repo-architecture.md`, `README.md`, and the narrow runtime-facing contract docs under `docs/*.md`
 
 Do not recreate deleted `ai/*` files under a new name. Keep deterministic facts in config and explanatory material in retained source docs.


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate


## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #66
