### PR TITLE
Add package artifact retention GC

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "3c3dada13232c44bbad850fb8548cd33cb1c9d73"
+lastReviewedAt: "2026-05-29"
+lastReviewedCommit: "76345d6bb9a17691dd661cfccf5017057c52047e"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 3c3dada13232c44bbad850fb8548cd33cb1c9d73
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/package_gc.rs
+++ b/crates/solver-worker/src/bin/package_gc.rs
@@ -1,0 +1,329 @@
+use clap::Parser;
+use solver_worker::{
+    package_retention::{
+        PackageArtifactGcCandidate, delete_package_jobs_after_object_gc,
+        delete_stale_package_request_cache_rows, fetch_package_artifact_gc_candidates,
+        fetch_package_retention_summary, mark_package_artifact_deleted,
+        record_package_artifact_gc_error, validate_retention_days,
+    },
+    pgbouncer_sqlx::{self as sqlx, postgres::PgPoolOptions},
+    storage::ObjectStoreClient,
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "package-gc")]
+struct Cli {
+    /// `PostgreSQL` URL (preferred env: `DATABASE_URL`, fallback: `CONN`).
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: Option<String>,
+    /// `PostgreSQL` URL fallback used by this project in local `.env`.
+    #[arg(long, env = "CONN")]
+    conn: Option<String>,
+    /// S3-compatible endpoint for package artifacts.
+    #[arg(long, env = "S3_ENDPOINT")]
+    s3_endpoint: Option<String>,
+    /// S3 region.
+    #[arg(long, env = "S3_REGION")]
+    s3_region: Option<String>,
+    /// S3 bucket.
+    #[arg(long, env = "S3_BUCKET")]
+    s3_bucket: Option<String>,
+    /// S3 access key id.
+    #[arg(long, env = "S3_ACCESS_KEY_ID")]
+    s3_access_key_id: Option<String>,
+    /// S3 secret access key.
+    #[arg(long, env = "S3_SECRET_ACCESS_KEY")]
+    s3_secret_access_key: Option<String>,
+    /// Optional S3 session token.
+    #[arg(long, env = "S3_SESSION_TOKEN")]
+    s3_session_token: Option<String>,
+    /// Object key prefix.
+    #[arg(long, env = "S3_PREFIX", default_value = "lca-results")]
+    s3_prefix: String,
+    /// Max rows per GC batch.
+    #[arg(long, env = "PACKAGE_GC_BATCH_SIZE", default_value_t = 100_i64)]
+    batch_size: i64,
+    /// Optional hard cap on total processed batches.
+    #[arg(long, env = "PACKAGE_GC_MAX_BATCHES")]
+    max_batches: Option<i64>,
+    /// Terminal package job metadata retention window.
+    #[arg(long, env = "PACKAGE_GC_JOB_RETENTION_DAYS", default_value_t = 30_i32)]
+    job_retention_days: i32,
+    /// Request-cache recent-access protection window.
+    #[arg(
+        long,
+        env = "PACKAGE_GC_REQUEST_CACHE_RETENTION_DAYS",
+        default_value_t = 30_i32
+    )]
+    request_cache_retention_days: i32,
+    /// Execute destructive object/metadata cleanup. Omit for dry-run only.
+    #[arg(long)]
+    execute: bool,
+}
+
+#[derive(Debug, Default)]
+struct PackageGcTotals {
+    batches: i64,
+    artifact_candidates: u64,
+    object_deleted: u64,
+    object_delete_failed: u64,
+    artifacts_marked_deleted: u64,
+    request_cache_deleted: u64,
+    jobs_deleted: u64,
+}
+
+fn required<'a>(value: Option<&'a str>, name: &str) -> anyhow::Result<&'a str> {
+    value.ok_or_else(|| anyhow::anyhow!("missing {name}"))
+}
+
+fn resolve_db_url(cli: &Cli) -> anyhow::Result<&str> {
+    cli.database_url
+        .as_deref()
+        .or(cli.conn.as_deref())
+        .ok_or_else(|| anyhow::anyhow!("missing DB connection: set DATABASE_URL or CONN"))
+}
+
+fn build_object_store(cli: &Cli) -> anyhow::Result<ObjectStoreClient> {
+    let endpoint = required(cli.s3_endpoint.as_deref(), "S3_ENDPOINT")?;
+    let region = required(cli.s3_region.as_deref(), "S3_REGION")?;
+    let bucket = required(cli.s3_bucket.as_deref(), "S3_BUCKET")?;
+    let access_key = required(cli.s3_access_key_id.as_deref(), "S3_ACCESS_KEY_ID")?;
+    let secret = required(cli.s3_secret_access_key.as_deref(), "S3_SECRET_ACCESS_KEY")?;
+
+    ObjectStoreClient::new(
+        endpoint,
+        region,
+        bucket,
+        &cli.s3_prefix,
+        access_key,
+        secret,
+        cli.s3_session_token.clone(),
+    )
+}
+
+async fn acquire_package_gc_lock(
+    pool: &sqlx::PgPool,
+) -> anyhow::Result<sqlx::pool::PoolConnection<sqlx::Postgres>> {
+    let mut conn = pool.acquire().await?;
+    let acquired = sqlx::query_scalar::<bool>(
+        "SELECT pg_try_advisory_lock(hashtext('solver_worker_package_gc'))",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+
+    if !acquired {
+        return Err(anyhow::anyhow!(
+            "another package-gc run holds the advisory lock"
+        ));
+    }
+
+    Ok(conn)
+}
+
+async fn release_package_gc_lock(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+) -> anyhow::Result<()> {
+    let _ = sqlx::query_scalar::<bool>(
+        "SELECT pg_advisory_unlock(hashtext('solver_worker_package_gc'))",
+    )
+    .fetch_one(&mut **conn)
+    .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    if cli.batch_size <= 0 {
+        return Err(anyhow::anyhow!("PACKAGE_GC_BATCH_SIZE must be > 0"));
+    }
+    if let Some(max_batches) = cli.max_batches
+        && max_batches <= 0
+    {
+        return Err(anyhow::anyhow!("PACKAGE_GC_MAX_BATCHES must be > 0"));
+    }
+    let job_retention_days =
+        validate_retention_days(cli.job_retention_days, "PACKAGE_GC_JOB_RETENTION_DAYS")?;
+    let request_cache_retention_days = validate_retention_days(
+        cli.request_cache_retention_days,
+        "PACKAGE_GC_REQUEST_CACHE_RETENTION_DAYS",
+    )?;
+
+    let db_url = resolve_db_url(&cli)?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(db_url)
+        .await?;
+    let store = if cli.execute {
+        Some(build_object_store(&cli)?)
+    } else {
+        None
+    };
+
+    let mut lock_conn = if cli.execute {
+        Some(acquire_package_gc_lock(&pool).await?)
+    } else {
+        None
+    };
+
+    let result = run_package_gc(
+        &pool,
+        store.as_ref(),
+        &cli,
+        job_retention_days,
+        request_cache_retention_days,
+    )
+    .await;
+
+    let unlock_result = if let Some(conn) = lock_conn.as_mut() {
+        release_package_gc_lock(conn).await
+    } else {
+        Ok(())
+    };
+
+    let totals = result?;
+    unlock_result?;
+
+    println!(
+        "[summary] dry_run={} batches={} artifact_candidates={} object_deleted={} object_delete_failed={} artifacts_marked_deleted={} request_cache_deleted={} jobs_deleted={}",
+        !cli.execute,
+        totals.batches,
+        totals.artifact_candidates,
+        totals.object_deleted,
+        totals.object_delete_failed,
+        totals.artifacts_marked_deleted,
+        totals.request_cache_deleted,
+        totals.jobs_deleted
+    );
+
+    Ok(())
+}
+
+async fn run_package_gc(
+    pool: &sqlx::PgPool,
+    store: Option<&ObjectStoreClient>,
+    cli: &Cli,
+    job_retention_days: i32,
+    request_cache_retention_days: i32,
+) -> anyhow::Result<PackageGcTotals> {
+    let summary =
+        fetch_package_retention_summary(pool, job_retention_days, request_cache_retention_days)
+            .await?;
+    for row in summary {
+        println!(
+            "[retention] area={} action={} eligible={} reason={} rows={} artifact_bytes={} hits={}",
+            row.retention_area,
+            row.retention_action,
+            row.is_eligible,
+            row.reason,
+            row.row_count,
+            row.total_artifact_bytes,
+            row.total_hit_count
+        );
+    }
+
+    if !cli.execute {
+        let candidates = fetch_package_artifact_gc_candidates(
+            pool,
+            cli.batch_size,
+            request_cache_retention_days,
+        )
+        .await?;
+        print_dry_run_candidates(candidates.as_slice());
+        return Ok(PackageGcTotals {
+            artifact_candidates: u64::try_from(candidates.len())
+                .map_err(|_| anyhow::anyhow!("candidate count overflow"))?,
+            ..PackageGcTotals::default()
+        });
+    }
+
+    let store = store.ok_or_else(|| anyhow::anyhow!("object store is required for --execute"))?;
+    let mut totals = PackageGcTotals::default();
+    loop {
+        if let Some(max_batches) = cli.max_batches
+            && totals.batches >= max_batches
+        {
+            break;
+        }
+
+        let candidates = fetch_package_artifact_gc_candidates(
+            pool,
+            cli.batch_size,
+            request_cache_retention_days,
+        )
+        .await?;
+        let candidate_count = u64::try_from(candidates.len())
+            .map_err(|_| anyhow::anyhow!("candidate count overflow"))?;
+
+        for candidate in candidates {
+            process_artifact_candidate(pool, store, &candidate, &mut totals).await?;
+        }
+
+        let request_cache_deleted = delete_stale_package_request_cache_rows(
+            pool,
+            cli.batch_size,
+            request_cache_retention_days,
+        )
+        .await?;
+        let jobs_deleted = delete_package_jobs_after_object_gc(
+            pool,
+            cli.batch_size,
+            job_retention_days,
+            request_cache_retention_days,
+        )
+        .await?;
+
+        totals.request_cache_deleted += request_cache_deleted;
+        totals.jobs_deleted += jobs_deleted;
+
+        if candidate_count == 0 && request_cache_deleted == 0 && jobs_deleted == 0 {
+            break;
+        }
+        totals.batches += 1;
+    }
+
+    Ok(totals)
+}
+
+fn print_dry_run_candidates(candidates: &[PackageArtifactGcCandidate]) {
+    for candidate in candidates {
+        println!(
+            "[dry-run] artifact_id={} job_id={} kind={} url={}",
+            candidate.artifact_id,
+            candidate.job_id,
+            candidate.artifact_kind,
+            candidate.artifact_url
+        );
+    }
+}
+
+async fn process_artifact_candidate(
+    pool: &sqlx::PgPool,
+    store: &ObjectStoreClient,
+    candidate: &PackageArtifactGcCandidate,
+    totals: &mut PackageGcTotals,
+) -> anyhow::Result<()> {
+    totals.artifact_candidates += 1;
+    match store.delete_object_url(&candidate.artifact_url).await {
+        Ok(()) => {
+            totals.object_deleted += 1;
+            totals.artifacts_marked_deleted +=
+                mark_package_artifact_deleted(pool, candidate.artifact_id).await?;
+            println!(
+                "[info] deleted package artifact object artifact_id={} job_id={} kind={}",
+                candidate.artifact_id, candidate.job_id, candidate.artifact_kind
+            );
+        }
+        Err(err) => {
+            totals.object_delete_failed += 1;
+            let message = err.to_string();
+            let _ = record_package_artifact_gc_error(pool, candidate.artifact_id, &message).await?;
+            eprintln!(
+                "[warn] package artifact object delete failed artifact_id={} job_id={} kind={} error={message}",
+                candidate.artifact_id, candidate.job_id, candidate.artifact_kind
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/solver-worker/src/bin/package_worker.rs
+++ b/crates/solver-worker/src/bin/package_worker.rs
@@ -12,6 +12,7 @@ use solver_worker::{
         update_package_job_status,
     },
     package_execution::clear_runtime_export_traversal_cache,
+    package_retention::refresh_import_source_retention,
     package_types::{PACKAGE_QUEUE_NAME, PackageJobPayload},
     storage::ObjectStoreUploadError,
 };
@@ -121,6 +122,22 @@ async fn run_package_worker_loop(
                                     cache_error_message.as_str(),
                                 )
                                 .await;
+                                if let PackageJobPayload::ImportPackage {
+                                    source_artifact_id, ..
+                                } = payload
+                                    && let Err(err) = refresh_import_source_retention(
+                                        &state.pool,
+                                        source_artifact_id,
+                                    )
+                                    .await
+                                {
+                                    warn!(
+                                        job_id = %job_id,
+                                        source_artifact_id = %source_artifact_id,
+                                        error = %err,
+                                        "failed to refresh import source retention after failed import job"
+                                    );
+                                }
                             }
                         } else {
                             info!("package job completed");

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -21,6 +21,7 @@ pub mod http;
 pub mod package_artifacts;
 pub mod package_db;
 pub mod package_execution;
+pub mod package_retention;
 pub mod package_types;
 pub mod pgbouncer_sqlx;
 pub mod queue;

--- a/crates/solver-worker/src/package_db.rs
+++ b/crates/solver-worker/src/package_db.rs
@@ -12,6 +12,7 @@ use crate::{
     package_execution::{
         clear_runtime_export_traversal_cache, execute_export_package, execute_import_package,
     },
+    package_retention::{default_package_artifact_retention_days, refresh_import_source_retention},
     package_types::{PACKAGE_QUEUE_NAME, PackageArtifactKind, PackageJobPayload},
 };
 
@@ -36,6 +37,8 @@ pub struct PackageArtifactInsert {
     pub metadata: Value,
     /// Row status.
     pub status: &'static str,
+    /// Retention window in days; `None` leaves `expires_at` unset.
+    pub retention_days: Option<i32>,
 }
 
 impl PackageArtifactInsert {
@@ -58,6 +61,7 @@ impl PackageArtifactInsert {
             content_type: meta.content_type,
             metadata,
             status: "ready",
+            retention_days: Some(default_package_artifact_retention_days(artifact_kind)),
         }
     }
 
@@ -141,10 +145,27 @@ pub async fn insert_package_artifact(
             artifact_format,
             content_type,
             metadata,
+            expires_at,
             created_at,
             updated_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, NOW(), NOW())
+        VALUES (
+            $1,
+            $2,
+            $3,
+            $4,
+            $5,
+            $6,
+            $7,
+            $8,
+            $9::jsonb,
+            CASE
+              WHEN $10::integer IS NULL THEN NULL
+              ELSE NOW() + make_interval(days => $10::integer)
+            END,
+            NOW(),
+            NOW()
+        )
         ON CONFLICT (job_id, artifact_kind) DO UPDATE
         SET status = EXCLUDED.status,
             artifact_url = EXCLUDED.artifact_url,
@@ -153,6 +174,7 @@ pub async fn insert_package_artifact(
             artifact_format = EXCLUDED.artifact_format,
             content_type = EXCLUDED.content_type,
             metadata = EXCLUDED.metadata,
+            expires_at = EXCLUDED.expires_at,
             updated_at = NOW()
         RETURNING id
         ",
@@ -166,6 +188,7 @@ pub async fn insert_package_artifact(
     .bind(insert.artifact_format)
     .bind(insert.content_type)
     .bind(insert.metadata)
+    .bind(insert.retention_days)
     .fetch_one(pool)
     .await?;
 
@@ -475,6 +498,15 @@ pub async fn handle_package_job_payload(
                 outcome.diagnostics,
             )
             .await?;
+            if let Err(err) = refresh_import_source_retention(&state.pool, source_artifact_id).await
+            {
+                warn!(
+                    error = %err,
+                    job_id = %job_id,
+                    source_artifact_id = %source_artifact_id,
+                    "failed to refresh import source artifact retention"
+                );
+            }
             if let Err(err) = mark_package_request_cache_ready(
                 &state.pool,
                 job_id,

--- a/crates/solver-worker/src/package_retention.rs
+++ b/crates/solver-worker/src/package_retention.rs
@@ -1,0 +1,471 @@
+use uuid::Uuid;
+
+use crate::{
+    package_types::PackageArtifactKind,
+    pgbouncer_sqlx::{self as sqlx, PgPool, Row},
+};
+
+pub const DEFAULT_EXPORT_PACKAGE_ARTIFACT_RETENTION_DAYS: i32 = 30;
+pub const DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS: i32 = 14;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageRetentionSummaryRow {
+    pub retention_area: String,
+    pub retention_action: String,
+    pub is_eligible: bool,
+    pub reason: String,
+    pub row_count: i64,
+    pub total_artifact_bytes: i64,
+    pub total_hit_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageArtifactGcCandidate {
+    pub artifact_id: Uuid,
+    pub job_id: Uuid,
+    pub artifact_kind: String,
+    pub artifact_url: String,
+}
+
+#[must_use]
+pub const fn default_package_artifact_retention_days(kind: PackageArtifactKind) -> i32 {
+    match kind {
+        PackageArtifactKind::ExportZip | PackageArtifactKind::ExportReport => {
+            DEFAULT_EXPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        }
+        PackageArtifactKind::ImportSource | PackageArtifactKind::ImportReport => {
+            DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        }
+    }
+}
+
+pub fn validate_retention_days(value: i32, name: &str) -> anyhow::Result<i32> {
+    if !(1..=3650).contains(&value) {
+        return Err(anyhow::anyhow!("{name} must be between 1 and 3650 days"));
+    }
+    Ok(value)
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn fetch_package_retention_summary(
+    pool: &PgPool,
+    job_retention_days: i32,
+    request_cache_retention_days: i32,
+) -> anyhow::Result<Vec<PackageRetentionSummaryRow>> {
+    let rows = sqlx::query(
+        r"
+        WITH job_rollup AS (
+          SELECT
+            jobs.id,
+            jobs.status,
+            COALESCE(jobs.finished_at, jobs.updated_at, jobs.created_at) AS lifecycle_at,
+            COALESCE(BOOL_OR(artifacts.is_pinned) FILTER (WHERE artifacts.id IS NOT NULL), FALSE) AS has_pinned_artifact,
+            COALESCE(BOOL_OR(artifacts.status <> 'deleted') FILTER (WHERE artifacts.id IS NOT NULL), FALSE) AS has_live_artifact,
+            COALESCE(SUM(COALESCE(artifacts.artifact_byte_size, 0)), 0)::bigint AS artifact_bytes,
+            EXISTS (
+              SELECT 1
+              FROM public.lca_package_request_cache AS recent_cache
+              WHERE recent_cache.job_id = jobs.id
+                AND (
+                  recent_cache.status IN ('pending', 'running')
+                  OR recent_cache.last_accessed_at >= NOW() - make_interval(days => $2::integer)
+                )
+            ) AS has_protected_request_cache
+          FROM public.lca_package_jobs AS jobs
+          LEFT JOIN public.lca_package_artifacts AS artifacts
+            ON artifacts.job_id = jobs.id
+          GROUP BY jobs.id
+        ),
+        artifact_classified AS (
+          SELECT
+            'lca_package_artifacts'::text AS retention_area,
+            'delete_object_then_mark_deleted'::text AS retention_action,
+            (classified.reason = 'eligible_expired_unpinned_artifact') AS is_eligible,
+            classified.reason,
+            1::bigint AS row_count,
+            COALESCE(classified.artifact_byte_size, 0)::bigint AS total_artifact_bytes,
+            0::bigint AS total_hit_count
+          FROM (
+            SELECT
+              artifacts.*,
+              jobs.status AS parent_job_status,
+              CASE
+                WHEN jobs.id IS NULL THEN 'protected_missing_parent_job'
+                WHEN artifacts.is_pinned THEN 'protected_pinned_artifact'
+                WHEN artifacts.status = 'deleted' THEN 'protected_already_deleted'
+                WHEN artifacts.status <> 'ready' THEN 'protected_artifact_not_ready'
+                WHEN jobs.status IN ('queued', 'running') THEN 'protected_active_parent_job'
+                WHEN artifacts.expires_at IS NULL THEN 'protected_missing_expires_at'
+                WHEN artifacts.expires_at > NOW() THEN 'protected_expires_at_in_future'
+                WHEN EXISTS (
+                  SELECT 1
+                  FROM public.lca_package_request_cache AS recent_cache
+                  WHERE (
+                      recent_cache.export_artifact_id = artifacts.id
+                      OR recent_cache.report_artifact_id = artifacts.id
+                    )
+                    AND (
+                      recent_cache.status IN ('pending', 'running')
+                      OR recent_cache.last_accessed_at >= NOW() - make_interval(days => $2::integer)
+                    )
+                ) THEN 'protected_request_cache_reference'
+                ELSE 'eligible_expired_unpinned_artifact'
+              END AS reason
+            FROM public.lca_package_artifacts AS artifacts
+            LEFT JOIN public.lca_package_jobs AS jobs
+              ON jobs.id = artifacts.job_id
+          ) AS classified
+        ),
+        request_cache_classified AS (
+          SELECT
+            'lca_package_request_cache'::text AS retention_area,
+            'delete_stale_request_cache_row'::text AS retention_action,
+            (classified.reason = 'eligible_stale_request_cache') AS is_eligible,
+            classified.reason,
+            1::bigint AS row_count,
+            0::bigint AS total_artifact_bytes,
+            classified.hit_count::bigint AS total_hit_count
+          FROM (
+            SELECT
+              request_cache.*,
+              jobs.status AS parent_job_status,
+              CASE
+                WHEN request_cache.status IN ('pending', 'running') THEN 'protected_active_request_cache'
+                WHEN request_cache.last_accessed_at >= NOW() - make_interval(days => $2::integer) THEN 'protected_recent_request_cache_access'
+                WHEN jobs.status IN ('queued', 'running') THEN 'protected_active_parent_job'
+                ELSE 'eligible_stale_request_cache'
+              END AS reason
+            FROM public.lca_package_request_cache AS request_cache
+            LEFT JOIN public.lca_package_jobs AS jobs
+              ON jobs.id = request_cache.job_id
+          ) AS classified
+        ),
+        job_classified AS (
+          SELECT
+            'lca_package_jobs'::text AS retention_area,
+            'delete_job_metadata_after_object_gc'::text AS retention_action,
+            (classified.reason = 'eligible_terminal_job_after_object_gc') AS is_eligible,
+            classified.reason,
+            1::bigint AS row_count,
+            classified.artifact_bytes AS total_artifact_bytes,
+            0::bigint AS total_hit_count
+          FROM (
+            SELECT
+              job_rollup.*,
+              CASE
+                WHEN job_rollup.status IN ('queued', 'running') THEN 'protected_active_job'
+                WHEN job_rollup.status NOT IN ('ready', 'completed', 'failed', 'stale') THEN 'protected_unknown_job_status'
+                WHEN job_rollup.lifecycle_at >= NOW() - make_interval(days => $1::integer) THEN 'protected_inside_job_retention_window'
+                WHEN job_rollup.has_pinned_artifact THEN 'protected_pinned_artifact'
+                WHEN job_rollup.has_live_artifact THEN 'protected_object_not_deleted'
+                WHEN job_rollup.has_protected_request_cache THEN 'protected_request_cache_reference'
+                ELSE 'eligible_terminal_job_after_object_gc'
+              END AS reason
+            FROM job_rollup
+          ) AS classified
+        ),
+        classified AS (
+          SELECT * FROM artifact_classified
+          UNION ALL
+          SELECT * FROM request_cache_classified
+          UNION ALL
+          SELECT * FROM job_classified
+        )
+        SELECT
+          retention_area,
+          retention_action,
+          is_eligible,
+          reason,
+          SUM(row_count)::bigint AS row_count,
+          COALESCE(SUM(total_artifact_bytes), 0)::bigint AS total_artifact_bytes,
+          COALESCE(SUM(total_hit_count), 0)::bigint AS total_hit_count
+        FROM classified
+        GROUP BY retention_area, retention_action, is_eligible, reason
+        ORDER BY retention_area, is_eligible DESC, reason
+        ",
+    )
+    .bind(job_retention_days)
+    .bind(request_cache_retention_days)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(PackageRetentionSummaryRow {
+                retention_area: row.try_get("retention_area")?,
+                retention_action: row.try_get("retention_action")?,
+                is_eligible: row.try_get("is_eligible")?,
+                reason: row.try_get("reason")?,
+                row_count: row.try_get("row_count")?,
+                total_artifact_bytes: row.try_get("total_artifact_bytes")?,
+                total_hit_count: row.try_get("total_hit_count")?,
+            })
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()
+        .map_err(Into::into)
+}
+
+pub async fn fetch_package_artifact_gc_candidates(
+    pool: &PgPool,
+    batch_size: i64,
+    request_cache_retention_days: i32,
+) -> anyhow::Result<Vec<PackageArtifactGcCandidate>> {
+    let rows = sqlx::query(
+        r"
+        SELECT
+          artifacts.id AS artifact_id,
+          artifacts.job_id,
+          artifacts.artifact_kind,
+          artifacts.artifact_url
+        FROM public.lca_package_artifacts AS artifacts
+        JOIN public.lca_package_jobs AS jobs
+          ON jobs.id = artifacts.job_id
+        WHERE artifacts.status = 'ready'
+          AND artifacts.is_pinned = FALSE
+          AND artifacts.expires_at IS NOT NULL
+          AND artifacts.expires_at <= NOW()
+          AND jobs.status NOT IN ('queued', 'running')
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.lca_package_request_cache AS request_cache
+            WHERE (
+                request_cache.export_artifact_id = artifacts.id
+                OR request_cache.report_artifact_id = artifacts.id
+              )
+              AND (
+                request_cache.status IN ('pending', 'running')
+                OR request_cache.last_accessed_at >= NOW() - make_interval(days => $2::integer)
+              )
+          )
+        ORDER BY artifacts.expires_at ASC, artifacts.created_at ASC, artifacts.id ASC
+        LIMIT $1
+        ",
+    )
+    .bind(batch_size)
+    .bind(request_cache_retention_days)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(PackageArtifactGcCandidate {
+                artifact_id: row.try_get("artifact_id")?,
+                job_id: row.try_get("job_id")?,
+                artifact_kind: row.try_get("artifact_kind")?,
+                artifact_url: row.try_get("artifact_url")?,
+            })
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()
+        .map_err(Into::into)
+}
+
+pub async fn mark_package_artifact_deleted(
+    pool: &PgPool,
+    artifact_id: Uuid,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        UPDATE public.lca_package_artifacts
+        SET status = 'deleted',
+            metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+              'gc',
+              jsonb_build_object(
+                'status', 'object_deleted',
+                'deleted_at', NOW(),
+                'reason', 'eligible_expired_unpinned_artifact'
+              )
+            ),
+            updated_at = NOW()
+        WHERE id = $1
+          AND status <> 'deleted'
+        ",
+    )
+    .bind(artifact_id)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn record_package_artifact_gc_error(
+    pool: &PgPool,
+    artifact_id: Uuid,
+    error_message: &str,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        UPDATE public.lca_package_artifacts
+        SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+              'gc',
+              jsonb_build_object(
+                'status', 'object_delete_failed',
+                'last_error_at', NOW(),
+                'last_error', $2
+              )
+            ),
+            updated_at = NOW()
+        WHERE id = $1
+          AND status <> 'deleted'
+        ",
+    )
+    .bind(artifact_id)
+    .bind(error_message)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn delete_stale_package_request_cache_rows(
+    pool: &PgPool,
+    batch_size: i64,
+    request_cache_retention_days: i32,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        WITH candidates AS (
+          SELECT request_cache.id
+          FROM public.lca_package_request_cache AS request_cache
+          LEFT JOIN public.lca_package_jobs AS jobs
+            ON jobs.id = request_cache.job_id
+          WHERE request_cache.status NOT IN ('pending', 'running')
+            AND request_cache.last_accessed_at < NOW() - make_interval(days => $2::integer)
+            AND COALESCE(jobs.status NOT IN ('queued', 'running'), TRUE)
+          ORDER BY request_cache.last_accessed_at ASC, request_cache.id ASC
+          LIMIT $1
+          FOR UPDATE OF request_cache SKIP LOCKED
+        )
+        DELETE FROM public.lca_package_request_cache AS request_cache
+        USING candidates
+        WHERE request_cache.id = candidates.id
+        ",
+    )
+    .bind(batch_size)
+    .bind(request_cache_retention_days)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn delete_package_jobs_after_object_gc(
+    pool: &PgPool,
+    batch_size: i64,
+    job_retention_days: i32,
+    request_cache_retention_days: i32,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        WITH candidates AS (
+          SELECT jobs.id
+          FROM public.lca_package_jobs AS jobs
+          WHERE jobs.status IN ('ready', 'completed', 'failed', 'stale')
+            AND COALESCE(jobs.finished_at, jobs.updated_at, jobs.created_at)
+              < NOW() - make_interval(days => $2::integer)
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.lca_package_artifacts AS artifacts
+              WHERE artifacts.job_id = jobs.id
+                AND artifacts.is_pinned
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.lca_package_artifacts AS artifacts
+              WHERE artifacts.job_id = jobs.id
+                AND artifacts.status <> 'deleted'
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.lca_package_request_cache AS request_cache
+              WHERE request_cache.job_id = jobs.id
+                AND (
+                  request_cache.status IN ('pending', 'running')
+                  OR request_cache.last_accessed_at >= NOW() - make_interval(days => $3::integer)
+                )
+            )
+          ORDER BY COALESCE(jobs.finished_at, jobs.updated_at, jobs.created_at) ASC, jobs.id ASC
+          LIMIT $1
+          FOR UPDATE OF jobs SKIP LOCKED
+        )
+        DELETE FROM public.lca_package_jobs AS jobs
+        USING candidates
+        WHERE jobs.id = candidates.id
+        ",
+    )
+    .bind(batch_size)
+    .bind(job_retention_days)
+    .bind(request_cache_retention_days)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn refresh_import_source_retention(
+    pool: &PgPool,
+    artifact_id: Uuid,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        UPDATE public.lca_package_artifacts
+        SET expires_at = NOW() + make_interval(days => $2::integer),
+            metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+              'retention',
+              jsonb_build_object(
+                'policy', 'import_source_terminal',
+                'retention_days', $2::integer,
+                'refreshed_at', NOW()
+              )
+            ),
+            updated_at = NOW()
+        WHERE id = $1
+          AND artifact_kind = 'import_source'
+          AND status = 'ready'
+          AND is_pinned = FALSE
+        ",
+    )
+    .bind(artifact_id)
+    .bind(DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DEFAULT_EXPORT_PACKAGE_ARTIFACT_RETENTION_DAYS,
+        DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS, default_package_artifact_retention_days,
+        validate_retention_days,
+    };
+    use crate::package_types::PackageArtifactKind;
+
+    #[test]
+    fn package_artifact_retention_defaults_follow_kind() {
+        assert_eq!(
+            default_package_artifact_retention_days(PackageArtifactKind::ExportZip),
+            DEFAULT_EXPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        );
+        assert_eq!(
+            default_package_artifact_retention_days(PackageArtifactKind::ExportReport),
+            DEFAULT_EXPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        );
+        assert_eq!(
+            default_package_artifact_retention_days(PackageArtifactKind::ImportSource),
+            DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        );
+        assert_eq!(
+            default_package_artifact_retention_days(PackageArtifactKind::ImportReport),
+            DEFAULT_IMPORT_PACKAGE_ARTIFACT_RETENTION_DAYS
+        );
+    }
+
+    #[test]
+    fn retention_days_must_be_positive_and_bounded() {
+        assert!(validate_retention_days(1, "retention").is_ok());
+        assert!(validate_retention_days(3650, "retention").is_ok());
+        assert!(validate_retention_days(0, "retention").is_err());
+        assert!(validate_retention_days(3651, "retention").is_err());
+    }
+}

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 3c3dada13232c44bbad850fb8548cd33cb1c9d73
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 3c3dada13232c44bbad850fb8548cd33cb1c9d73
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -21,8 +21,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 4825474f906832a8ab9b2e93ce13b64fa42ef8f0
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - .docpact/config.yaml
   - crates/solver-worker/**
   - docs/agents/repo-validation.md
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: f7c7d97e64dab987631281c3835eb7d2a343b94a
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -134,7 +134,34 @@ related:
 - ZIP: `application/zip`
 - report: `application/json`
 
-### 7.1 import report payload（新增字段）
+### 7.1 Artifact retention / GC 契约
+
+package artifact 必须带或刷新 `expires_at`：
+
+- `export_zip` / `export_report`：默认 30 天；
+- `import_source` / `import_report`：默认 14 天；
+- worker 写入的新 artifact 在插入时写入 `expires_at`；
+- `import_source` 由 API 上传创建时，worker 在 import job 进入 terminal 成功/失败状态后刷新 14 天 TTL；
+- `is_pinned = true` 的 artifact 不参与自动 GC；
+- `status = deleted` 表示对象 payload 已被 GC 删除，API 不应再返回可下载 URL。
+
+calculator 侧 GC 必须 object-aware：
+
+1. dry-run 先输出 eligible/protected reason；
+2. 只处理 `expires_at <= now()`、`is_pinned = false`、父 job 非 `queued/running`、且无 active/recent request-cache 引用的 ready artifact；
+3. 先删除对象存储 payload；
+4. 对象删除成功后，才把 artifact 标记为 `deleted`；
+5. 对象删除失败时只记录 `metadata.gc` 错误，不删除 DB metadata；
+6. 当一个 terminal package job 的 artifact 都已 `deleted`、且无 active/recent cache 引用后，才允许删除 job metadata，让 `lca_package_export_items` 通过 FK cascade 清理。
+
+当前 calculator 提供 `package_gc` CLI：
+
+```bash
+cargo run -p solver-worker --bin package_gc --
+cargo run -p solver-worker --bin package_gc -- --execute
+```
+
+### 7.2 import report payload（新增字段）
 
 `tidas-package-import-report:v1` 的 payload 结构扩展如下：
 


### PR DESCRIPTION
## Summary
- add `package_gc` dry-run/execute CLI for package artifact retention cleanup
- mark package artifacts deleted only after object storage deletion succeeds, and preserve DB metadata on object-delete failures
- write default package artifact expiry and refresh `import_source` retention after terminal import success/failure
- document package artifact TTL/protection rules in the TIDAS package contract

## Scope Notes
- This PR closes the calculator package-artifact slice of workspace#201.
- Compute snapshot/result/factorization unified expiry remains deferred to a future schema-gap child issue, as recorded in tiangong-lca/workspace#201.
- Root workspace submodule pointer integration is required after merge because calculator is an M1 submodule.

## Validation
- `cargo check -p solver-worker --bin package_gc`
- `cargo test -p solver-worker package_retention`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `make check`
- `scripts/docpact lint --root . --worktree --mode enforce`

## Risk / Rollback
- `package_gc` is dry-run by default; destructive cleanup requires explicit `--execute` and S3 credentials.
- Object deletion failures are recorded in `metadata.gc` and do not delete package artifact metadata.
- Rollback is to stop scheduling/running `package_gc`; already-deleted objects remain represented by `status='deleted'` metadata.

Closes #62
