### PR TITLE
docs: document package_gc deployment

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "76345d6bb9a17691dd661cfccf5017057c52047e"
+lastReviewedAt: "2026-05-30"
+lastReviewedCommit: "bb29be8898df1edba319483fd9d1fd1d3f00114a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Supabase 连接说明：
 - 运行时 SQLx 查询使用非持久 prepared statement，以避免后端复用导致 `sqlx_s_*` 语句名冲突；高频 pgmq polling / archive 操作使用 `raw_sql` 简单查询协议与受限队列名字面量，避免 6543 transaction pooler 不支持 prepared statement 协议导致空轮询失败。
 - `build_snapshot` 全局并发控制使用 transaction-level advisory lock，适配 transaction pooler；生产环境仍建议保持 `BUILD_SNAPSHOT_MAX_CONCURRENCY=1`。
 
-对象存储（snapshot builder / solver-worker / result_gc 必需）：
+对象存储（snapshot builder / solver-worker / result_gc 必需；`package_gc --execute` 删除 package artifact 对象时也必需）：
 
 - `S3_ENDPOINT`
 - `S3_REGION`
@@ -681,7 +681,77 @@ journalctl -u package-worker.service -f
 sudo systemctl restart package-worker.service
 ```
 
-### 6.5 结果保留与 GC（S3 + DB）
+### 6.5 TIDAS Package Artifact GC（systemd timer，推荐）
+
+`package_gc` 负责清理 package artifact 对象、过期 request cache 和已无 artifact 依赖的 terminal package job metadata。部署建议分两层：
+
+- 所有活跃 calculator worker 主机都构建并保留最新 `target/release/package_gc`，便于切换。
+- 只有一台主机启用 `package-gc.timer`。`--execute` 模式内部会使用 PostgreSQL advisory lock，但调度层仍应避免三台机器同时跑 destructive GC。
+- 首次启用必须保持 dry-run，确认日志中的 eligible/protected reason 后，再把唯一 timer 主机切到 `--execute`。
+
+构建：
+
+```bash
+cd /home/ubuntu/projects/lca_workspace/tiangong-lca-calculator
+cargo build -p solver-worker --bin package_gc --release
+```
+
+创建 dry-run 服务文件 `/etc/systemd/system/package-gc.service`：
+
+```ini
+[Unit]
+Description=TianGong LCA Package Artifact GC (dry-run)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator
+EnvironmentFile=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/.env
+Environment=RUST_LOG=info
+Environment=PACKAGE_GC_BATCH_SIZE=100
+Environment=PACKAGE_GC_MAX_BATCHES=1
+SyslogIdentifier=package_gc
+ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/release/package_gc
+```
+
+创建 timer 文件 `/etc/systemd/system/package-gc.timer`：
+
+```ini
+[Unit]
+Description=Daily TianGong LCA Package Artifact GC dry-run
+
+[Timer]
+OnCalendar=*-*-* 03:15:00
+RandomizedDelaySec=15m
+Persistent=true
+Unit=package-gc.service
+
+[Install]
+WantedBy=timers.target
+```
+
+启用 timer 并立即跑一次 dry-run：
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now package-gc.timer
+sudo systemctl start package-gc.service
+systemctl status package-gc.timer package-gc.service --no-pager
+journalctl -u package-gc.service -n 100 --no-pager
+```
+
+日志里应出现 `[retention]` 与 `[summary] dry_run=true ...`。切到实际清理时，只在唯一 timer 主机上把 `ExecStart` 改为：
+
+```ini
+ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/release/package_gc --execute
+```
+
+`--execute` 会先删除对象存储 payload，再标记 artifact 为 `deleted`；对象删除失败时不会删除 DB metadata。建议保留 `PACKAGE_GC_BATCH_SIZE=100`、`PACKAGE_GC_MAX_BATCHES=1` 作为首轮 execute canary，再按运行结果逐步调整。
+
+### 6.6 结果保留与 GC（S3 + DB）
 
 `lca_results` 采用过期字段 + 保留规则：
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -161,6 +161,15 @@ cargo run -p solver-worker --bin package_gc --
 cargo run -p solver-worker --bin package_gc -- --execute
 ```
 
+生产部署契约：
+
+- `package_gc` release binary 应随 `package_worker` 一起部署到所有活跃 calculator worker 主机；
+- `package-gc.timer` 只能在一个调度主机启用，其他主机保留 binary 作为故障切换候选；
+- timer 首次启用必须 dry-run，不带 `--execute`，并检查 `[retention]` eligible/protected reason 与 `[summary] dry_run=true ...`；
+- destructive 清理必须显式加 `--execute`，并在首轮保留小批量限制，例如 `PACKAGE_GC_BATCH_SIZE=100`、`PACKAGE_GC_MAX_BATCHES=1`；
+- `--execute` 模式需要对象存储环境变量，且会先删对象 payload，再标记 artifact `deleted`；对象删除失败时只记录 `metadata.gc` 错误，不删除 DB metadata；
+- `--execute` 模式使用 PostgreSQL advisory lock 防止重叠执行，但这不是三台机器都启 timer 的理由。
+
 ### 7.2 import report payload（新增字段）
 
 `tidas-package-import-report:v1` 的 payload 结构扩展如下：


### PR DESCRIPTION
## Summary

- Add README operator guidance for package_gc build, systemd service, timer, dry-run verification, and execute promotion.
- Record the package_gc production deployment contract in docs/tidas-package-contract.md.
- Refresh docpact review evidence for governed calculator docs reviewed with this change.

## Rollout note

- calculator main commit bb29be8898df1edba319483fd9d1fd1d3f00114a has been deployed to the three active worker hosts.
- package_gc is built on all three hosts; only aws-dev has package-gc.timer enabled in dry-run mode.
- The first dry-run completed with dry_run=true and no object or metadata deletions.

## Validation

- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --worktree --mode enforce

Closes #70