### PR TITLE
feat: add snapshot storage gc worker

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-30"
-lastReviewedCommit: "bb29be8898df1edba319483fd9d1fd1d3f00114a"
+lastReviewedAt: "2026-05-31"
+lastReviewedCommit: "ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-30
-lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
+lastReviewedAt: 2026-05-31
+lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -751,7 +751,69 @@ ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/rel
 
 `--execute` 会先删除对象存储 payload，再标记 artifact 为 `deleted`；对象删除失败时不会删除 DB metadata。建议保留 `PACKAGE_GC_BATCH_SIZE=100`、`PACKAGE_GC_MAX_BATCHES=1` 作为首轮 execute canary，再按运行结果逐步调整。
 
-### 6.6 结果保留与 GC（S3 + DB）
+### 6.6 Snapshot Storage GC（systemd timer，推荐）
+
+`snapshot_gc` 负责清理 `lca-results/snapshots/<snapshot_id>/...` 存储目录。候选判断来自 database-engine 的 `util.list_lca_snapshot_gc_candidates(...)`，calculator 只执行对象删除与安全的 DB row 删除：
+
+- CLI 默认 dry-run；实际删除必须显式传 `--execute`。
+- active snapshot 永远保护；执行前会再次检查 `lca_active_snapshots`。
+- 非 active snapshot 超过 TTL 后，先删除该 snapshot directory 下所有 Storage objects；全部成功后才删除 `public.lca_network_snapshots`，由现有 FK cascade 清理 jobs/results/cache/latest/factorization/artifact metadata。
+- orphan storage directory 只删除 Storage objects，不做 DB 操作。
+- 404 object delete 视为成功，便于重试幂等。
+- 允许 3 台 calculator worker host 都安装 timer；`snapshot_gc` 使用 `solver_worker_snapshot_gc` PostgreSQL advisory lock，抢不到锁会写 `skipped` audit run 并退出 0。
+
+构建：
+
+```bash
+cd /home/ubuntu/projects/lca_workspace/tiangong-lca-calculator
+cargo build -p solver-worker --bin snapshot_gc --release
+```
+
+手动 dry-run：
+
+```bash
+./scripts/gc_lca_snapshots.sh
+```
+
+首轮 execute canary：
+
+```bash
+./scripts/gc_lca_snapshots.sh --execute \
+  --max-bytes 536870912 \
+  --max-snapshots 10 \
+  --max-orphan-dirs 50
+```
+
+systemd 模板位于：
+
+- `deploy/systemd/snapshot-gc.service`
+- `deploy/systemd/snapshot-gc.timer`
+
+timer 策略：
+
+```ini
+OnCalendar=Sun 20:30:00 UTC
+RandomizedDelaySec=30m
+Persistent=true
+```
+
+部署到 3 台 calculator worker host：
+
+```bash
+sudo cp deploy/systemd/snapshot-gc.service /etc/systemd/system/snapshot-gc.service
+sudo cp deploy/systemd/snapshot-gc.timer /etc/systemd/system/snapshot-gc.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now snapshot-gc.timer
+```
+
+上线后检查：
+
+```bash
+systemctl status snapshot-gc.timer snapshot-gc.service --no-pager
+journalctl -u snapshot-gc.service -n 100 --no-pager
+```
+
+### 6.7 结果保留与 GC（S3 + DB）
 
 `lca_results` 采用过期字段 + 保留规则：
 

--- a/crates/solver-worker/src/bin/snapshot_gc.rs
+++ b/crates/solver-worker/src/bin/snapshot_gc.rs
@@ -1,0 +1,484 @@
+use clap::Parser;
+use serde_json::json;
+use solver_worker::{
+    pgbouncer_sqlx::{self as sqlx, postgres::PgPoolOptions},
+    snapshot_retention::{
+        DEFAULT_BATCH_SIZE, DEFAULT_MAX_BYTES, DEFAULT_MAX_ORPHAN_DIRS, DEFAULT_MAX_SNAPSHOTS,
+        DEFAULT_ORPHAN_RETENTION_DAYS, DEFAULT_SNAPSHOT_RETENTION_DAYS, ObjectDeleteStatus,
+        SnapshotGcDirectory, SnapshotGcPolicy, SnapshotGcRunTotals, create_snapshot_gc_run,
+        delete_snapshot_row_if_inactive, fetch_snapshot_gc_candidates,
+        fetch_snapshot_retention_summary, finish_snapshot_gc_run, group_candidates_by_directory,
+        insert_snapshot_gc_run_items, is_snapshot_active, should_delete_db_snapshot,
+        update_snapshot_gc_run_item_status, validate_positive_i32, validate_snapshot_gc_policy,
+    },
+    storage::{ObjectDeleteOutcome, ObjectStoreClient},
+};
+use uuid::Uuid;
+
+#[derive(Debug, Parser)]
+#[command(name = "snapshot-gc")]
+struct Cli {
+    /// `PostgreSQL` URL (preferred env: `DATABASE_URL`, fallback: `CONN`).
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: Option<String>,
+    /// `PostgreSQL` URL fallback used by this project in local `.env`.
+    #[arg(long, env = "CONN")]
+    conn: Option<String>,
+    /// S3-compatible endpoint for snapshot artifacts.
+    #[arg(long, env = "S3_ENDPOINT")]
+    s3_endpoint: Option<String>,
+    /// S3 region.
+    #[arg(long, env = "S3_REGION")]
+    s3_region: Option<String>,
+    /// S3 bucket.
+    #[arg(long, env = "S3_BUCKET")]
+    s3_bucket: Option<String>,
+    /// S3 access key id.
+    #[arg(long, env = "S3_ACCESS_KEY_ID")]
+    s3_access_key_id: Option<String>,
+    /// S3 secret access key.
+    #[arg(long, env = "S3_SECRET_ACCESS_KEY")]
+    s3_secret_access_key: Option<String>,
+    /// Optional S3 session token.
+    #[arg(long, env = "S3_SESSION_TOKEN")]
+    s3_session_token: Option<String>,
+    /// Object key prefix.
+    #[arg(long, env = "S3_PREFIX", default_value = "lca-results")]
+    s3_prefix: String,
+    /// Default retention window for non-active snapshots without TTL metadata.
+    #[arg(
+        long,
+        env = "SNAPSHOT_GC_SNAPSHOT_RETENTION_DAYS",
+        default_value_t = DEFAULT_SNAPSHOT_RETENTION_DAYS
+    )]
+    snapshot_retention_days: i32,
+    /// Retention window for orphan snapshot storage directories.
+    #[arg(
+        long,
+        env = "SNAPSHOT_GC_ORPHAN_RETENTION_DAYS",
+        default_value_t = DEFAULT_ORPHAN_RETENTION_DAYS
+    )]
+    orphan_retention_days: i32,
+    /// Max non-active DB snapshot directories per run.
+    #[arg(
+        long,
+        env = "SNAPSHOT_GC_MAX_SNAPSHOTS",
+        default_value_t = DEFAULT_MAX_SNAPSHOTS
+    )]
+    max_snapshots: i32,
+    /// Max orphan storage directories per run.
+    #[arg(
+        long,
+        env = "SNAPSHOT_GC_MAX_ORPHAN_DIRS",
+        default_value_t = DEFAULT_MAX_ORPHAN_DIRS
+    )]
+    max_orphan_dirs: i32,
+    /// Max storage bytes per run.
+    #[arg(long, env = "SNAPSHOT_GC_MAX_BYTES", default_value_t = DEFAULT_MAX_BYTES)]
+    max_bytes: i64,
+    /// Object processing chunk size.
+    #[arg(
+        long,
+        env = "SNAPSHOT_GC_BATCH_SIZE",
+        default_value_t = DEFAULT_BATCH_SIZE
+    )]
+    batch_size: usize,
+    /// Execute destructive object/metadata cleanup. Omit for dry-run only.
+    #[arg(long)]
+    execute: bool,
+}
+
+#[derive(Debug, Default)]
+struct SnapshotGcExecutionTotals {
+    candidate_objects: usize,
+    candidate_directories: usize,
+    storage_missing_count: i32,
+    skipped_active_directories: i32,
+    run_totals: SnapshotGcRunTotals,
+}
+
+fn required<'a>(value: Option<&'a str>, name: &str) -> anyhow::Result<&'a str> {
+    value.ok_or_else(|| anyhow::anyhow!("missing {name}"))
+}
+
+fn resolve_db_url(cli: &Cli) -> anyhow::Result<&str> {
+    cli.database_url
+        .as_deref()
+        .or(cli.conn.as_deref())
+        .ok_or_else(|| anyhow::anyhow!("missing DB connection: set DATABASE_URL or CONN"))
+}
+
+fn build_policy(cli: &Cli) -> anyhow::Result<SnapshotGcPolicy> {
+    validate_snapshot_gc_policy(SnapshotGcPolicy {
+        snapshot_retention_days: cli.snapshot_retention_days,
+        orphan_retention_days: cli.orphan_retention_days,
+        max_snapshots: cli.max_snapshots,
+        max_orphan_dirs: cli.max_orphan_dirs,
+        max_bytes: cli.max_bytes,
+    })
+}
+
+fn validate_batch_size(value: usize) -> anyhow::Result<usize> {
+    if value == 0 {
+        return Err(anyhow::anyhow!("SNAPSHOT_GC_BATCH_SIZE must be > 0"));
+    }
+    Ok(value)
+}
+
+fn build_object_store(cli: &Cli) -> anyhow::Result<ObjectStoreClient> {
+    let endpoint = required(cli.s3_endpoint.as_deref(), "S3_ENDPOINT")?;
+    let region = required(cli.s3_region.as_deref(), "S3_REGION")?;
+    let bucket = required(cli.s3_bucket.as_deref(), "S3_BUCKET")?;
+    let access_key = required(cli.s3_access_key_id.as_deref(), "S3_ACCESS_KEY_ID")?;
+    let secret = required(cli.s3_secret_access_key.as_deref(), "S3_SECRET_ACCESS_KEY")?;
+
+    ObjectStoreClient::new(
+        endpoint,
+        region,
+        bucket,
+        &cli.s3_prefix,
+        access_key,
+        secret,
+        cli.s3_session_token.clone(),
+    )
+}
+
+async fn try_acquire_snapshot_gc_lock(
+    pool: &sqlx::PgPool,
+) -> anyhow::Result<Option<sqlx::pool::PoolConnection<sqlx::Postgres>>> {
+    let mut conn = pool.acquire().await?;
+    let acquired = sqlx::query_scalar::<bool>(
+        "SELECT pg_try_advisory_lock(hashtext('solver_worker_snapshot_gc'))",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+
+    if acquired { Ok(Some(conn)) } else { Ok(None) }
+}
+
+async fn release_snapshot_gc_lock(
+    conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+) -> anyhow::Result<()> {
+    let _ = sqlx::query_scalar::<bool>(
+        "SELECT pg_advisory_unlock(hashtext('solver_worker_snapshot_gc'))",
+    )
+    .fetch_one(&mut **conn)
+    .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let policy = build_policy(&cli)?;
+    let batch_size = validate_batch_size(cli.batch_size)?;
+    validate_positive_i32(cli.max_snapshots, "SNAPSHOT_GC_MAX_SNAPSHOTS")?;
+    validate_positive_i32(cli.max_orphan_dirs, "SNAPSHOT_GC_MAX_ORPHAN_DIRS")?;
+
+    let db_url = resolve_db_url(&cli)?;
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(db_url)
+        .await?;
+    let store = if cli.execute {
+        Some(build_object_store(&cli)?)
+    } else {
+        None
+    };
+    let mode = if cli.execute { "execute" } else { "dry_run" };
+
+    let Some(mut lock_conn) = try_acquire_snapshot_gc_lock(&pool).await? else {
+        let run_id = create_snapshot_gc_run(
+            &pool,
+            mode,
+            "skipped",
+            policy,
+            &[],
+            json!({"reason": "advisory_lock_held"}),
+        )
+        .await?;
+        println!(
+            "[summary] run_id={run_id} dry_run={} status=skipped reason=advisory_lock_held",
+            !cli.execute
+        );
+        return Ok(());
+    };
+
+    let result = run_snapshot_gc(&pool, store.as_ref(), &cli, policy, batch_size).await;
+    let unlock_result = release_snapshot_gc_lock(&mut lock_conn).await;
+    let totals = result?;
+    unlock_result?;
+
+    println!(
+        "[summary] dry_run={} candidate_directories={} candidate_objects={} storage_deleted_or_missing={} storage_missing={} storage_failed={} db_snapshot_deleted={} skipped_active_directories={}",
+        !cli.execute,
+        totals.candidate_directories,
+        totals.candidate_objects,
+        totals.run_totals.storage_deleted_count,
+        totals.storage_missing_count,
+        totals.run_totals.storage_failed_count,
+        totals.run_totals.db_snapshot_deleted_count,
+        totals.skipped_active_directories
+    );
+
+    if totals.run_totals.storage_failed_count > 0 {
+        return Err(anyhow::anyhow!(
+            "snapshot GC finished with {} storage delete failures",
+            totals.run_totals.storage_failed_count
+        ));
+    }
+
+    Ok(())
+}
+
+async fn run_snapshot_gc(
+    pool: &sqlx::PgPool,
+    store: Option<&ObjectStoreClient>,
+    cli: &Cli,
+    policy: SnapshotGcPolicy,
+    batch_size: usize,
+) -> anyhow::Result<SnapshotGcExecutionTotals> {
+    let summary = fetch_snapshot_retention_summary(pool, policy).await?;
+    print_retention_summary(summary.as_slice());
+
+    let candidates = fetch_snapshot_gc_candidates(pool, policy).await?;
+    let directories = group_candidates_by_directory(candidates.as_slice());
+    let run_id = create_snapshot_gc_run(
+        pool,
+        if cli.execute { "execute" } else { "dry_run" },
+        "running",
+        policy,
+        candidates.as_slice(),
+        json!({
+            "contract": "util.list_lca_snapshot_gc_candidates",
+            "execute": cli.execute
+        }),
+    )
+    .await?;
+
+    insert_snapshot_gc_run_items(
+        pool,
+        run_id,
+        candidates.as_slice(),
+        if cli.execute { "planned" } else { "dry_run" },
+    )
+    .await?;
+
+    let mut totals = SnapshotGcExecutionTotals {
+        candidate_objects: candidates.len(),
+        candidate_directories: directories.len(),
+        ..SnapshotGcExecutionTotals::default()
+    };
+
+    if !cli.execute {
+        print_dry_run_candidates(directories.as_slice());
+        finish_snapshot_gc_run(
+            pool,
+            run_id,
+            "succeeded",
+            totals.run_totals,
+            json!({
+                "storage_missing_count": totals.storage_missing_count,
+                "skipped_active_directories": totals.skipped_active_directories
+            }),
+        )
+        .await?;
+        return Ok(totals);
+    }
+
+    let store = store.ok_or_else(|| anyhow::anyhow!("object store is required for --execute"))?;
+    for directory_batch in directories.chunks(batch_size) {
+        for directory in directory_batch {
+            process_snapshot_gc_directory(pool, store, run_id, directory, batch_size, &mut totals)
+                .await?;
+        }
+    }
+
+    let run_status = if totals.run_totals.storage_failed_count > 0 {
+        "failed"
+    } else {
+        "succeeded"
+    };
+    finish_snapshot_gc_run(
+        pool,
+        run_id,
+        run_status,
+        totals.run_totals,
+        json!({
+            "storage_missing_count": totals.storage_missing_count,
+            "skipped_active_directories": totals.skipped_active_directories
+        }),
+    )
+    .await?;
+
+    Ok(totals)
+}
+
+fn print_retention_summary(
+    summary: &[solver_worker::snapshot_retention::SnapshotRetentionSummaryRow],
+) {
+    for row in summary {
+        println!(
+            "[retention] area={} action={} eligible={} reason={} snapshots={} objects={} bytes={} downstream_jobs={} downstream_results={} downstream_cache={} downstream_latest={} downstream_factorization={} downstream_artifacts={}",
+            row.retention_area,
+            row.retention_action,
+            row.is_eligible,
+            row.reason,
+            row.snapshot_count,
+            row.object_count,
+            row.total_storage_bytes,
+            row.downstream_job_count,
+            row.downstream_result_count,
+            row.downstream_cache_count,
+            row.downstream_latest_count,
+            row.downstream_factorization_count,
+            row.downstream_artifact_count
+        );
+    }
+}
+
+fn print_dry_run_candidates(directories: &[SnapshotGcDirectory]) {
+    for directory in directories {
+        println!(
+            "[dry-run] type={} snapshot_id={} directory={} objects={} bytes={} reason={} delete_db_snapshot={}",
+            directory.candidate_type,
+            directory
+                .snapshot_id
+                .map_or_else(|| "null".to_owned(), |snapshot_id| snapshot_id.to_string()),
+            directory.snapshot_directory,
+            directory.objects.len(),
+            directory.storage_bytes,
+            directory.reason,
+            directory.delete_db_snapshot
+        );
+        for object in &directory.objects {
+            println!(
+                "[dry-run-object] directory={} object={} bytes={}",
+                directory.snapshot_directory, object.object_name, object.storage_bytes
+            );
+        }
+    }
+}
+
+async fn process_snapshot_gc_directory(
+    pool: &sqlx::PgPool,
+    store: &ObjectStoreClient,
+    run_id: Uuid,
+    directory: &SnapshotGcDirectory,
+    batch_size: usize,
+    totals: &mut SnapshotGcExecutionTotals,
+) -> anyhow::Result<()> {
+    if directory.delete_db_snapshot {
+        let snapshot_id = directory
+            .snapshot_id
+            .ok_or_else(|| anyhow::anyhow!("DB snapshot candidate missing snapshot_id"))?;
+        if is_snapshot_active(pool, snapshot_id).await? {
+            totals.skipped_active_directories += 1;
+            for object in &directory.objects {
+                update_snapshot_gc_run_item_status(
+                    pool,
+                    run_id,
+                    &object.object_name,
+                    "skipped",
+                    Some("snapshot became active before GC"),
+                )
+                .await?;
+            }
+            eprintln!(
+                "[warn] skip active snapshot directory={} snapshot_id={snapshot_id}",
+                directory.snapshot_directory
+            );
+            return Ok(());
+        }
+    }
+
+    let mut object_statuses = Vec::with_capacity(directory.objects.len());
+    for object_batch in directory.objects.chunks(batch_size) {
+        for object in object_batch {
+            let status = delete_snapshot_object(pool, store, run_id, &object.object_name).await?;
+            match status {
+                ObjectDeleteStatus::Deleted => totals.run_totals.storage_deleted_count += 1,
+                ObjectDeleteStatus::Missing => {
+                    totals.run_totals.storage_deleted_count += 1;
+                    totals.storage_missing_count += 1;
+                }
+                ObjectDeleteStatus::Failed => totals.run_totals.storage_failed_count += 1,
+            }
+            object_statuses.push(status);
+        }
+    }
+
+    if should_delete_db_snapshot(directory, object_statuses.as_slice()) {
+        let snapshot_id = directory
+            .snapshot_id
+            .ok_or_else(|| anyhow::anyhow!("DB snapshot candidate missing snapshot_id"))?;
+        let deleted = delete_snapshot_row_if_inactive(pool, snapshot_id).await?;
+        if deleted > 0 {
+            totals.run_totals.db_snapshot_deleted_count += i32::try_from(deleted)
+                .map_err(|_| anyhow::anyhow!("deleted snapshot row count exceeds i32::MAX"))?;
+            for object in &directory.objects {
+                update_snapshot_gc_run_item_status(
+                    pool,
+                    run_id,
+                    &object.object_name,
+                    "db_deleted",
+                    None,
+                )
+                .await?;
+            }
+            println!(
+                "[info] deleted snapshot row snapshot_id={snapshot_id} directory={} objects={}",
+                directory.snapshot_directory,
+                directory.objects.len()
+            );
+        } else {
+            eprintln!(
+                "[warn] snapshot row was not deleted snapshot_id={snapshot_id} directory={}",
+                directory.snapshot_directory
+            );
+        }
+    } else if directory.delete_db_snapshot {
+        eprintln!(
+            "[warn] keep DB snapshot row after object delete failure directory={} snapshot_id={}",
+            directory.snapshot_directory,
+            directory
+                .snapshot_id
+                .map_or_else(|| "null".to_owned(), |snapshot_id| snapshot_id.to_string())
+        );
+    }
+
+    Ok(())
+}
+
+async fn delete_snapshot_object(
+    pool: &sqlx::PgPool,
+    store: &ObjectStoreClient,
+    run_id: Uuid,
+    object_name: &str,
+) -> anyhow::Result<ObjectDeleteStatus> {
+    match store.delete_object_key(object_name).await {
+        Ok(ObjectDeleteOutcome::Deleted) => {
+            update_snapshot_gc_run_item_status(pool, run_id, object_name, "storage_deleted", None)
+                .await?;
+            Ok(ObjectDeleteStatus::Deleted)
+        }
+        Ok(ObjectDeleteOutcome::Missing) => {
+            update_snapshot_gc_run_item_status(pool, run_id, object_name, "storage_missing", None)
+                .await?;
+            Ok(ObjectDeleteStatus::Missing)
+        }
+        Err(err) => {
+            let message = err.to_string();
+            update_snapshot_gc_run_item_status(
+                pool,
+                run_id,
+                object_name,
+                "storage_failed",
+                Some(&message),
+            )
+            .await?;
+            eprintln!("[warn] snapshot object delete failed object={object_name} error={message}");
+            Ok(ObjectDeleteStatus::Failed)
+        }
+    }
+}

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -30,5 +30,6 @@ pub mod review_submit_gate;
 pub mod review_submit_gate_runner;
 pub mod snapshot_artifacts;
 pub mod snapshot_index;
+pub mod snapshot_retention;
 pub mod storage;
 pub mod types;

--- a/crates/solver-worker/src/snapshot_retention.rs
+++ b/crates/solver-worker/src/snapshot_retention.rs
@@ -1,0 +1,648 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::pgbouncer_sqlx::{self as sqlx, PgPool, Row};
+
+pub const DEFAULT_SNAPSHOT_RETENTION_DAYS: i32 = 30;
+pub const DEFAULT_ORPHAN_RETENTION_DAYS: i32 = 30;
+pub const DEFAULT_MAX_SNAPSHOTS: i32 = 100;
+pub const DEFAULT_MAX_ORPHAN_DIRS: i32 = 200;
+pub const DEFAULT_MAX_BYTES: i64 = 2_147_483_648;
+pub const DEFAULT_BATCH_SIZE: usize = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotGcPolicy {
+    pub snapshot_retention_days: i32,
+    pub orphan_retention_days: i32,
+    pub max_snapshots: i32,
+    pub max_orphan_dirs: i32,
+    pub max_bytes: i64,
+}
+
+impl Default for SnapshotGcPolicy {
+    fn default() -> Self {
+        Self {
+            snapshot_retention_days: DEFAULT_SNAPSHOT_RETENTION_DAYS,
+            orphan_retention_days: DEFAULT_ORPHAN_RETENTION_DAYS,
+            max_snapshots: DEFAULT_MAX_SNAPSHOTS,
+            max_orphan_dirs: DEFAULT_MAX_ORPHAN_DIRS,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRetentionSummaryRow {
+    pub retention_area: String,
+    pub retention_action: String,
+    pub is_eligible: bool,
+    pub reason: String,
+    pub snapshot_count: i64,
+    pub object_count: i64,
+    pub total_storage_bytes: i64,
+    pub downstream_active_count: i64,
+    pub downstream_job_count: i64,
+    pub downstream_result_count: i64,
+    pub downstream_cache_count: i64,
+    pub downstream_latest_count: i64,
+    pub downstream_factorization_count: i64,
+    pub downstream_artifact_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotGcCandidate {
+    pub candidate_type: String,
+    pub snapshot_id: Option<Uuid>,
+    pub snapshot_directory: String,
+    pub bucket_id: String,
+    pub object_name: String,
+    pub storage_bytes: i64,
+    pub reason: String,
+    pub delete_db_snapshot: bool,
+    pub object_count: i64,
+    pub snapshot_storage_bytes: i64,
+    pub downstream_job_count: i64,
+    pub downstream_result_count: i64,
+    pub downstream_cache_count: i64,
+    pub downstream_latest_count: i64,
+    pub downstream_factorization_count: i64,
+    pub downstream_artifact_count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotGcDirectory {
+    pub candidate_type: String,
+    pub snapshot_id: Option<Uuid>,
+    pub snapshot_directory: String,
+    pub reason: String,
+    pub delete_db_snapshot: bool,
+    pub storage_bytes: i64,
+    pub objects: Vec<SnapshotGcCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectDeleteStatus {
+    Deleted,
+    Missing,
+    Failed,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotGcRunTotals {
+    pub storage_deleted_count: i32,
+    pub storage_failed_count: i32,
+    pub db_snapshot_deleted_count: i32,
+}
+
+pub fn validate_snapshot_gc_policy(policy: SnapshotGcPolicy) -> anyhow::Result<SnapshotGcPolicy> {
+    validate_days(
+        policy.snapshot_retention_days,
+        "SNAPSHOT_GC_SNAPSHOT_RETENTION_DAYS",
+    )?;
+    validate_days(
+        policy.orphan_retention_days,
+        "SNAPSHOT_GC_ORPHAN_RETENTION_DAYS",
+    )?;
+    validate_positive_i32(policy.max_snapshots, "SNAPSHOT_GC_MAX_SNAPSHOTS")?;
+    validate_positive_i32(policy.max_orphan_dirs, "SNAPSHOT_GC_MAX_ORPHAN_DIRS")?;
+    if policy.max_bytes <= 0 {
+        return Err(anyhow::anyhow!("SNAPSHOT_GC_MAX_BYTES must be > 0"));
+    }
+    Ok(policy)
+}
+
+pub fn validate_days(value: i32, name: &str) -> anyhow::Result<i32> {
+    if !(1..=3650).contains(&value) {
+        return Err(anyhow::anyhow!("{name} must be between 1 and 3650 days"));
+    }
+    Ok(value)
+}
+
+pub fn validate_positive_i32(value: i32, name: &str) -> anyhow::Result<i32> {
+    if value <= 0 {
+        return Err(anyhow::anyhow!("{name} must be > 0"));
+    }
+    Ok(value)
+}
+
+#[must_use]
+pub fn group_candidates_by_directory(
+    candidates: &[SnapshotGcCandidate],
+) -> Vec<SnapshotGcDirectory> {
+    let mut grouped: BTreeMap<(String, String), SnapshotGcDirectory> = BTreeMap::new();
+    for candidate in candidates {
+        let key = (
+            candidate.candidate_type.clone(),
+            candidate.snapshot_directory.clone(),
+        );
+        let entry = grouped.entry(key).or_insert_with(|| SnapshotGcDirectory {
+            candidate_type: candidate.candidate_type.clone(),
+            snapshot_id: candidate.snapshot_id,
+            snapshot_directory: candidate.snapshot_directory.clone(),
+            reason: candidate.reason.clone(),
+            delete_db_snapshot: candidate.delete_db_snapshot,
+            storage_bytes: candidate.snapshot_storage_bytes,
+            objects: Vec::new(),
+        });
+        entry.objects.push(candidate.clone());
+    }
+
+    grouped.into_values().collect()
+}
+
+#[must_use]
+pub const fn object_delete_succeeded(status: ObjectDeleteStatus) -> bool {
+    matches!(
+        status,
+        ObjectDeleteStatus::Deleted | ObjectDeleteStatus::Missing
+    )
+}
+
+#[must_use]
+pub fn should_delete_db_snapshot(
+    directory: &SnapshotGcDirectory,
+    object_statuses: &[ObjectDeleteStatus],
+) -> bool {
+    directory.delete_db_snapshot
+        && object_statuses.len() == directory.objects.len()
+        && object_statuses.iter().copied().all(object_delete_succeeded)
+}
+
+pub async fn fetch_snapshot_retention_summary(
+    pool: &PgPool,
+    policy: SnapshotGcPolicy,
+) -> anyhow::Result<Vec<SnapshotRetentionSummaryRow>> {
+    let rows = sqlx::query(
+        r"
+        SELECT
+          retention_area,
+          retention_action,
+          is_eligible,
+          reason,
+          snapshot_count,
+          object_count,
+          total_storage_bytes,
+          downstream_active_count,
+          downstream_job_count,
+          downstream_result_count,
+          downstream_cache_count,
+          downstream_latest_count,
+          downstream_factorization_count,
+          downstream_artifact_count
+        FROM util.preview_lca_snapshot_retention(
+          make_interval(days => $1::integer),
+          make_interval(days => $2::integer),
+          NOW()
+        )
+        ",
+    )
+    .bind(policy.snapshot_retention_days)
+    .bind(policy.orphan_retention_days)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(SnapshotRetentionSummaryRow {
+                retention_area: row.try_get("retention_area")?,
+                retention_action: row.try_get("retention_action")?,
+                is_eligible: row.try_get("is_eligible")?,
+                reason: row.try_get("reason")?,
+                snapshot_count: row.try_get("snapshot_count")?,
+                object_count: row.try_get("object_count")?,
+                total_storage_bytes: row.try_get("total_storage_bytes")?,
+                downstream_active_count: row.try_get("downstream_active_count")?,
+                downstream_job_count: row.try_get("downstream_job_count")?,
+                downstream_result_count: row.try_get("downstream_result_count")?,
+                downstream_cache_count: row.try_get("downstream_cache_count")?,
+                downstream_latest_count: row.try_get("downstream_latest_count")?,
+                downstream_factorization_count: row.try_get("downstream_factorization_count")?,
+                downstream_artifact_count: row.try_get("downstream_artifact_count")?,
+            })
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()
+        .map_err(Into::into)
+}
+
+pub async fn fetch_snapshot_gc_candidates(
+    pool: &PgPool,
+    policy: SnapshotGcPolicy,
+) -> anyhow::Result<Vec<SnapshotGcCandidate>> {
+    let rows = sqlx::query(
+        r"
+        SELECT
+          candidate_type,
+          snapshot_id,
+          snapshot_directory,
+          bucket_id,
+          object_name,
+          storage_bytes,
+          reason,
+          delete_db_snapshot,
+          object_count,
+          snapshot_storage_bytes,
+          downstream_job_count,
+          downstream_result_count,
+          downstream_cache_count,
+          downstream_latest_count,
+          downstream_factorization_count,
+          downstream_artifact_count
+        FROM util.list_lca_snapshot_gc_candidates(
+          make_interval(days => $1::integer),
+          make_interval(days => $2::integer),
+          NOW(),
+          $3::integer,
+          $4::integer,
+          $5::bigint
+        )
+        ",
+    )
+    .bind(policy.snapshot_retention_days)
+    .bind(policy.orphan_retention_days)
+    .bind(policy.max_snapshots)
+    .bind(policy.max_orphan_dirs)
+    .bind(policy.max_bytes)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(SnapshotGcCandidate {
+                candidate_type: row.try_get("candidate_type")?,
+                snapshot_id: row.try_get("snapshot_id")?,
+                snapshot_directory: row.try_get("snapshot_directory")?,
+                bucket_id: row.try_get("bucket_id")?,
+                object_name: row.try_get("object_name")?,
+                storage_bytes: row.try_get("storage_bytes")?,
+                reason: row.try_get("reason")?,
+                delete_db_snapshot: row.try_get("delete_db_snapshot")?,
+                object_count: row.try_get("object_count")?,
+                snapshot_storage_bytes: row.try_get("snapshot_storage_bytes")?,
+                downstream_job_count: row.try_get("downstream_job_count")?,
+                downstream_result_count: row.try_get("downstream_result_count")?,
+                downstream_cache_count: row.try_get("downstream_cache_count")?,
+                downstream_latest_count: row.try_get("downstream_latest_count")?,
+                downstream_factorization_count: row.try_get("downstream_factorization_count")?,
+                downstream_artifact_count: row.try_get("downstream_artifact_count")?,
+            })
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()
+        .map_err(Into::into)
+}
+
+pub async fn create_snapshot_gc_run(
+    pool: &PgPool,
+    mode: &str,
+    status: &str,
+    policy: SnapshotGcPolicy,
+    candidates: &[SnapshotGcCandidate],
+    diagnostics: Value,
+) -> anyhow::Result<Uuid> {
+    let candidate_snapshot_count = count_directories(candidates, "snapshot_directory")?;
+    let candidate_orphan_dir_count = count_directories(candidates, "orphan_storage_directory")?;
+    let candidate_object_count = usize_to_i32(candidates.len(), "candidate object count")?;
+    let candidate_storage_bytes = sum_candidate_storage_bytes(candidates)?;
+
+    let row = sqlx::query(
+        r"
+        INSERT INTO public.lca_snapshot_gc_runs (
+          mode,
+          status,
+          snapshot_retention_window,
+          orphan_retention_window,
+          max_snapshots,
+          max_orphan_dirs,
+          max_bytes,
+          candidate_snapshot_count,
+          candidate_orphan_dir_count,
+          candidate_object_count,
+          candidate_storage_bytes,
+          diagnostics,
+          finished_at
+        ) VALUES (
+          $1,
+          $2,
+          make_interval(days => $3::integer),
+          make_interval(days => $4::integer),
+          $5,
+          $6,
+          $7,
+          $8,
+          $9,
+          $10,
+          $11,
+          $12,
+          CASE WHEN $2 IN ('succeeded', 'failed', 'skipped') THEN NOW() ELSE NULL END
+        )
+        RETURNING id
+        ",
+    )
+    .bind(mode)
+    .bind(status)
+    .bind(policy.snapshot_retention_days)
+    .bind(policy.orphan_retention_days)
+    .bind(policy.max_snapshots)
+    .bind(policy.max_orphan_dirs)
+    .bind(policy.max_bytes)
+    .bind(candidate_snapshot_count)
+    .bind(candidate_orphan_dir_count)
+    .bind(candidate_object_count)
+    .bind(candidate_storage_bytes)
+    .bind(diagnostics)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row.try_get("id")?)
+}
+
+pub async fn insert_snapshot_gc_run_items(
+    pool: &PgPool,
+    run_id: Uuid,
+    candidates: &[SnapshotGcCandidate],
+    action_status: &str,
+) -> anyhow::Result<()> {
+    for candidate in candidates {
+        sqlx::query(
+            r"
+            INSERT INTO public.lca_snapshot_gc_run_items (
+              run_id,
+              candidate_type,
+              snapshot_id,
+              bucket_id,
+              object_name,
+              storage_bytes,
+              reason,
+              delete_db_snapshot,
+              action_status
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ",
+        )
+        .bind(run_id)
+        .bind(&candidate.candidate_type)
+        .bind(candidate.snapshot_id)
+        .bind(&candidate.bucket_id)
+        .bind(&candidate.object_name)
+        .bind(candidate.storage_bytes)
+        .bind(&candidate.reason)
+        .bind(candidate.delete_db_snapshot)
+        .bind(action_status)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
+pub async fn update_snapshot_gc_run_item_status(
+    pool: &PgPool,
+    run_id: Uuid,
+    object_name: &str,
+    action_status: &str,
+    error_message: Option<&str>,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        UPDATE public.lca_snapshot_gc_run_items
+        SET action_status = $3,
+            error_message = $4,
+            updated_at = NOW()
+        WHERE run_id = $1
+          AND object_name = $2
+        ",
+    )
+    .bind(run_id)
+    .bind(object_name)
+    .bind(action_status)
+    .bind(error_message)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn finish_snapshot_gc_run(
+    pool: &PgPool,
+    run_id: Uuid,
+    status: &str,
+    totals: SnapshotGcRunTotals,
+    diagnostics: Value,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        UPDATE public.lca_snapshot_gc_runs
+        SET status = $2,
+            finished_at = NOW(),
+            storage_deleted_count = $3,
+            storage_failed_count = $4,
+            db_snapshot_deleted_count = $5,
+            diagnostics = COALESCE(diagnostics, '{}'::jsonb) || $6::jsonb
+        WHERE id = $1
+        ",
+    )
+    .bind(run_id)
+    .bind(status)
+    .bind(totals.storage_deleted_count)
+    .bind(totals.storage_failed_count)
+    .bind(totals.db_snapshot_deleted_count)
+    .bind(diagnostics)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+pub async fn is_snapshot_active(pool: &PgPool, snapshot_id: Uuid) -> anyhow::Result<bool> {
+    let active = sqlx::query_scalar::<bool>(
+        r"
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.lca_active_snapshots
+          WHERE snapshot_id = $1
+        )
+        ",
+    )
+    .bind(snapshot_id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(active)
+}
+
+pub async fn delete_snapshot_row_if_inactive(
+    pool: &PgPool,
+    snapshot_id: Uuid,
+) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        r"
+        DELETE FROM public.lca_network_snapshots AS snapshots
+        WHERE snapshots.id = $1
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.lca_active_snapshots AS active
+            WHERE active.snapshot_id = snapshots.id
+          )
+        ",
+    )
+    .bind(snapshot_id)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+fn count_directories(
+    candidates: &[SnapshotGcCandidate],
+    candidate_type: &str,
+) -> anyhow::Result<i32> {
+    let count = group_candidates_by_directory(candidates)
+        .into_iter()
+        .filter(|directory| directory.candidate_type == candidate_type)
+        .count();
+    usize_to_i32(count, "candidate directory count")
+}
+
+fn usize_to_i32(value: usize, name: &str) -> anyhow::Result<i32> {
+    i32::try_from(value).map_err(|_| anyhow::anyhow!("{name} exceeds i32::MAX"))
+}
+
+fn sum_candidate_storage_bytes(candidates: &[SnapshotGcCandidate]) -> anyhow::Result<i64> {
+    candidates.iter().try_fold(0_i64, |acc, candidate| {
+        acc.checked_add(candidate.storage_bytes.max(0))
+            .ok_or_else(|| anyhow::anyhow!("candidate storage bytes overflow"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::{
+        ObjectDeleteStatus, SnapshotGcCandidate, group_candidates_by_directory,
+        object_delete_succeeded, should_delete_db_snapshot, validate_snapshot_gc_policy,
+    };
+
+    #[test]
+    fn groups_candidates_by_snapshot_directory() {
+        let snapshot_id =
+            Uuid::parse_str("91540000-0000-4000-8000-000000000001").expect("valid fixture uuid");
+        let candidates = vec![
+            candidate(
+                "snapshot_directory",
+                Some(snapshot_id),
+                "91540000-0000-4000-8000-000000000001",
+                "a.json",
+                true,
+            ),
+            candidate(
+                "snapshot_directory",
+                Some(snapshot_id),
+                "91540000-0000-4000-8000-000000000001",
+                "b.json",
+                true,
+            ),
+            candidate(
+                "orphan_storage_directory",
+                None,
+                "91540000-0000-4000-8000-000000000002",
+                "c.json",
+                false,
+            ),
+        ];
+
+        let grouped = group_candidates_by_directory(&candidates);
+
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[0].objects.len(), 1);
+        assert_eq!(grouped[1].objects.len(), 2);
+        assert!(grouped[1].delete_db_snapshot);
+    }
+
+    #[test]
+    fn partial_object_delete_failure_blocks_db_snapshot_delete() {
+        let snapshot_id =
+            Uuid::parse_str("91540000-0000-4000-8000-000000000001").expect("valid fixture uuid");
+        let candidates = vec![
+            candidate(
+                "snapshot_directory",
+                Some(snapshot_id),
+                "91540000-0000-4000-8000-000000000001",
+                "a.json",
+                true,
+            ),
+            candidate(
+                "snapshot_directory",
+                Some(snapshot_id),
+                "91540000-0000-4000-8000-000000000001",
+                "b.json",
+                true,
+            ),
+        ];
+        let directory = group_candidates_by_directory(&candidates)
+            .pop()
+            .expect("one directory");
+
+        assert!(!should_delete_db_snapshot(
+            &directory,
+            &[ObjectDeleteStatus::Deleted, ObjectDeleteStatus::Failed]
+        ));
+        assert!(should_delete_db_snapshot(
+            &directory,
+            &[ObjectDeleteStatus::Deleted, ObjectDeleteStatus::Missing]
+        ));
+    }
+
+    #[test]
+    fn object_missing_counts_as_success_for_retry_semantics() {
+        assert!(object_delete_succeeded(ObjectDeleteStatus::Deleted));
+        assert!(object_delete_succeeded(ObjectDeleteStatus::Missing));
+        assert!(!object_delete_succeeded(ObjectDeleteStatus::Failed));
+    }
+
+    #[test]
+    fn validates_policy_bounds() {
+        assert!(validate_snapshot_gc_policy(super::SnapshotGcPolicy::default()).is_ok());
+        assert!(
+            validate_snapshot_gc_policy(super::SnapshotGcPolicy {
+                snapshot_retention_days: 0,
+                ..super::SnapshotGcPolicy::default()
+            })
+            .is_err()
+        );
+        assert!(
+            validate_snapshot_gc_policy(super::SnapshotGcPolicy {
+                max_bytes: 0,
+                ..super::SnapshotGcPolicy::default()
+            })
+            .is_err()
+        );
+    }
+
+    fn candidate(
+        candidate_type: &str,
+        snapshot_id: Option<Uuid>,
+        snapshot_directory: &str,
+        object_name: &str,
+        delete_db_snapshot: bool,
+    ) -> SnapshotGcCandidate {
+        SnapshotGcCandidate {
+            candidate_type: candidate_type.to_owned(),
+            snapshot_id,
+            snapshot_directory: snapshot_directory.to_owned(),
+            bucket_id: "lca_results".to_owned(),
+            object_name: format!("lca-results/snapshots/{snapshot_directory}/{object_name}"),
+            storage_bytes: 10,
+            reason: "eligible_default_30d_snapshot".to_owned(),
+            delete_db_snapshot,
+            object_count: 2,
+            snapshot_storage_bytes: 20,
+            downstream_job_count: 0,
+            downstream_result_count: 0,
+            downstream_cache_count: 0,
+            downstream_latest_count: 0,
+            downstream_factorization_count: 0,
+            downstream_artifact_count: 0,
+        }
+    }
+}

--- a/crates/solver-worker/src/storage.rs
+++ b/crates/solver-worker/src/storage.rs
@@ -37,6 +37,12 @@ pub struct ObjectUploadResult {
     pub part_count: Option<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectDeleteOutcome {
+    Deleted,
+    Missing,
+}
+
 #[derive(Debug, Clone)]
 pub struct ObjectStoreUploadError {
     pub stage: &'static str,
@@ -215,6 +221,25 @@ impl ObjectStoreClient {
 
     /// Deletes an object by full object URL.
     pub async fn delete_object_url(&self, object_url: &str) -> anyhow::Result<()> {
+        self.delete_object_url_with_outcome(object_url)
+            .await
+            .map(|_| ())
+    }
+
+    /// Deletes an object by bucket-relative object key.
+    pub async fn delete_object_key(&self, object_key: &str) -> anyhow::Result<ObjectDeleteOutcome> {
+        let key = object_key.trim_start_matches('/');
+        if key.trim().is_empty() {
+            return Err(anyhow::anyhow!("object key must not be empty"));
+        }
+        let object_url = format!("{}/{}/{}", self.endpoint, self.bucket, key);
+        self.delete_object_url_with_outcome(&object_url).await
+    }
+
+    async fn delete_object_url_with_outcome(
+        &self,
+        object_url: &str,
+    ) -> anyhow::Result<ObjectDeleteOutcome> {
         let url = Url::parse(object_url)
             .map_err(|err| anyhow::anyhow!("invalid object URL {object_url}: {err}"))?;
         let host = canonical_host(&url)?;
@@ -246,8 +271,8 @@ impl ObjectStoreClient {
         }
 
         let response = request.send().await?;
-        if response.status().is_success() || response.status() == StatusCode::NOT_FOUND {
-            return Ok(());
+        if let Some(outcome) = object_delete_outcome(response.status()) {
+            return Ok(outcome);
         }
 
         let status = response.status();
@@ -781,6 +806,16 @@ fn sigv4_timestamps() -> (String, String) {
     )
 }
 
+fn object_delete_outcome(status: StatusCode) -> Option<ObjectDeleteOutcome> {
+    if status.is_success() {
+        Some(ObjectDeleteOutcome::Deleted)
+    } else if status == StatusCode::NOT_FOUND {
+        Some(ObjectDeleteOutcome::Missing)
+    } else {
+        None
+    }
+}
+
 fn canonical_host(url: &Url) -> anyhow::Result<String> {
     let host = url
         .host_str()
@@ -866,7 +901,35 @@ fn hmac_sha256_hex(key: &[u8], data: &str) -> anyhow::Result<String> {
 mod tests {
     use reqwest::StatusCode;
 
-    use super::{ObjectStoreUploadError, extract_xml_tag, object_upload_error};
+    use super::{
+        ObjectDeleteOutcome, ObjectStoreUploadError, extract_xml_tag, object_delete_outcome,
+        object_upload_error,
+    };
+
+    #[test]
+    fn delete_treats_success_statuses_as_deleted() {
+        assert_eq!(
+            object_delete_outcome(StatusCode::NO_CONTENT),
+            Some(ObjectDeleteOutcome::Deleted)
+        );
+        assert_eq!(
+            object_delete_outcome(StatusCode::OK),
+            Some(ObjectDeleteOutcome::Deleted)
+        );
+    }
+
+    #[test]
+    fn delete_treats_404_as_successful_missing_object() {
+        assert_eq!(
+            object_delete_outcome(StatusCode::NOT_FOUND),
+            Some(ObjectDeleteOutcome::Missing)
+        );
+    }
+
+    #[test]
+    fn delete_rejects_non_success_statuses() {
+        assert_eq!(object_delete_outcome(StatusCode::FORBIDDEN), None);
+    }
 
     #[test]
     fn extract_xml_tag_reads_s3_error_code() {

--- a/deploy/systemd/snapshot-gc.service
+++ b/deploy/systemd/snapshot-gc.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=TianGong LCA Snapshot Storage GC
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator
+EnvironmentFile=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/.env
+Environment=RUST_LOG=info
+Environment=SNAPSHOT_GC_SNAPSHOT_RETENTION_DAYS=30
+Environment=SNAPSHOT_GC_ORPHAN_RETENTION_DAYS=30
+Environment=SNAPSHOT_GC_MAX_SNAPSHOTS=100
+Environment=SNAPSHOT_GC_MAX_ORPHAN_DIRS=200
+Environment=SNAPSHOT_GC_MAX_BYTES=2147483648
+Environment=SNAPSHOT_GC_BATCH_SIZE=50
+SyslogIdentifier=snapshot_gc
+ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-calculator/target/release/snapshot_gc --execute

--- a/deploy/systemd/snapshot-gc.timer
+++ b/deploy/systemd/snapshot-gc.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly TianGong LCA Snapshot Storage GC
+
+[Timer]
+OnCalendar=Sun 20:30:00 UTC
+RandomizedDelaySec=30m
+Persistent=true
+Unit=snapshot-gc.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-30
-lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
+lastReviewedAt: 2026-05-31
+lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-30
-lastReviewedCommit: bb29be8898df1edba319483fd9d1fd1d3f00114a
+lastReviewedAt: 2026-05-31
+lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -21,8 +21,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 76345d6bb9a17691dd661cfccf5017057c52047e
+lastReviewedAt: 2026-05-31
+lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/scripts/gc_lca_snapshots.sh
+++ b/scripts/gc_lca_snapshots.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ -f .env ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source .env
+  set +a
+fi
+
+exec cargo run -p solver-worker --bin snapshot_gc --release -- "$@"


### PR DESCRIPTION
## Summary

- adds `snapshot_gc` for database-contract-driven snapshot Storage cleanup
- adds object-key delete support with 404 treated as successful missing object
- records dry-run/execute audit rows in `lca_snapshot_gc_runs` / `lca_snapshot_gc_run_items`
- uses PostgreSQL advisory lock so all three calculator worker hosts can install the weekly timer safely
- adds `scripts/gc_lca_snapshots.sh` plus systemd service/timer templates and README rollout notes

## Execution Semantics

- default mode is dry-run; destructive cleanup requires `--execute`
- candidates come from `util.list_lca_snapshot_gc_candidates(...)`
- all Storage objects in a snapshot directory must delete successfully before deleting `public.lca_network_snapshots`
- orphan storage directories delete only Storage objects
- partial object delete failure leaves the DB snapshot row for retry

## Validation

- `cargo check -p solver-worker --bin snapshot_gc`
- `cargo test -p solver-worker snapshot_retention --lib`
- `cargo test -p solver-worker delete_treats --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `make check`
- `cargo run -p solver-worker --bin snapshot_gc -- --database-url postgresql://postgres:postgres@127.0.0.1:55322/postgres`
- `scripts/docpact lint --root . --worktree --mode enforce`

Closes #72

Parent: tiangong-lca/workspace#215
Database contract: tiangong-lca/database-engine#160 / tiangong-lca/database-engine#161
