### PR TITLE
Fix worker_jobs service-role context

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-31"
-lastReviewedCommit: "6244c4cf04ea0b239eb82bb0d3ab7ef7ce554ef5"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "58fadf136fadff7ab70c8466bcb883815ea439f5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: 6244c4cf04ea0b239eb82bb0d3ab7ef7ce554ef5
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 58fadf136fadff7ab70c8466bcb883815ea439f5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/maintenance_enqueue.rs
+++ b/crates/solver-worker/src/bin/maintenance_enqueue.rs
@@ -154,6 +154,9 @@ async fn enqueue_maintenance_job(
 
     let row = solver_worker::pgbouncer_sqlx::query(
         r"
+        WITH _service_role AS (
+          SELECT set_config('request.jwt.claim.role', 'service_role', true)
+        )
         SELECT public.worker_enqueue_job(
           p_job_kind => $1,
           p_payload_json => $2::jsonb,
@@ -167,6 +170,7 @@ async fn enqueue_maintenance_job(
           p_visibility => $10,
           p_max_attempts => $11
         ) AS result
+        FROM _service_role
         ",
     )
     .bind(cli.job_kind.job_kind())

--- a/crates/solver-worker/src/bin/review_submit_gate_runner.rs
+++ b/crates/solver-worker/src/bin/review_submit_gate_runner.rs
@@ -32,17 +32,17 @@ struct Cli {
     #[arg(long, env = "REVIEW_SUBMIT_GATE_WORKER_JOBS", default_value_t = false)]
     worker_jobs: bool,
     #[arg(
-        long,
+        long = "review-submit-gate-worker-id",
         env = "REVIEW_SUBMIT_GATE_WORKER_ID",
         default_value = "review_submit_gate_runner"
     )]
-    worker_id: String,
+    review_submit_gate_worker_id: String,
     #[arg(
-        long,
+        long = "review-submit-gate-worker-lease-seconds",
         env = "REVIEW_SUBMIT_GATE_WORKER_LEASE_SECONDS",
         default_value_t = 900_i32
     )]
-    worker_lease_seconds: i32,
+    review_submit_gate_worker_lease_seconds: i32,
 }
 
 #[tokio::main]
@@ -62,8 +62,8 @@ async fn main() -> anyhow::Result<()> {
             poll_interval,
             max_runs,
             exit_when_idle,
-            worker_id: cli.worker_id,
-            lease_seconds: cli.worker_lease_seconds.max(60),
+            worker_id: cli.review_submit_gate_worker_id,
+            lease_seconds: cli.review_submit_gate_worker_lease_seconds.max(60),
         };
         run_review_submit_gate_worker_jobs_runner(&state, options).await?
     } else {

--- a/crates/solver-worker/src/worker_jobs.rs
+++ b/crates/solver-worker/src/worker_jobs.rs
@@ -230,7 +230,11 @@ pub async fn claim_worker_jobs(
 ) -> anyhow::Result<Vec<WorkerJob>> {
     let row = sqlx::query(
         r"
+        WITH _service_role AS (
+            SELECT set_config('request.jwt.claim.role', 'service_role', true)
+        )
         SELECT public.worker_claim_jobs($1, $2, $3, $4) AS result
+        FROM _service_role
         ",
     )
     .bind(worker_queue)
@@ -259,7 +263,11 @@ pub async fn heartbeat_worker_job(
 ) -> anyhow::Result<()> {
     let row = sqlx::query(
         r"
+        WITH _service_role AS (
+            SELECT set_config('request.jwt.claim.role', 'service_role', true)
+        )
         SELECT public.worker_heartbeat_job($1, $2, $3, $4::double precision::numeric, $5::jsonb, $6) AS result
+        FROM _service_role
         ",
     )
     .bind(job_id)
@@ -283,6 +291,9 @@ pub async fn record_worker_job_result(
 ) -> anyhow::Result<Value> {
     let row = sqlx::query(
         r"
+        WITH _service_role AS (
+            SELECT set_config('request.jwt.claim.role', 'service_role', true)
+        )
         SELECT public.worker_record_job_result(
             $1,
             $2,
@@ -298,6 +309,7 @@ pub async fn record_worker_job_result(
             $12,
             $13
         ) AS result
+        FROM _service_role
         ",
     )
     .bind(job_id)

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 58fadf136fadff7ab70c8466bcb883815ea439f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: ea4c76d2b08934ff243cb6a5d5d84a9df73f67cf
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 58fadf136fadff7ab70c8466bcb883815ea439f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -21,8 +21,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: 6244c4cf04ea0b239eb82bb0d3ab7ef7ce554ef5
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 58fadf136fadff7ab70c8466bcb883815ea439f5
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -74,7 +74,7 @@ worker_jobs once-mode：
 cargo run -p solver-worker --bin review_submit_gate_runner -- \
   --worker-jobs \
   --once \
-  --worker-id review_submit_gate_runner
+  --review-submit-gate-worker-id review_submit_gate_runner
 ```
 
 runner 读取 `DATABASE_URL` / `CONN` 与 S3 artifact 环境变量。legacy 模式直接访问 `public.dataset_review_submit_gate_runs`。它只领取：


### PR DESCRIPTION
Closes #82

## Summary
- set `request.jwt.claim.role=service_role` inside calculator-side `worker_jobs` RPC statements
- apply the same scoped context to maintenance enqueue jobs
- keep the role setting local to each SQL statement so pooled connections do not rely on startup options

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p solver-worker worker_jobs`
- `cargo test -p solver-worker --bin maintenance_enqueue`
- `cargo check -p solver-worker --bin maintenance_worker --bin maintenance_enqueue --bin review_submit_gate_runner --bin package_worker --bin solver-worker`
