### PR TITLE
test: cover result_gc retention query contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "83cfd124cab6ecaac0a01424ef36d00542a8fac6"
+lastReviewedCommit: "07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 83cfd124cab6ecaac0a01424ef36d00542a8fac6
+lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/result_gc.rs
+++ b/crates/solver-worker/src/bin/result_gc.rs
@@ -59,6 +59,36 @@ struct GcTotals {
     batches: i64,
 }
 
+const GC_CANDIDATE_QUERY: &str = r"
+        WITH ranked AS (
+          SELECT
+            r.id AS result_id,
+            r.artifact_url,
+            r.created_at,
+            r.expires_at,
+            r.is_pinned,
+            ROW_NUMBER() OVER (
+              PARTITION BY j.requested_by, j.snapshot_id, COALESCE(j.request_key, j.id::text)
+              ORDER BY r.created_at DESC, r.id DESC
+            ) AS rn,
+            rc.result_id AS active_cache_result_id
+          FROM public.lca_results AS r
+          JOIN public.lca_jobs AS j
+            ON j.id = r.job_id
+          LEFT JOIN public.lca_result_cache AS rc
+            ON rc.result_id = r.id
+           AND rc.status IN ('pending', 'running', 'ready')
+        )
+        SELECT result_id, artifact_url
+        FROM ranked
+        WHERE expires_at < now()
+          AND is_pinned = false
+          AND active_cache_result_id IS NULL
+          AND rn > 1
+        ORDER BY created_at ASC
+        LIMIT $1
+        ";
+
 fn required<'a>(value: Option<&'a str>, name: &str) -> anyhow::Result<&'a str> {
     value.ok_or_else(|| anyhow::anyhow!("missing {name}"))
 }
@@ -180,40 +210,10 @@ async fn fetch_gc_candidates(
     pool: &sqlx::PgPool,
     batch_size: i64,
 ) -> anyhow::Result<Vec<GcCandidate>> {
-    let rows = sqlx::query(
-        r"
-        WITH ranked AS (
-          SELECT
-            r.id AS result_id,
-            r.artifact_url,
-            r.created_at,
-            r.expires_at,
-            r.is_pinned,
-            ROW_NUMBER() OVER (
-              PARTITION BY j.requested_by, j.snapshot_id, COALESCE(j.request_key, j.id::text)
-              ORDER BY r.created_at DESC, r.id DESC
-            ) AS rn,
-            rc.result_id AS active_cache_result_id
-          FROM public.lca_results AS r
-          JOIN public.lca_jobs AS j
-            ON j.id = r.job_id
-          LEFT JOIN public.lca_result_cache AS rc
-            ON rc.result_id = r.id
-           AND rc.status IN ('pending', 'running', 'ready')
-        )
-        SELECT result_id, artifact_url
-        FROM ranked
-        WHERE expires_at < now()
-          AND is_pinned = false
-          AND active_cache_result_id IS NULL
-          AND rn > 1
-        ORDER BY created_at ASC
-        LIMIT $1
-        ",
-    )
-    .bind(batch_size)
-    .fetch_all(pool)
-    .await?;
+    let rows = sqlx::query(GC_CANDIDATE_QUERY)
+        .bind(batch_size)
+        .fetch_all(pool)
+        .await?;
 
     rows.into_iter()
         .map(|r| {
@@ -232,4 +232,49 @@ async fn delete_results_by_ids(pool: &sqlx::PgPool, ids: Vec<Uuid>) -> anyhow::R
         .execute(pool)
         .await?;
     Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GC_CANDIDATE_QUERY;
+
+    #[test]
+    fn candidate_query_uses_db_owned_retention_contract() {
+        assert!(
+            GC_CANDIDATE_QUERY.contains("r.expires_at"),
+            "result_gc must select the DB-owned lca_results.expires_at retention field"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("r.is_pinned"),
+            "result_gc must select the DB-owned lca_results.is_pinned protection field"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("expires_at < now()"),
+            "result_gc candidates must require an expired retention deadline"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("is_pinned = false"),
+            "result_gc candidates must exclude pinned results"
+        );
+    }
+
+    #[test]
+    fn candidate_query_protects_active_and_latest_results() {
+        assert!(
+            GC_CANDIDATE_QUERY.contains("rc.status IN ('pending', 'running', 'ready')"),
+            "result_gc must keep results referenced by active cache rows"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("active_cache_result_id IS NULL"),
+            "result_gc must exclude active cache result ids"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("ROW_NUMBER() OVER"),
+            "result_gc must rank results within each request partition"
+        );
+        assert!(
+            GC_CANDIDATE_QUERY.contains("rn > 1"),
+            "result_gc must keep the latest result for a request partition"
+        );
+    }
 }

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 85b34dbdc910346055ce2188918f0d7d6332f361
+lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,7 +38,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 83cfd124cab6ecaac0a01424ef36d00542a8fac6
+lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,7 +22,7 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 85b34dbdc910346055ce2188918f0d7d6332f361
+lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
## Summary
- Extract the `result_gc` candidate SQL into a named constant so its retention contract can be tested directly.
- Add focused unit tests that assert the query still uses the DB-owned `lca_results.expires_at` / `is_pinned` contract, excludes active cache rows, and keeps the latest result in each request partition.
- Record docpact review evidence for the runtime-contract docs that already document this behavior.

Refs #92
Refs tiangong-lca/workspace#242
Refs tiangong-lca/database-engine#177

## Validation
- `cargo test -p solver-worker --bin result_gc`
- `cargo test -p solver-worker --bin maintenance_worker`
- `cargo test -p solver-worker --bin maintenance_enqueue`
- `cargo check -p solver-worker --bin result_gc --bin maintenance_worker --bin maintenance_enqueue`
- `cargo fmt --all -- --check`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `make check`
- `scripts/docpact lint --root . --worktree --mode enforce`
- `scripts/docpact validate-config --root . --strict`

## Dev Proof
- After tiangong-lca/database-engine#177 merged, Supabase dev project `fotofiyqnuyvgtotswie` has migration `20260602091430` applied and `lca_results.expires_at` / `is_pinned` plus retention indexes present.
- Fresh dev `lca.result_gc` dry-run worker job `ffdfe0ee-3199-4248-ab1a-95edc9deb741` completed via `worker_jobs` with `result_schema_version=lca.result_gc.result.v1`, `exitCode=0`, and summary `dry_run=true`.
