### PR TITLE
Fix worker DB session observability and bounded snapshot queries

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-04"
-lastReviewedCommit: "d49e96f7c6fdf6c2d83531bebe68236a5d9919c1"
+lastReviewedAt: "2026-06-10"
+lastReviewedCommit: "4546fb8fff034c84cd1b699cb049345b70eabe16"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,7 @@ BUILD_SNAPSHOT_LOCK_POLL_MS="5000"
 # ------------------------------------------------------------------------------
 SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS="4"
 SNAPSHOT_BUILDER_DB_ACQUIRE_TIMEOUT_SECONDS="30"
+SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS="900"
 
 # ------------------------------------------------------------------------------
 # Review-submit gate runner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: d49e96f7c6fdf6c2d83531bebe68236a5d9919c1
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 - `BUILD_SNAPSHOT_LOCK_POLL_MS`（等待 `build_snapshot` 并发槽位时的轮询间隔，默认 `5000`）
 - `SNAPSHOT_BUILDER_DB_MAX_CONNECTIONS`（`snapshot_builder` 子进程连接池上限，默认 `4`）
 - `SNAPSHOT_BUILDER_DB_ACQUIRE_TIMEOUT_SECONDS`（`snapshot_builder` 获取连接超时，默认 `30`）
+- `SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS`（`snapshot_builder` 单条 SQL statement timeout，默认 `900`；设置为 `0` 表示关闭，仅建议用于人工恢复或排障）
 - `REVIEW_SUBMIT_GATE_POLL_MS`（review-submit gate runner 轮询间隔，默认 `1000`）
 - `REVIEW_SUBMIT_GATE_MAX_RUNS`（可选；设置后 runner 处理指定条数后退出）
 - `REVIEW_SUBMIT_GATE_STALE_RUNNING_SECONDS`（runner 重新领取 stale `running` gate run 的阈值，默认 `21600`）
@@ -319,6 +320,8 @@ Supabase 连接说明：
 - 推荐生产配置：主业务连接保留在 session/direct 连接或 session pooler；`QUEUE_DATABASE_URL` 使用 Supabase transaction pooler（通常是 `:6543`）。
 - 运行时 SQLx 查询使用非持久 prepared statement，以避免后端复用导致 `sqlx_s_*` 语句名冲突；高频 pgmq polling / archive 操作使用 `raw_sql` 简单查询协议与受限队列名字面量，避免 6543 transaction pooler 不支持 prepared statement 协议导致空轮询失败。
 - `build_snapshot` 全局并发控制使用 transaction-level advisory lock，适配 transaction pooler；生产环境仍建议保持 `BUILD_SNAPSHOT_MAX_CONCURRENCY=1`。
+- worker 入口会设置明确的 PostgreSQL `application_name`，例如 `solver-worker`、`snapshot-builder`、`package-worker`、`package-gc`、`snapshot-gc`、`result-gc`、`maintenance-worker` 和 `maintenance-enqueue`，用于在 `pg_stat_activity` 中归因长连接或长事务。
+- 如果 `snapshot_builder` 查询超过 `SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS`，当前任务应失败并释放连接；短期可调大该值恢复生产，但稳定超时应进入后续查询优化，而不是长期设置为 `0`。
 
 对象存储（snapshot builder / solver-worker / result_gc 必需；`package_gc --execute` 删除 package artifact 对象时也必需）：
 

--- a/crates/solver-worker/src/bin/maintenance_enqueue.rs
+++ b/crates/solver-worker/src/bin/maintenance_enqueue.rs
@@ -1,7 +1,10 @@
 use chrono::{DateTime, Utc};
 use clap::{Parser, ValueEnum};
 use serde_json::{Map, Value, json};
-use solver_worker::pgbouncer_sqlx::{Row, postgres::PgPoolOptions};
+use solver_worker::{
+    db_pool::{APP_MAINTENANCE_ENQUEUE, WorkerDbPoolOptions},
+    pgbouncer_sqlx::Row,
+};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -124,7 +127,7 @@ impl Cli {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let pool = PgPoolOptions::new()
+    let pool = WorkerDbPoolOptions::new(APP_MAINTENANCE_ENQUEUE)
         .max_connections(1)
         .connect(cli.resolved_database_url()?)
         .await?;

--- a/crates/solver-worker/src/bin/maintenance_worker.rs
+++ b/crates/solver-worker/src/bin/maintenance_worker.rs
@@ -3,7 +3,8 @@ use std::{path::PathBuf, process::Command, time::Duration};
 use clap::Parser;
 use serde_json::{Map, Value, json};
 use solver_worker::{
-    pgbouncer_sqlx::{self as sqlx, Row, postgres::PgPoolOptions},
+    db_pool::{APP_MAINTENANCE_WORKER, WorkerDbPoolOptions},
+    pgbouncer_sqlx::{self as sqlx, Row},
     worker_jobs::{
         WorkerJob, WorkerJobResult, claim_worker_jobs, heartbeat_worker_job,
         record_worker_job_result,
@@ -120,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = Cli::parse();
-    let pool = PgPoolOptions::new()
+    let pool = WorkerDbPoolOptions::new(APP_MAINTENANCE_WORKER)
         .max_connections(cli.db_max_connections.max(1))
         .connect(cli.resolved_database_url()?)
         .await?;

--- a/crates/solver-worker/src/bin/package_gc.rs
+++ b/crates/solver-worker/src/bin/package_gc.rs
@@ -1,12 +1,13 @@
 use clap::Parser;
 use solver_worker::{
+    db_pool::{APP_PACKAGE_GC, WorkerDbPoolOptions},
     package_retention::{
         PackageArtifactGcCandidate, delete_package_jobs_after_object_gc,
         delete_stale_package_request_cache_rows, fetch_package_artifact_gc_candidates,
         fetch_package_retention_summary, mark_package_artifact_deleted,
         record_package_artifact_gc_error, validate_retention_days,
     },
-    pgbouncer_sqlx::{self as sqlx, postgres::PgPoolOptions},
+    pgbouncer_sqlx::{self as sqlx},
     storage::ObjectStoreClient,
 };
 
@@ -150,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
     )?;
 
     let db_url = resolve_db_url(&cli)?;
-    let pool = PgPoolOptions::new()
+    let pool = WorkerDbPoolOptions::new(APP_PACKAGE_GC)
         .max_connections(4)
         .connect(db_url)
         .await?;

--- a/crates/solver-worker/src/bin/package_worker.rs
+++ b/crates/solver-worker/src/bin/package_worker.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value, json};
 use solver_worker::{
     config::AppConfig,
     db::{AppState, archive_queue_message, read_one_queue_message},
+    db_pool::{APP_PACKAGE_WORKER, APP_PACKAGE_WORKER_QUEUE},
     package_db::{
         PackageJobContinuation, extract_package_job_id, extract_package_job_id_from_raw_payload,
         handle_package_job_payload, handle_package_job_payload_once,
@@ -90,7 +91,14 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = PackageWorkerCli::parse();
-    let state = Arc::new(AppState::new(&cli.app).await?);
+    let state = Arc::new(
+        AppState::new_with_application_names(
+            &cli.app,
+            APP_PACKAGE_WORKER,
+            APP_PACKAGE_WORKER_QUEUE,
+        )
+        .await?,
+    );
 
     match cli.package_queue_backend {
         PackageQueueBackend::Pgmq => {

--- a/crates/solver-worker/src/bin/result_gc.rs
+++ b/crates/solver-worker/src/bin/result_gc.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
-use solver_worker::pgbouncer_sqlx::{self as sqlx, Row, postgres::PgPoolOptions};
+use solver_worker::db_pool::{APP_RESULT_GC, WorkerDbPoolOptions};
+use solver_worker::pgbouncer_sqlx::{self as sqlx, Row};
 use solver_worker::storage::ObjectStoreClient;
 use uuid::Uuid;
 
@@ -181,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
     let access_key = required(cli.s3_access_key_id.as_deref(), "S3_ACCESS_KEY_ID")?;
     let secret = required(cli.s3_secret_access_key.as_deref(), "S3_SECRET_ACCESS_KEY")?;
 
-    let pool = PgPoolOptions::new()
+    let pool = WorkerDbPoolOptions::new(APP_RESULT_GC)
         .max_connections(4)
         .connect(db_url)
         .await?;

--- a/crates/solver-worker/src/bin/review_submit_gate_runner.rs
+++ b/crates/solver-worker/src/bin/review_submit_gate_runner.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use solver_worker::{
     config::AppConfig,
     db::AppState,
+    db_pool::{APP_REVIEW_SUBMIT_GATE_RUNNER, APP_REVIEW_SUBMIT_GATE_RUNNER_QUEUE},
     review_submit_gate_runner::{
         ReviewSubmitGateRunnerOptions, ReviewSubmitGateWorkerJobsOptions,
         run_review_submit_gate_runner, run_review_submit_gate_worker_jobs_runner,
@@ -52,7 +53,12 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = Cli::parse();
-    let state = AppState::new(&cli.config).await?;
+    let state = AppState::new_with_application_names(
+        &cli.config,
+        APP_REVIEW_SUBMIT_GATE_RUNNER,
+        APP_REVIEW_SUBMIT_GATE_RUNNER_QUEUE,
+    )
+    .await?;
     let poll_interval = Duration::from_millis(cli.poll_ms.max(100));
     let max_runs = cli.max_runs.or_else(|| cli.once.then_some(1));
     let exit_when_idle = cli.once;

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -32,10 +32,11 @@ use solver_worker::compiled_graph::{
     CompiledProviderResolutionStrategy, CompiledProviderSupplyRegionSource, CompiledReferenceStats,
     CompiledTechnosphereEdge,
 };
+use solver_worker::db_pool::{APP_SNAPSHOT_BUILDER, WorkerDbPoolOptions};
 use solver_worker::graph_types::{
     RequestRootProcess, ResolvedScopeProcess, ScopeProcessPartition, SnapshotSelectionMode,
 };
-use solver_worker::pgbouncer_sqlx::{self as sqlx, PgPool, Row, postgres::PgPoolOptions};
+use solver_worker::pgbouncer_sqlx::{self as sqlx, PgPool, Row};
 use solver_worker::readiness::{
     MatrixReadinessInput, MatrixReadinessPolicy, MatrixReadinessReport, verify_matrix_readiness,
 };
@@ -56,6 +57,8 @@ use uuid::Uuid;
 const REVIEW_SUBMIT_OVERLAY_ARTIFACT_PURPOSE: &str = "review_submit_overlay";
 const REVIEW_SUBMIT_BASELINE_ARTIFACT_PURPOSE: &str = "review_submit_baseline";
 const REVIEW_SUBMIT_BASELINE_TTL_SECONDS: i64 = 30 * 24 * 60 * 60;
+const DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS: u64 = 900;
+const SLOW_QUERY_LOG_THRESHOLD: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Parser)]
 #[command(name = "snapshot-builder")]
@@ -76,6 +79,12 @@ struct Cli {
         default_value_t = 30_u64
     )]
     db_acquire_timeout_seconds: u64,
+    #[arg(
+        long,
+        env = "SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS",
+        default_value_t = DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS
+    )]
+    db_statement_timeout_seconds: u64,
     #[arg(long, env = "S3_ENDPOINT")]
     s3_endpoint: Option<String>,
     #[arg(long, env = "S3_REGION")]
@@ -421,6 +430,14 @@ impl AllocationMode {
     }
 }
 
+fn snapshot_db_statement_timeout(seconds: u64) -> Option<Duration> {
+    if seconds == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(seconds))
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let total_started = Instant::now();
@@ -434,19 +451,29 @@ async fn main() -> anyhow::Result<()> {
         .as_deref()
         .or(cli.conn.as_deref())
         .ok_or_else(|| anyhow::anyhow!("missing DB connection: set DATABASE_URL or CONN"))?;
-    let pool = PgPoolOptions::new()
+    let statement_timeout = snapshot_db_statement_timeout(cli.db_statement_timeout_seconds);
+    if statement_timeout.is_none() {
+        eprintln!(
+            "[warn] SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS=0 disables statement_timeout; use only for targeted manual recovery"
+        );
+    }
+    let pool_options = WorkerDbPoolOptions::new(APP_SNAPSHOT_BUILDER)
         .max_connections(cli.db_max_connections.max(1))
         .acquire_timeout(Duration::from_secs(cli.db_acquire_timeout_seconds.max(1)))
-        .after_connect(|conn, _meta| {
-            Box::pin(async move {
-                sqlx::query("SET statement_timeout = 0")
-                    .execute(conn)
-                    .await?;
-                Ok(())
-            })
-        })
-        .connect(db_url)
-        .await?;
+        .statement_timeout(statement_timeout);
+    println!(
+        "[db_pool] application_name={} max_connections={} min_connections={} acquire_timeout_seconds={} idle_timeout_seconds={} max_lifetime_seconds={} statement_timeout_seconds={}",
+        pool_options.application_name(),
+        pool_options.max_connections_value(),
+        pool_options.min_connections_value(),
+        pool_options.acquire_timeout_value().as_secs(),
+        pool_options.idle_timeout_value().as_secs(),
+        pool_options.max_lifetime_value().as_secs(),
+        pool_options
+            .statement_timeout_value()
+            .map_or(0, |duration| duration.as_secs())
+    );
+    let pool = pool_options.connect(db_url).await?;
 
     let requested_snapshot_id = cli.snapshot_id;
     let (all_states, state_codes, process_states_label) =
@@ -4510,6 +4537,7 @@ async fn fetch_processes(
     state_codes: &[i32],
     include_user_id: Option<Uuid>,
 ) -> anyhow::Result<Vec<ProcessRow>> {
+    let query_started = Instant::now();
     let rows = if all_states {
         sqlx::query(
             r#"
@@ -4550,6 +4578,20 @@ async fn fetch_processes(
         .await?
     };
 
+    let elapsed = query_started.elapsed();
+    let level = if elapsed >= SLOW_QUERY_LOG_THRESHOLD {
+        "warn"
+    } else {
+        "info"
+    };
+    println!(
+        "[query] level={level} name=snapshot.fetch_processes all_states={all_states} state_code_count={} include_user_id={} rows={} elapsed_seconds={:.3}",
+        state_codes.len(),
+        include_user_id.is_some(),
+        rows.len(),
+        elapsed.as_secs_f64()
+    );
+
     let mut out = Vec::with_capacity(rows.len());
     for row in rows {
         out.push(ProcessRow {
@@ -4571,6 +4613,7 @@ async fn fetch_flow_meta(
     if flow_candidates.is_empty() {
         return Ok(HashMap::new());
     }
+    let query_started = Instant::now();
     let candidate_ids = flow_candidates.iter().copied().collect::<Vec<_>>();
     let rows = sqlx::query(
         r#"
@@ -4583,6 +4626,21 @@ async fn fetch_flow_meta(
     .bind(&candidate_ids)
     .fetch_all(pool)
     .await?;
+
+    let elapsed = query_started.elapsed();
+    let missing_count = candidate_ids.len().saturating_sub(rows.len());
+    let level = if elapsed >= SLOW_QUERY_LOG_THRESHOLD {
+        "warn"
+    } else {
+        "info"
+    };
+    println!(
+        "[query] level={level} name=snapshot.fetch_flow_meta candidate_count={} rows={} missing_count={} elapsed_seconds={:.3}",
+        candidate_ids.len(),
+        rows.len(),
+        missing_count,
+        elapsed.as_secs_f64()
+    );
 
     let mut out = HashMap::<Uuid, Value>::new();
     for row in rows {
@@ -5724,7 +5782,8 @@ fn write_provider_rule_replay_report_files(
 #[cfg(test)]
 mod tests {
     use super::{
-        AllocationFractionState, AllocationMode, Cli, ExchangeDirection, MethodSelection,
+        AllocationFractionState, AllocationMode, Cli,
+        DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS, ExchangeDirection, MethodSelection,
         MultiProviderDecision, NormalizationMode, ParsedExchange, ProcessMeta, ProcessRow,
         ProviderRule, add_technosphere_edge, assemble_sparse_payload, attach_artifact_lifecycle,
         biosphere_gross_value, build_review_submit_overlay_graph, candidate_count_bucket_label,
@@ -5732,7 +5791,8 @@ mod tests {
         normalize_request_roots, parse_process_annual_supply_or_production_volume,
         parse_process_states, parse_provider_rule_list, resolve_allocation_fraction,
         resolve_multi_provider, resolve_process_selection, resolve_reference_normalization,
-        review_submit_root_dependency_fingerprint, summarize_matching_diagnostics, time_score,
+        review_submit_root_dependency_fingerprint, snapshot_db_statement_timeout,
+        summarize_matching_diagnostics, time_score,
     };
     use chrono::Utc;
     use clap::Parser;
@@ -5758,6 +5818,19 @@ mod tests {
             delta <= 1e-12,
             "expected {expected}, got {actual}, delta={delta}"
         );
+    }
+
+    #[test]
+    fn snapshot_db_statement_timeout_defaults_to_bounded_duration() {
+        assert_eq!(
+            snapshot_db_statement_timeout(DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS),
+            Some(std::time::Duration::from_secs(900))
+        );
+    }
+
+    #[test]
+    fn snapshot_db_statement_timeout_allows_explicit_unbounded_recovery_mode() {
+        assert_eq!(snapshot_db_statement_timeout(0), None);
     }
 
     #[test]

--- a/crates/solver-worker/src/bin/snapshot_gc.rs
+++ b/crates/solver-worker/src/bin/snapshot_gc.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use serde_json::json;
 use solver_worker::{
-    pgbouncer_sqlx::{self as sqlx, postgres::PgPoolOptions},
+    db_pool::{APP_SNAPSHOT_GC, WorkerDbPoolOptions},
+    pgbouncer_sqlx::{self as sqlx},
     snapshot_retention::{
         DEFAULT_BATCH_SIZE, DEFAULT_MAX_BYTES, DEFAULT_MAX_ORPHAN_DIRS, DEFAULT_MAX_SNAPSHOTS,
         DEFAULT_ORPHAN_RETENTION_DAYS, DEFAULT_SNAPSHOT_RETENTION_DAYS, ObjectDeleteStatus,
@@ -176,7 +177,7 @@ async fn main() -> anyhow::Result<()> {
     validate_positive_i32(cli.max_orphan_dirs, "SNAPSHOT_GC_MAX_ORPHAN_DIRS")?;
 
     let db_url = resolve_db_url(&cli)?;
-    let pool = PgPoolOptions::new()
+    let pool = WorkerDbPoolOptions::new(APP_SNAPSHOT_GC)
         .max_connections(4)
         .connect(db_url)
         .await?;

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -5,9 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::pgbouncer_sqlx::{
-    self as sqlx, PgPool, Postgres, Row, Transaction, postgres::PgPoolOptions,
-};
+use crate::pgbouncer_sqlx::{self as sqlx, PgPool, Postgres, Row, Transaction};
 use serde_json::{Map, Value};
 use solver_core::{
     ModelSparseData, NumericOptions, PrepareResult, SolveBatchResult, SolveComputationTiming,
@@ -24,6 +22,7 @@ use crate::{
     },
     config::AppConfig,
     contribution_path::{ContributionPathArtifact, analyze_contribution_path},
+    db_pool::{APP_SOLVER_WORKER, APP_SOLVER_WORKER_QUEUE, WorkerDbPoolOptions},
     snapshot_artifacts::{DecodedSnapshotArtifact, decode_snapshot_artifact},
     snapshot_index::{SnapshotIndexDocument, derive_snapshot_index_url},
     storage::ObjectStoreClient,
@@ -79,6 +78,7 @@ struct BuildSnapshotLockGuard {
     slot: u32,
     wait_sec: f64,
     max_concurrency: u32,
+    acquired_at: Instant,
 }
 
 impl BuildSnapshotLockGuard {
@@ -89,6 +89,7 @@ impl BuildSnapshotLockGuard {
             "max_concurrency": self.max_concurrency,
             "slot": self.slot,
             "wait_sec": self.wait_sec,
+            "hold_sec": self.acquired_at.elapsed().as_secs_f64(),
         })
     }
 
@@ -97,7 +98,17 @@ impl BuildSnapshotLockGuard {
             return Ok(());
         };
 
+        let hold_sec = self.acquired_at.elapsed().as_secs_f64();
         tx.commit().await?;
+        info!(
+            lock_key = self.key,
+            slot = self.slot,
+            max_concurrency = self.max_concurrency,
+            wait_sec = self.wait_sec,
+            hold_sec,
+            release_path = "explicit",
+            "released build_snapshot transaction advisory lock"
+        );
         Ok(())
     }
 }
@@ -105,9 +116,14 @@ impl BuildSnapshotLockGuard {
 impl Drop for BuildSnapshotLockGuard {
     fn drop(&mut self) {
         if self.tx.is_some() {
+            let hold_sec = self.acquired_at.elapsed().as_secs_f64();
             warn!(
                 lock_key = self.key,
                 slot = self.slot,
+                max_concurrency = self.max_concurrency,
+                wait_sec = self.wait_sec,
+                hold_sec,
+                release_path = "drop",
                 "build_snapshot transaction advisory lock guard dropped before explicit release"
             );
         }
@@ -117,7 +133,17 @@ impl Drop for BuildSnapshotLockGuard {
 impl AppState {
     /// Creates app state with DB pool and required object storage.
     pub async fn new(config: &AppConfig) -> anyhow::Result<Self> {
+        Self::new_with_application_names(config, APP_SOLVER_WORKER, APP_SOLVER_WORKER_QUEUE).await
+    }
+
+    /// Creates app state with explicit DB application names for the main and queue pools.
+    pub async fn new_with_application_names(
+        config: &AppConfig,
+        application_name: &str,
+        queue_application_name: &str,
+    ) -> anyhow::Result<Self> {
         let pool = connect_pool(
+            application_name,
             config.resolved_database_url()?,
             config.db_max_connections(),
             config.db_min_connections(),
@@ -127,6 +153,7 @@ impl AppState {
 
         let queue_pool = if config.has_explicit_queue_database_url() {
             connect_pool(
+                queue_application_name,
                 config.resolved_queue_database_url()?,
                 config.queue_db_max_connections(),
                 config.queue_db_min_connections(),
@@ -177,20 +204,18 @@ impl AppState {
 }
 
 async fn connect_pool(
+    application_name: &str,
     database_url: &str,
     max_connections: u32,
     min_connections: u32,
     acquire_timeout: Duration,
 ) -> anyhow::Result<PgPool> {
-    Ok(PgPoolOptions::new()
+    WorkerDbPoolOptions::new(application_name)
         .max_connections(max_connections)
         .min_connections(min_connections)
         .acquire_timeout(acquire_timeout)
-        .idle_timeout(Duration::from_mins(5))
-        .max_lifetime(Duration::from_mins(30))
-        .test_before_acquire(true)
         .connect(database_url)
-        .await?)
+        .await
 }
 
 async fn acquire_build_snapshot_lock(
@@ -225,6 +250,7 @@ async fn acquire_build_snapshot_lock(
                     slot,
                     wait_sec,
                     max_concurrency,
+                    acquired_at: Instant::now(),
                 });
             }
             tx.rollback().await?;

--- a/crates/solver-worker/src/db_pool.rs
+++ b/crates/solver-worker/src/db_pool.rs
@@ -1,0 +1,206 @@
+use std::time::Duration;
+
+use crate::pgbouncer_sqlx::{self as sqlx, PgPool, postgres::PgPoolOptions};
+
+pub const APP_SOLVER_WORKER: &str = "solver-worker";
+pub const APP_SOLVER_WORKER_QUEUE: &str = "solver-worker-queue";
+pub const APP_SNAPSHOT_BUILDER: &str = "snapshot-builder";
+pub const APP_PACKAGE_WORKER: &str = "package-worker";
+pub const APP_PACKAGE_WORKER_QUEUE: &str = "package-worker-queue";
+pub const APP_REVIEW_SUBMIT_GATE_RUNNER: &str = "review-submit-gate-runner";
+pub const APP_REVIEW_SUBMIT_GATE_RUNNER_QUEUE: &str = "review-submit-gate-runner-queue";
+pub const APP_PACKAGE_GC: &str = "package-gc";
+pub const APP_SNAPSHOT_GC: &str = "snapshot-gc";
+pub const APP_RESULT_GC: &str = "result-gc";
+pub const APP_MAINTENANCE_WORKER: &str = "maintenance-worker";
+pub const APP_MAINTENANCE_ENQUEUE: &str = "maintenance-enqueue";
+
+const POSTGRES_APPLICATION_NAME_MAX_BYTES: usize = 63;
+const DEFAULT_MAX_CONNECTIONS: u32 = 4;
+const DEFAULT_MIN_CONNECTIONS: u32 = 0;
+const DEFAULT_ACQUIRE_TIMEOUT_SECONDS: u64 = 30;
+const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 5 * 60;
+const DEFAULT_MAX_LIFETIME_SECONDS: u64 = 30 * 60;
+
+#[derive(Debug, Clone)]
+pub struct WorkerDbPoolOptions {
+    application_name: String,
+    max_connections: u32,
+    min_connections: u32,
+    acquire_timeout: Duration,
+    idle_timeout: Duration,
+    max_lifetime: Duration,
+    statement_timeout: Option<Duration>,
+}
+
+impl WorkerDbPoolOptions {
+    #[must_use]
+    pub fn new(application_name: impl AsRef<str>) -> Self {
+        Self {
+            application_name: normalize_application_name(
+                application_name.as_ref(),
+                APP_SOLVER_WORKER,
+            ),
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            min_connections: DEFAULT_MIN_CONNECTIONS,
+            acquire_timeout: Duration::from_secs(DEFAULT_ACQUIRE_TIMEOUT_SECONDS),
+            idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECONDS),
+            max_lifetime: Duration::from_secs(DEFAULT_MAX_LIFETIME_SECONDS),
+            statement_timeout: None,
+        }
+    }
+
+    #[must_use]
+    pub fn max_connections(mut self, max_connections: u32) -> Self {
+        self.max_connections = max_connections.max(1);
+        self
+    }
+
+    #[must_use]
+    pub fn min_connections(mut self, min_connections: u32) -> Self {
+        self.min_connections = min_connections.min(self.max_connections);
+        self
+    }
+
+    #[must_use]
+    pub fn acquire_timeout(mut self, acquire_timeout: Duration) -> Self {
+        self.acquire_timeout = acquire_timeout.max(Duration::from_secs(1));
+        self
+    }
+
+    #[must_use]
+    pub fn statement_timeout(mut self, statement_timeout: Option<Duration>) -> Self {
+        self.statement_timeout = statement_timeout;
+        self
+    }
+
+    #[must_use]
+    pub fn application_name(&self) -> &str {
+        &self.application_name
+    }
+
+    #[must_use]
+    pub fn max_connections_value(&self) -> u32 {
+        self.max_connections
+    }
+
+    #[must_use]
+    pub fn min_connections_value(&self) -> u32 {
+        self.min_connections
+    }
+
+    #[must_use]
+    pub fn acquire_timeout_value(&self) -> Duration {
+        self.acquire_timeout
+    }
+
+    #[must_use]
+    pub fn idle_timeout_value(&self) -> Duration {
+        self.idle_timeout
+    }
+
+    #[must_use]
+    pub fn max_lifetime_value(&self) -> Duration {
+        self.max_lifetime
+    }
+
+    #[must_use]
+    pub fn statement_timeout_value(&self) -> Option<Duration> {
+        self.statement_timeout
+    }
+
+    pub async fn connect(self, database_url: &str) -> anyhow::Result<PgPool> {
+        let application_name = self.application_name.clone();
+        let statement_timeout_ms = self.statement_timeout.map(duration_millis_text);
+
+        Ok(PgPoolOptions::new()
+            .max_connections(self.max_connections)
+            .min_connections(self.min_connections)
+            .acquire_timeout(self.acquire_timeout)
+            .idle_timeout(self.idle_timeout)
+            .max_lifetime(self.max_lifetime)
+            .test_before_acquire(true)
+            .after_connect(move |conn, _meta| {
+                let application_name = application_name.clone();
+                let statement_timeout_ms = statement_timeout_ms.clone();
+                Box::pin(async move {
+                    sqlx::query("SELECT set_config('application_name', $1, false)")
+                        .bind(application_name.as_str())
+                        .execute(&mut *conn)
+                        .await?;
+                    if let Some(statement_timeout_ms) = statement_timeout_ms.as_deref() {
+                        sqlx::query("SELECT set_config('statement_timeout', $1, false)")
+                            .bind(statement_timeout_ms)
+                            .execute(&mut *conn)
+                            .await?;
+                    }
+                    Ok(())
+                })
+            })
+            .connect(database_url)
+            .await?)
+    }
+}
+
+#[must_use]
+pub fn normalize_application_name(value: &str, fallback: &str) -> String {
+    let trimmed = value.trim();
+    let candidate = if trimmed.is_empty() {
+        fallback.trim()
+    } else {
+        trimmed
+    };
+
+    truncate_to_bytes(candidate, POSTGRES_APPLICATION_NAME_MAX_BYTES)
+}
+
+#[must_use]
+pub fn duration_millis_text(duration: Duration) -> String {
+    duration.as_millis().to_string()
+}
+
+fn truncate_to_bytes(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+
+    let mut out = String::new();
+    for ch in value.chars() {
+        if out.len() + ch.len_utf8() > max_bytes {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{duration_millis_text, normalize_application_name};
+
+    #[test]
+    fn normalize_application_name_uses_fallback_for_blank_values() {
+        assert_eq!(
+            normalize_application_name("   ", "solver-worker"),
+            "solver-worker"
+        );
+    }
+
+    #[test]
+    fn normalize_application_name_limits_postgres_name_length() {
+        let name = normalize_application_name(
+            "snapshot-builder-with-a-very-long-deployment-suffix-that-exceeds-the-limit",
+            "solver-worker",
+        );
+        assert!(name.len() <= 63);
+        assert!(name.starts_with("snapshot-builder"));
+    }
+
+    #[test]
+    fn duration_millis_text_formats_postgres_statement_timeout_value() {
+        assert_eq!(duration_millis_text(Duration::from_secs(900)), "900000");
+        assert_eq!(duration_millis_text(Duration::from_millis(250)), "250");
+    }
+}

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -16,6 +16,7 @@ pub mod compiled_graph;
 pub mod config;
 pub mod contribution_path;
 pub mod db;
+pub mod db_pool;
 pub mod graph_types;
 pub mod http;
 pub mod package_artifacts;

--- a/crates/solver-worker/src/package_execution.rs
+++ b/crates/solver-worker/src/package_execution.rs
@@ -14,6 +14,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use tempfile::{Builder, NamedTempFile, TempDir};
+use tracing::{info, warn};
 use uuid::Uuid;
 use zip::{CompressionMethod, ZipArchive, ZipWriter, write::SimpleFileOptions};
 
@@ -45,6 +46,7 @@ const EXPORT_FINALIZE_FETCH_BATCH_SIZE: usize = 256;
 const EXPORT_ITEM_INSERT_CHUNK_SIZE: usize = 500;
 const EXPORT_BATCHES_PER_PASS: usize = 6;
 const EXPORT_PASS_TIME_BUDGET: Duration = Duration::from_secs(20);
+const EXPORT_SEED_SCAN_SLOW_BATCH_THRESHOLD: Duration = Duration::from_secs(5);
 
 const SUPPORTED_PACKAGE_TABLES: [PackageRootTable; 7] = [
     PackageRootTable::Contacts,
@@ -925,6 +927,8 @@ async fn fetch_scope_seed_scan_batch_after_cursor(
     after_version: Option<&str>,
     limit: i64,
 ) -> anyhow::Result<Vec<PackageSeedScanEntry>> {
+    let query_started = Instant::now();
+    let has_cursor = after_id.is_some();
     let mut builder = QueryBuilder::<Postgres>::new(scope_seed_scan_select_prefix_sql(table));
     builder.push(" WHERE ");
     match scope {
@@ -965,6 +969,28 @@ async fn fetch_scope_seed_scan_batch_after_cursor(
         .push(" ORDER BY id ASC, version ASC LIMIT ")
         .push_bind(limit);
     let rows = builder.build().persistent(false).fetch_all(pool).await?;
+    let elapsed = query_started.elapsed();
+    if elapsed >= EXPORT_SEED_SCAN_SLOW_BATCH_THRESHOLD {
+        warn!(
+            ?table,
+            ?scope,
+            limit,
+            has_cursor,
+            rows = rows.len(),
+            elapsed_sec = elapsed.as_secs_f64(),
+            "package seed scan batch completed slowly"
+        );
+    } else {
+        info!(
+            ?table,
+            ?scope,
+            limit,
+            has_cursor,
+            rows = rows.len(),
+            elapsed_sec = elapsed.as_secs_f64(),
+            "package seed scan batch completed"
+        );
+    }
 
     rows.iter()
         .map(|row| parse_seed_scan_entry_row(table, row))
@@ -1225,6 +1251,7 @@ async fn process_seed_scan_pass(
     mut state: ExportSeedScanState,
     pass_started: Instant,
 ) -> anyhow::Result<ExportSeedScanResult> {
+    let seed_scan_pass_started = Instant::now();
     let mut pass_scanned_count = 0usize;
     let mut pass_discovered_count = 0usize;
 
@@ -1295,6 +1322,27 @@ async fn process_seed_scan_pass(
 
     if state.table_index >= SUPPORTED_PACKAGE_TABLES.len() {
         state.complete = true;
+    }
+
+    let elapsed = seed_scan_pass_started.elapsed();
+    if elapsed >= EXPORT_PASS_TIME_BUDGET {
+        warn!(
+            scanned_count = pass_scanned_count,
+            discovered_count = pass_discovered_count,
+            table_index = state.table_index,
+            complete = state.complete,
+            elapsed_sec = elapsed.as_secs_f64(),
+            "package seed scan pass consumed time budget"
+        );
+    } else {
+        info!(
+            scanned_count = pass_scanned_count,
+            discovered_count = pass_discovered_count,
+            table_index = state.table_index,
+            complete = state.complete,
+            elapsed_sec = elapsed.as_secs_f64(),
+            "package seed scan pass completed"
+        );
     }
 
     Ok(ExportSeedScanResult {

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -142,6 +142,7 @@ Result artifacts are persisted through the worker and supporting runtime storage
 - Runtime SQLx queries use non-persistent prepared statements so the worker does not reuse named prepared statements across PostgreSQL session reuse boundaries. High-frequency pgmq polling and archive operations use the queue-only pool plus `raw_sql` with validated queue-name literals so they can run through the simple query protocol on Supabase's 6543 transaction pooler without moving compute/package/snapshot queries onto that pooler.
 - Queue enqueue and protected writes stay on service-side runtime paths guarded by existing RLS and `service_role` boundaries.
 - Worker and snapshot paths require DB connectivity plus the required S3 env set before runtime validation is meaningful.
+- Worker-owned DB pools set explicit PostgreSQL `application_name` values for observability. `snapshot_builder` also applies `SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS` as a bounded statement timeout; `0` is reserved for targeted manual recovery, not normal production operation.
 
 ## Runtime SQL Boundary
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -37,8 +37,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: d49e96f7c6fdf6c2d83531bebe68236a5d9919c1
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: fe323a1f2d884e7f812e9ebd66d5a32146e80766
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: fe323a1f2d884e7f812e9ebd66d5a32146e80766
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -21,8 +21,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -23,8 +23,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: fe323a1f2d884e7f812e9ebd66d5a32146e80766
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -29,8 +29,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-06-04
-lastReviewedCommit: d49e96f7c6fdf6c2d83531bebe68236a5d9919c1
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - .docpact/config.yaml
   - crates/solver-worker/**
   - docs/agents/repo-validation.md
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 07c46d2f1c5a01b702caa5c7b52d5fd6480a2fa6
+lastReviewedAt: 2026-06-10
+lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #103

## Summary
- Add a shared worker DB pool helper that sets explicit PostgreSQL application_name values, idle timeout, max lifetime, acquire timeout, and connection health checks for worker-owned pools.
- Replace snapshot_builder's unconditional SET statement_timeout = 0 with SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS, defaulting to 900 seconds and warning when explicitly disabled.
- Add lightweight timing/row-count telemetry for snapshot process/flow reads, package seed scan batches, and build_snapshot advisory-lock hold duration.

## Key Decisions
- This PR keeps snapshot artifact semantics and package export behavior unchanged; it only adds attribution, bounds, and observability for the first-phase #103 scope.
- The existing transaction-level build_snapshot advisory lock is retained; the PR logs wait/hold time so a later #102 phase can decide whether the lock model must change.

## Validation
- cargo test -p solver-worker
- cargo fmt --all -- --check
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- make check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --worktree --mode enforce

## Risks / Rollback
- If a production snapshot query legitimately exceeds the default 900 second timeout, operators can temporarily raise SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS or set it to 0 for targeted recovery, then follow up with query-shape optimization under #102.

## Follow-ups
- Run a representative live snapshot/package job in an environment with DB/S3 credentials and inspect pg_stat_activity for application_name attribution and absence of unexpected idle-in-transaction sessions.

## Workspace Integration
- Worker is an M1 repo; this PR targets main. After merge, lca-workspace must deliberately bump the tiangong-lca-worker submodule pointer before delivery is complete.