### PR TITLE
fix: resume package seed scan from worker_jobs diagnostics

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-23"
-lastReviewedCommit: "aaba7d6b2664619e66d7c5296545b011483298a0"
+lastReviewedAt: "2026-07-02"
+lastReviewedCommit: "5f753c3ca145909b032a05d36d4664eb0dc6feab"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-23
-lastReviewedCommit: aaba7d6b2664619e66d7c5296545b011483298a0
+lastReviewedAt: 2026-07-02
+lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/package_execution.rs
+++ b/crates/solver-worker/src/package_execution.rs
@@ -26,8 +26,8 @@ use crate::{
     },
     package_db::{PackageArtifactInsert, insert_package_artifact},
     package_types::{
-        PACKAGE_ZIP_ARTIFACT_FORMAT, PackageArtifactKind, PackageExportScope, PackageRootRef,
-        PackageRootTable,
+        PACKAGE_EXPORT_WORKER_JOB_KIND, PACKAGE_WORKER_QUEUE, PACKAGE_ZIP_ARTIFACT_FORMAT,
+        PackageArtifactKind, PackageExportScope, PackageRootRef, PackageRootTable,
     },
 };
 
@@ -658,24 +658,122 @@ pub fn clear_runtime_export_traversal_cache(job_id: Uuid) {
 }
 
 async fn fetch_package_job_diagnostics(pool: &PgPool, job_id: Uuid) -> anyhow::Result<Value> {
+    let legacy_diagnostics = fetch_legacy_package_job_diagnostics(pool, job_id).await?;
+    if legacy_diagnostics
+        .as_ref()
+        .is_some_and(diagnostics_has_export_seed_scan_resume_state)
+    {
+        return Ok(legacy_diagnostics.unwrap_or_else(|| json!({})));
+    }
+
+    let worker_jobs_diagnostics = fetch_worker_package_job_diagnostics(pool, job_id).await?;
+    Ok(select_package_job_diagnostics_for_resume(
+        legacy_diagnostics,
+        worker_jobs_diagnostics,
+    ))
+}
+
+async fn fetch_legacy_package_job_diagnostics(
+    pool: &PgPool,
+    job_id: Uuid,
+) -> anyhow::Result<Option<Value>> {
     let result = sqlx::query(
         r"
         SELECT diagnostics
-        FROM lca_package_jobs
+        FROM public.lca_package_jobs
         WHERE id = $1
         ",
     )
     .bind(job_id)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await;
     match result {
-        Ok(row) => Ok(row
-            .try_get::<Option<Value>, _>("diagnostics")?
-            .unwrap_or_else(|| json!({}))),
-        Err(sqlx::Error::RowNotFound) => Ok(json!({})),
-        Err(err) if is_undefined_table(&err) => Ok(json!({})),
+        Ok(Some(row)) => Ok(Some(
+            row.try_get::<Option<Value>, _>("diagnostics")?
+                .unwrap_or_else(|| json!({})),
+        )),
+        Ok(None) => Ok(None),
+        Err(err) if is_undefined_table(&err) => Ok(None),
         Err(err) => Err(err.into()),
     }
+}
+
+async fn fetch_worker_package_job_diagnostics(
+    pool: &PgPool,
+    job_id: Uuid,
+) -> anyhow::Result<Option<Value>> {
+    let job_id_text = job_id.to_string();
+    let result = sqlx::query(
+        r"
+        SELECT diagnostics
+        FROM public.worker_jobs
+        WHERE worker_queue = $1
+          AND job_kind = $2
+          AND (
+              subject_id = $3
+              OR payload_json->>'job_id' = $4
+              OR payload_json->>'jobId' = $4
+              OR payload_json->>'packageJobId' = $4
+          )
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT 1
+        ",
+    )
+    .bind(PACKAGE_WORKER_QUEUE)
+    .bind(PACKAGE_EXPORT_WORKER_JOB_KIND)
+    .bind(job_id)
+    .bind(job_id_text)
+    .fetch_optional(pool)
+    .await;
+
+    match result {
+        Ok(Some(row)) => Ok(Some(
+            row.try_get::<Option<Value>, _>("diagnostics")?
+                .unwrap_or_else(|| json!({})),
+        )),
+        Ok(None) => Ok(None),
+        Err(err) if is_undefined_table(&err) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn select_package_job_diagnostics_for_resume(
+    legacy_diagnostics: Option<Value>,
+    worker_jobs_diagnostics: Option<Value>,
+) -> Value {
+    if legacy_diagnostics
+        .as_ref()
+        .is_some_and(diagnostics_has_export_seed_scan_resume_state)
+    {
+        return legacy_diagnostics.unwrap_or_else(|| json!({}));
+    }
+
+    if worker_jobs_diagnostics
+        .as_ref()
+        .is_some_and(diagnostics_has_export_seed_scan_resume_state)
+    {
+        return worker_jobs_diagnostics.unwrap_or_else(|| json!({}));
+    }
+
+    legacy_diagnostics
+        .or(worker_jobs_diagnostics)
+        .unwrap_or_else(|| json!({}))
+}
+
+fn diagnostics_has_export_seed_scan_resume_state(diagnostics: &Value) -> bool {
+    if diagnostics
+        .get("seed_scan_complete")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    diagnostics
+        .get("seed_scan")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<ExportSeedScanState>(value).ok())
+        .is_some()
 }
 
 fn load_export_seed_scan_state(diagnostics: &Value) -> ExportSeedScanState {
@@ -4289,7 +4387,8 @@ mod tests {
         parse_tidas_validation_report, partition_conflicts_from_rows, plan_reference_resolution,
         preflight_import_validation, remember_root_in_traversal_cache,
         report_from_validation_failure, resolve_exact_or_latest_roots,
-        resolve_referenced_entries_from_rows, store_runtime_export_traversal_cache,
+        resolve_referenced_entries_from_rows, select_package_job_diagnostics_for_resume,
+        store_runtime_export_traversal_cache,
     };
     use crate::package_types::{PackageExportScope, PackageRootRef, PackageRootTable};
 
@@ -4735,6 +4834,35 @@ mod tests {
 
         clear_runtime_export_traversal_cache(job_id);
         assert!(load_runtime_export_traversal_cache(job_id).is_none());
+    }
+
+    #[test]
+    fn package_diagnostics_falls_back_to_worker_jobs_seed_scan_when_legacy_missing() {
+        let last_id = Uuid::from_u128(16);
+        let worker_jobs_diagnostics = json!({
+            "phase": "export_package",
+            "stage": "scan_seed_roots",
+            "seed_scan_complete": false,
+            "seed_scan": {
+                "table_index": 2,
+                "last_id": last_id,
+                "last_version": "01.01.000",
+                "scanned_seed_count": 512,
+                "discovered_external_count": 7,
+                "complete": false
+            }
+        });
+
+        let selected =
+            select_package_job_diagnostics_for_resume(None, Some(worker_jobs_diagnostics));
+        let state = super::load_export_seed_scan_state(&selected);
+
+        assert_eq!(state.table_index, 2);
+        assert_eq!(state.last_id, Some(last_id));
+        assert_eq!(state.last_version.as_deref(), Some("01.01.000"));
+        assert_eq!(state.scanned_seed_count, 512);
+        assert_eq!(state.discovered_external_count, 7);
+        assert!(!state.complete);
     }
 
     #[test]

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: b3ea058f0cda4824c65976aac7a64d005028039d
+lastReviewedAt: 2026-07-02
+lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-23
-lastReviewedCommit: aaba7d6b2664619e66d7c5296545b011483298a0
+lastReviewedAt: 2026-07-02
+lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,8 +22,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-06-10
-lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
+lastReviewedAt: 2026-07-02
+lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -255,6 +255,7 @@ legacy pgmq/debug 路径语义：
 
 - legacy `export_package` 多 pass 通过重新写入 `pgmq.lca_package_jobs` 继续执行；
 - `worker_jobs` 模式下，worker runtime 不再把 continuation 写回 legacy pgmq，而是在同一个 worker job lease 内连续执行 export pass，并在 pass 间 heartbeat；
+- `worker_jobs` 模式下，长导出的 seed-scan continuation state 以 `worker_jobs.diagnostics.seed_scan` 为 canonical resume source；当 optional `lca_package_jobs` 缺失或没有可用 seed-scan diagnostics 时，worker 必须从最新匹配 `tidas.export_package` worker job diagnostics 恢复游标；
 - 因此 `PACKAGE_WORKER_JOBS_LEASE_SECONDS` 必须大于正常单 pass 时间，长导出仍应依赖 pass 间 heartbeat 续租。
 
 ## 9. 权限边界


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#111

## Summary
- Resume TIDAS package export seed-scan state from worker_jobs diagnostics when the optional legacy lca_package_jobs row is missing or lacks seed-scan state.
- Keep legacy lca_package_jobs diagnostics as the preferred compatibility source when it contains a seed-scan cursor.

## Key Decisions
- Query the latest matching tidas.export_package worker job by package compatibility job id through subject_id first, with payload alias fallbacks for older enqueue shapes.
- Treat worker_jobs.diagnostics.seed_scan as the canonical continuation state for worker_jobs-only package exports.

## Validation
- cargo test -p solver-worker package_diagnostics_falls_back_to_worker_jobs_seed_scan_when_legacy_missing
- cargo test -p solver-worker --bin package_worker
- cargo test -p solver-worker package_worker
- cargo check -p solver-worker --bin package_worker
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- make check
- scripts/docpact validate-config --root . --strict --format json
- scripts/docpact lint --root . --worktree --mode enforce --format json --output /tmp/worker-issue111-docpact.json

## Risks / Rollback
- Low runtime risk: fallback is only used when legacy diagnostics do not already contain seed-scan resume state, and worker_jobs absence still degrades to the previous empty diagnostics behavior.

## Follow-ups
- Deploy the worker fix, then allow affected running/stale worker_jobs package exports to be reclaimed or rerun normally so the next pass can read the saved worker_jobs seed_scan cursor.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after this worker PR merges.