### PR TITLE
fix: preflight package artifact upload limits

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-02"
-lastReviewedCommit: "5f753c3ca145909b032a05d36d4664eb0dc6feab"
+lastReviewedCommit: "68360a0331788281afbb15d58d694b4c4e686b78"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@
 # S3_SECRET_ACCESS_KEY=""
 # S3_SESSION_TOKEN=""
 S3_PREFIX="lca-results"
+# Optional local guard matching the storage backend max-file-limit. Set this
+# below the backend limit to fail oversized artifacts before multipart upload.
+# S3_MAX_UPLOAD_BYTES="536870912"
 
 # PROCESS_FLOW_GRAPH_CACHE_BUCKET purpose: optional dedicated S3 bucket for
 # process-flow graph cache objects. If unset, the builder writes to S3_BUCKET.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-02
-lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
+lastReviewedCommit: 68360a0331788281afbb15d58d694b4c4e686b78
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -338,8 +338,9 @@ Supabase 连接说明：
 - `S3_SECRET_ACCESS_KEY`
 - `S3_SESSION_TOKEN`（可选，临时凭证时使用）
 - `S3_PREFIX`（默认 `lca-results`）
+- `S3_MAX_UPLOAD_BYTES`（可选，本地 preflight 上限；应与对象存储 max-file-limit 对齐）
 
-说明：结果持久化已改为 S3-only。`S3_ENDPOINT/S3_REGION/S3_BUCKET/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY` 必须同时提供。上传请求使用 SigV4 签名认证。
+说明：结果持久化已改为 S3-only。`S3_ENDPOINT/S3_REGION/S3_BUCKET/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY` 必须同时提供。上传请求使用 SigV4 签名认证。若对象存储平台设置了文件大小上限，生产环境应先在平台侧调高该 max-file-limit；`S3_MAX_UPLOAD_BYTES` 只是在 worker 侧提前阻断明显超限的 artifact，避免 multipart 上传到中途才返回 `EntityTooLarge`。
 
 ## 6. 启动与检查
 

--- a/crates/solver-worker/src/bin/package_worker.rs
+++ b/crates/solver-worker/src/bin/package_worker.rs
@@ -882,6 +882,7 @@ fn build_package_job_failure_diagnostics(
             "error": err.to_string(),
             "upload_mode": upload_err.upload_mode,
             "artifact_byte_size": upload_err.object_byte_size,
+            "max_upload_bytes": upload_err.max_upload_bytes,
             "http_status": upload_err.status_code,
             "storage_error_code": upload_err.s3_error_code,
             "part_number": upload_err.part_number,
@@ -913,13 +914,18 @@ fn package_request_cache_error_message(payload: &PackageJobPayload, err: &anyhow
             PackageJobPayload::ExportPackage { .. } => "export package",
             PackageJobPayload::ImportPackage { .. } => "package artifact",
         };
+        let max_hint = upload_err
+            .max_upload_bytes
+            .map(|size| format!(" max_upload_bytes={size}."))
+            .unwrap_or_default();
         return format!(
-            "The {operation} exceeded the object storage upload size limit; upload mode={}, stage={}, artifact_byte_size={}.",
+            "The {operation} exceeded the object storage upload size limit; upload mode={}, stage={}, artifact_byte_size={}.{}",
             upload_err.upload_mode,
             upload_err.stage,
             upload_err
                 .object_byte_size
-                .map_or_else(|| "unknown".to_owned(), |size| size.to_string())
+                .map_or_else(|| "unknown".to_owned(), |size| size.to_string()),
+            max_hint
         );
     }
 
@@ -1143,6 +1149,7 @@ mod tests {
             status_code: Some(StatusCode::PAYLOAD_TOO_LARGE.as_u16()),
             s3_error_code: Some("EntityTooLarge".to_owned()),
             object_byte_size: Some(12),
+            max_upload_bytes: None,
             part_number: None,
             part_count: None,
             message: "object upload failed".to_owned(),
@@ -1165,12 +1172,15 @@ mod tests {
             status_code: Some(StatusCode::PAYLOAD_TOO_LARGE.as_u16()),
             s3_error_code: Some("EntityTooLarge".to_owned()),
             object_byte_size: Some(34),
+            max_upload_bytes: Some(128),
             part_number: None,
             part_count: None,
             message: "object upload failed".to_owned(),
         });
 
         assert_eq!(package_request_cache_error_code(&err), "artifact_too_large");
-        assert!(package_request_cache_error_message(&payload, &err).contains("upload size limit"));
+        let message = package_request_cache_error_message(&payload, &err);
+        assert!(message.contains("upload size limit"));
+        assert!(message.contains("max_upload_bytes=128"));
     }
 }

--- a/crates/solver-worker/src/config.rs
+++ b/crates/solver-worker/src/config.rs
@@ -123,6 +123,9 @@ pub struct AppConfig {
     /// Object key prefix under the bucket.
     #[arg(long, env = "S3_PREFIX", default_value = "lca-results")]
     pub s3_prefix: String,
+    /// Optional local preflight upload limit matching the storage max-file-limit.
+    #[arg(long, env = "S3_MAX_UPLOAD_BYTES")]
+    pub s3_max_upload_bytes: Option<u64>,
 }
 
 impl AppConfig {
@@ -247,6 +250,12 @@ impl AppConfig {
         Duration::from_millis(self.build_snapshot_lock_poll_ms.max(100))
     }
 
+    /// Optional local upload-size guard for object-storage writes.
+    #[must_use]
+    pub fn s3_max_upload_bytes(&self) -> Option<u64> {
+        self.s3_max_upload_bytes
+    }
+
     /// Parsed http socket addr.
     pub fn http_socket_addr(&self) -> anyhow::Result<SocketAddr> {
         SocketAddr::from_str(&self.http_addr)
@@ -349,6 +358,19 @@ mod tests {
             "postgres://pooler.example.local/app"
         );
         assert!(config.has_explicit_queue_database_url());
+    }
+
+    #[test]
+    fn parses_optional_s3_max_upload_bytes() {
+        let config = AppConfig::parse_from([
+            "solver-worker",
+            "--database-url",
+            "postgres://example.local/app",
+            "--s3-max-upload-bytes",
+            "209715200",
+        ]);
+
+        assert_eq!(config.s3_max_upload_bytes(), Some(209_715_200));
     }
 
     #[test]

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -183,7 +183,7 @@ impl AppState {
         let secret_access_key = config.s3_secret_access_key.as_deref().ok_or_else(|| {
             anyhow::anyhow!("missing S3_SECRET_ACCESS_KEY: result persistence is S3-only")
         })?;
-        let object_store = ObjectStoreClient::new(
+        let object_store = ObjectStoreClient::new_with_upload_limit(
             endpoint,
             region,
             bucket,
@@ -191,6 +191,7 @@ impl AppState {
             access_key_id,
             secret_access_key,
             config.s3_session_token.clone(),
+            config.s3_max_upload_bytes(),
         )?;
 
         Ok(Self {

--- a/crates/solver-worker/src/storage.rs
+++ b/crates/solver-worker/src/storage.rs
@@ -27,6 +27,7 @@ pub struct ObjectStoreClient {
     access_key_id: String,
     secret_access_key: String,
     session_token: Option<String>,
+    max_upload_bytes: Option<u64>,
     client: reqwest::Client,
 }
 
@@ -50,6 +51,7 @@ pub struct ObjectStoreUploadError {
     pub status_code: Option<u16>,
     pub s3_error_code: Option<String>,
     pub object_byte_size: Option<u64>,
+    pub max_upload_bytes: Option<u64>,
     pub part_number: Option<usize>,
     pub part_count: Option<usize>,
     pub message: String,
@@ -92,6 +94,30 @@ impl ObjectStoreClient {
         secret_access_key: &str,
         session_token: Option<String>,
     ) -> anyhow::Result<Self> {
+        Self::new_with_upload_limit(
+            endpoint,
+            region,
+            bucket,
+            prefix,
+            access_key_id,
+            secret_access_key,
+            session_token,
+            None,
+        )
+    }
+
+    /// Creates storage client from config with an optional local upload-size limit.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_upload_limit(
+        endpoint: &str,
+        region: &str,
+        bucket: &str,
+        prefix: &str,
+        access_key_id: &str,
+        secret_access_key: &str,
+        session_token: Option<String>,
+        max_upload_bytes: Option<u64>,
+    ) -> anyhow::Result<Self> {
         let endpoint = endpoint.trim_end_matches('/').to_owned();
         let region = region.trim().to_owned();
         let bucket = bucket.trim().to_owned();
@@ -113,6 +139,11 @@ impl ObjectStoreClient {
         if secret_access_key.is_empty() {
             return Err(anyhow::anyhow!("S3 secret access key must not be empty"));
         }
+        if max_upload_bytes == Some(0) {
+            return Err(anyhow::anyhow!(
+                "S3 max upload bytes must be greater than 0"
+            ));
+        }
 
         Ok(Self {
             endpoint,
@@ -122,6 +153,7 @@ impl ObjectStoreClient {
             access_key_id,
             secret_access_key,
             session_token,
+            max_upload_bytes,
             client: reqwest::Client::new(),
         })
     }
@@ -218,6 +250,12 @@ impl ObjectStoreClient {
         artifact_byte_size: u64,
     ) -> anyhow::Result<ObjectUploadResult> {
         let key = self.package_object_key(job_id, suffix, extension);
+        let upload_mode = if artifact_byte_size < MULTIPART_UPLOAD_THRESHOLD_BYTES {
+            "single_put"
+        } else {
+            "multipart"
+        };
+        self.ensure_upload_size_allowed(upload_mode, Some(artifact_byte_size))?;
         if artifact_byte_size < MULTIPART_UPLOAD_THRESHOLD_BYTES {
             let bytes = std::fs::read(file_path)?;
             return self
@@ -354,6 +392,29 @@ impl ObjectStoreClient {
         }
     }
 
+    fn ensure_upload_size_allowed(
+        &self,
+        upload_mode: &'static str,
+        object_byte_size: Option<u64>,
+    ) -> anyhow::Result<()> {
+        let Some(max_upload_bytes) = self.max_upload_bytes else {
+            return Ok(());
+        };
+        let Some(object_byte_size) = object_byte_size else {
+            return Ok(());
+        };
+        if object_byte_size <= max_upload_bytes {
+            return Ok(());
+        }
+
+        Err(object_upload_size_limit_error(
+            "preflight_upload_size",
+            upload_mode,
+            object_byte_size,
+            max_upload_bytes,
+        ))
+    }
+
     async fn upload_object(
         &self,
         key: &str,
@@ -368,6 +429,7 @@ impl ObjectStoreClient {
 
         let payload_hash = sha256_hex(bytes.as_slice());
         let payload_size = object_byte_size.or_else(|| u64::try_from(bytes.len()).ok());
+        self.ensure_upload_size_allowed("single_put", payload_size)?;
         let (amz_date, date_stamp) = sigv4_timestamps();
         let signed = self.sign_request(
             &Method::PUT,
@@ -425,6 +487,7 @@ impl ObjectStoreClient {
         file_path: &Path,
         object_byte_size: u64,
     ) -> anyhow::Result<ObjectUploadResult> {
+        self.ensure_upload_size_allowed("multipart", Some(object_byte_size))?;
         let upload_id = self
             .create_multipart_upload(key, content_type, object_byte_size)
             .await?;
@@ -881,10 +944,32 @@ fn object_upload_error(
         status_code: Some(status.as_u16()),
         s3_error_code,
         object_byte_size,
+        max_upload_bytes: None,
         part_number,
         part_count,
         message: format!(
             "object upload failed stage={stage} upload_mode={upload_mode} status={status}{code_hint}{size_hint}{part_hint}{auth_hint} body={body_preview}"
+        ),
+    })
+}
+
+fn object_upload_size_limit_error(
+    stage: &'static str,
+    upload_mode: &'static str,
+    object_byte_size: u64,
+    max_upload_bytes: u64,
+) -> anyhow::Error {
+    anyhow::Error::new(ObjectStoreUploadError {
+        stage,
+        upload_mode,
+        status_code: None,
+        s3_error_code: Some("EntityTooLarge".to_owned()),
+        object_byte_size: Some(object_byte_size),
+        max_upload_bytes: Some(max_upload_bytes),
+        part_number: None,
+        part_count: None,
+        message: format!(
+            "object upload rejected before network upload stage={stage} upload_mode={upload_mode} object_byte_size={object_byte_size} max_upload_bytes={max_upload_bytes}; raise the storage max-file-limit or set S3_MAX_UPLOAD_BYTES above the expected artifact size"
         ),
     })
 }
@@ -909,11 +994,15 @@ fn hmac_sha256_hex(key: &[u8], data: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use reqwest::StatusCode;
+    use tempfile::NamedTempFile;
+    use uuid::Uuid;
 
     use super::{
-        ObjectDeleteOutcome, ObjectStoreUploadError, extract_xml_tag, object_delete_outcome,
-        object_upload_error,
+        MULTIPART_UPLOAD_THRESHOLD_BYTES, ObjectDeleteOutcome, ObjectStoreClient,
+        ObjectStoreUploadError, extract_xml_tag, object_delete_outcome, object_upload_error,
     };
 
     #[test]
@@ -964,6 +1053,53 @@ mod tests {
         let upload_err = err
             .downcast_ref::<ObjectStoreUploadError>()
             .expect("downcast upload error");
+        assert!(upload_err.is_oversize());
+        assert_eq!(upload_err.error_code(), "artifact_too_large");
+    }
+
+    #[tokio::test]
+    async fn package_file_upload_rejects_configured_oversize_before_network_upload() {
+        let mut file = NamedTempFile::new().expect("temp file");
+        file.write_all(b"header").expect("write file header");
+        let artifact_byte_size = MULTIPART_UPLOAD_THRESHOLD_BYTES + 1;
+        file.as_file()
+            .set_len(artifact_byte_size)
+            .expect("set sparse file length");
+
+        let client = ObjectStoreClient::new_with_upload_limit(
+            "https://storage.example.test",
+            "auto",
+            "lca-results",
+            "lca-results",
+            "access-key",
+            "secret-key",
+            None,
+            Some(MULTIPART_UPLOAD_THRESHOLD_BYTES),
+        )
+        .expect("client");
+
+        let err = client
+            .upload_package_artifact_file(
+                Uuid::nil(),
+                "export-package",
+                "zip",
+                "application/zip",
+                file.path(),
+                artifact_byte_size,
+            )
+            .await
+            .expect_err("configured upload limit should reject oversized package artifact");
+        let upload_err = err
+            .downcast_ref::<ObjectStoreUploadError>()
+            .expect("downcast upload error");
+
+        assert_eq!(upload_err.stage, "preflight_upload_size");
+        assert_eq!(upload_err.upload_mode, "multipart");
+        assert_eq!(upload_err.object_byte_size, Some(artifact_byte_size));
+        assert_eq!(
+            upload_err.max_upload_bytes,
+            Some(MULTIPART_UPLOAD_THRESHOLD_BYTES)
+        );
         assert!(upload_err.is_oversize());
         assert_eq!(upload_err.error_code(), "artifact_too_large");
     }

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-02
-lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
+lastReviewedCommit: 68360a0331788281afbb15d58d694b4c4e686b78
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -39,7 +39,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-02
-lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
+lastReviewedCommit: 68360a0331788281afbb15d58d694b4c4e686b78
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -23,7 +23,7 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-07-02
-lastReviewedCommit: 5f753c3ca145909b032a05d36d4664eb0dc6feab
+lastReviewedCommit: 68360a0331788281afbb15d58d694b4c4e686b78
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -164,6 +164,12 @@ payload 必须仍携带有效 `job_id` compatibility UUID，因为 `lca_package_
 - ZIP: `application/zip`
 - report: `application/json`
 
+### 7.0.1 大 artifact 上传上限
+
+package worker 通过 S3-compatible object storage 写入 export ZIP / report artifact。对象存储平台的真实 max-file-limit 必须大于预期 package artifact 体积；例如全量 `open_data` export 可能达到数百 MB。若生产后端限制低于 artifact 体积，运维应优先调高平台侧 max-file-limit。
+
+`S3_MAX_UPLOAD_BYTES` 是 worker 本地 preflight guard，应配置为与平台侧 max-file-limit 一致或略低。设置后，worker 会在 single PUT 或 multipart upload 发起前检查 artifact byte size；超限时使用 `artifact_too_large` 失败诊断，并保留 `upload_mode`、`stage=preflight_upload_size`、`artifact_byte_size`、`max_upload_bytes` 和 `storage_error_code=EntityTooLarge`，避免 multipart 上传到中途才失败。
+
 ### 7.1 Artifact retention / GC 契约
 
 package artifact 必须带或刷新 `expires_at`：


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#113

## Summary
- Add an optional S3_MAX_UPLOAD_BYTES runtime guard so oversized package artifacts fail before single PUT or multipart upload starts.
- Surface max_upload_bytes in package worker diagnostics and request-cache error messages for artifact_too_large failures.
- Document the operational requirement to align the worker guard with the object-storage max-file-limit.

## Key Decisions
- Keep the fix in the worker object-store path so package export, request-cache diagnostics, and worker_jobs failure projection share one error type.
- Treat S3_MAX_UPLOAD_BYTES as a local preflight guard; production still needs the storage platform max-file-limit raised when large open_data exports should succeed.

## Validation
- make check
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --worktree --mode enforce

## Risks / Rollback
- Low runtime risk: no behavior changes unless S3_MAX_UPLOAD_BYTES is configured or an existing upload fails with ObjectStoreUploadError.

## Follow-ups
- After deploy/config, retry the failed open_data request-cache row or enqueue a fresh open_data export and confirm artifact rows are ready.

## Workspace Integration
- Requires later lca-workspace submodule pointer bump after merge.