### PR TITLE
feat: persist canonical calculation bundles

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-15"
-lastReviewedCommit: "19c4ddbf18a8792c939341ba97ab8393112b7be3"
+lastReviewedAt: "2026-07-16"
+lastReviewedCommit: "31f2bb4af9a73c39e548d9a0d8390ace92647ad5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "31f2bb4af9a73c39e548d9a0d8390ace92647ad5"
+lastReviewedAt: "2026-07-17"
+lastReviewedCommit: "7822f8988e0702faa745c0e97509f851450d81e7"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: 19c4ddbf18a8792c939341ba97ab8393112b7be3
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 7822f8988e0702faa745c0e97509f851450d81e7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ related:
 - 已切换为结果 S3-only：
   - 所有 `solve` 结果统一上传对象存储（HDF5）
   - `lca_results` 仅存 artifact 元数据 + diagnostics（不存 inline payload）
+- `solve_all_unit` 同时生成 canonical `tiangong.calculation-bundle.v1`：
+  - 固定 256-process deterministic gzip NDJSON chunks，保存 exact quantitative reference、direct provider edge、directional LCI 和 reviewed 25-method LCIA
+  - 只在单个 artifact chunk 内临时保留 `x`，不跨 chunk 聚合完整 G/LCI；sidecars 先上传，content-addressed manifest 最后上传
 - 已支持 snapshot artifact-first：
   - builder 直接生成 `M/B/C` 并上传 `HDF5`
   - worker 优先从 `lca_snapshot_artifacts` 下载 artifact，失败才回退到旧 `lca_*_entries` 读取

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -34,12 +34,14 @@ use solver_worker::calculation_evidence::{
     validate_calculation_evidence, validate_public_owner_draft_build_request,
 };
 use solver_worker::compiled_graph::{
-    CompiledAllocationStats, CompiledBiosphereEdge, CompiledEdgePartition, CompiledFlow,
-    CompiledFlowKind, CompiledGraph, CompiledMatchingStats, CompiledProcess,
-    CompiledProviderAllocation, CompiledProviderCandidate, CompiledProviderCandidateEligibility,
-    CompiledProviderDecision, CompiledProviderDecisionKind, CompiledProviderFailureReason,
-    CompiledProviderGeographyTier, CompiledProviderOutput, CompiledProviderOutputAllocationState,
-    CompiledProviderResolutionStrategy, CompiledProviderSupplyRegionSource, CompiledReferenceStats,
+    CompiledAllocationStats, CompiledBiosphereEdge, CompiledEdgePartition,
+    CompiledExchangeDirection, CompiledFlow, CompiledFlowKind, CompiledGraph,
+    CompiledMatchingStats, CompiledProcess, CompiledProviderAllocation, CompiledProviderCandidate,
+    CompiledProviderCandidateEligibility, CompiledProviderDecision, CompiledProviderDecisionKind,
+    CompiledProviderFailureReason, CompiledProviderGeographyTier, CompiledProviderOutput,
+    CompiledProviderOutputAllocationState, CompiledProviderResolutionStrategy,
+    CompiledProviderSupplyRegionSource, CompiledReferenceStats, CompiledReleaseEvidence,
+    CompiledReleaseInventoryExchange, CompiledReleaseProcess, CompiledReleaseTechnosphereEdge,
     CompiledTechnosphereEdge,
 };
 use solver_worker::db_pool::{APP_SNAPSHOT_BUILDER, WorkerDbPoolOptions};
@@ -235,6 +237,12 @@ struct FlowRow {
 }
 
 #[derive(Debug, Clone)]
+struct FlowReleaseMetadata {
+    version: String,
+    reference_unit: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 struct MethodRow {
     id: Uuid,
     version: String,
@@ -276,6 +284,8 @@ struct ParsedExchange {
     is_reference_exchange: bool,
     amount: Option<f64>,
     allocation_state: AllocationFractionState,
+    allocation_fraction: f64,
+    allocation_target_internal_id: String,
     location: Option<String>,
 }
 
@@ -1806,6 +1816,7 @@ fn empty_compiled_graph() -> CompiledGraph {
         reference_stats: CompiledReferenceStats::default(),
         allocation_stats: CompiledAllocationStats::default(),
         matching_stats: CompiledMatchingStats::default(),
+        release_evidence: None,
     }
 }
 
@@ -2976,6 +2987,8 @@ fn parse_process_chunk(
             ),
             amount,
             allocation_state,
+            allocation_fraction,
+            allocation_target_internal_id: reference_internal_id.clone(),
             location: parse_exchange_location(ex),
         });
         local_flow_ids.insert(flow_id);
@@ -3115,6 +3128,7 @@ async fn compile_scope_graph(
     }
 
     let flow_meta = fetch_flow_meta(pool, &flow_candidates, versioned_scope).await?;
+    let flow_release_metadata = fetch_flow_release_metadata(pool, &flow_meta).await?;
     if versioned_scope.is_some() {
         for flow_id in &exchange_flow_candidates {
             if !flow_meta.contains_key(flow_id) {
@@ -3183,6 +3197,7 @@ async fn compile_scope_graph(
     let mut provider_decisions = Vec::<CompiledProviderDecision>::new();
     let mut technosphere_edges = Vec::<CompiledTechnosphereEdge>::new();
     let mut biosphere_edges = Vec::<CompiledBiosphereEdge>::new();
+    let mut release_technosphere_edges = Vec::<CompiledReleaseTechnosphereEdge>::new();
     let mut matching_stats = CompiledMatchingStats::default();
 
     for ex in &exchanges {
@@ -3275,6 +3290,21 @@ async fn compile_scope_graph(
                     consumer.partition,
                 ),
             });
+            release_technosphere_edges.push(CompiledReleaseTechnosphereEdge {
+                consumer_process_idx: ex.process_idx,
+                consumer_input_exchange_internal_id: ex.internal_id.clone().unwrap_or_default(),
+                provider_process_idx: provider_idx,
+                provider_output_exchange_internal_id: provider_output_internal_id(
+                    provider_outputs,
+                    provider_idx,
+                )
+                .unwrap_or_default(),
+                provider_weight: 1.0,
+                normalized_amount: amount,
+                flow_id: ex.flow_id,
+                flow_version: ex.flow_version.clone(),
+                location: ex.location.clone(),
+            });
         } else if candidate_provider_count > 1 {
             matching_stats.matched_multi_provider += 1;
             let resolution =
@@ -3348,6 +3378,24 @@ async fn compile_scope_graph(
                                 consumer.partition,
                             ),
                         });
+                        release_technosphere_edges.push(CompiledReleaseTechnosphereEdge {
+                            consumer_process_idx: ex.process_idx,
+                            consumer_input_exchange_internal_id: ex
+                                .internal_id
+                                .clone()
+                                .unwrap_or_default(),
+                            provider_process_idx: allocation.provider_idx,
+                            provider_output_exchange_internal_id: provider_output_internal_id(
+                                provider_outputs,
+                                allocation.provider_idx,
+                            )
+                            .unwrap_or_default(),
+                            provider_weight: allocation.weight,
+                            normalized_amount: amount,
+                            flow_id: ex.flow_id,
+                            flow_version: ex.flow_version.clone(),
+                            location: ex.location.clone(),
+                        });
                     }
                 }
                 MultiProviderDecision::Unresolved(failure_reason) => {
@@ -3404,6 +3452,14 @@ async fn compile_scope_graph(
         })
         .collect();
 
+    let release_evidence = build_compiled_release_evidence(
+        &process_meta,
+        &exchanges,
+        &flow_release_metadata,
+        &flow_kind_by_id,
+        release_technosphere_edges,
+    )?;
+
     Ok(CompiledScopeGraph {
         graph: CompiledGraph {
             processes: compiled_processes,
@@ -3428,6 +3484,7 @@ async fn compile_scope_graph(
                     .legacy_single_output_target_inferred_count,
             },
             matching_stats,
+            release_evidence: Some(release_evidence),
         },
         lcia_exchange_observations,
     })
@@ -3450,6 +3507,136 @@ fn lcia_exchange_observation_for_attributed_exchange(
         exchange_id: exchange.exchange_id.clone(),
         amount: exchange.amount,
     })
+}
+
+fn provider_output_internal_id(
+    outputs: Option<&Vec<ProviderOutputCandidate>>,
+    provider_idx: i32,
+) -> Option<String> {
+    outputs?
+        .iter()
+        .find(|output| {
+            output.provider_idx == provider_idx
+                && output.output_exchange_is_reference
+                && output.output_allocation_state != AllocationFractionState::Invalid
+        })?
+        .output_exchange_internal_id
+        .clone()
+}
+
+fn build_compiled_release_evidence(
+    processes: &[ProcessMeta],
+    exchanges: &[ParsedExchange],
+    flow_metadata: &HashMap<Uuid, FlowReleaseMetadata>,
+    flow_kind_by_id: &HashMap<Uuid, CompiledFlowKind>,
+    mut technosphere_edges: Vec<CompiledReleaseTechnosphereEdge>,
+) -> anyhow::Result<CompiledReleaseEvidence> {
+    let mut release_processes = Vec::with_capacity(processes.len());
+    for process in processes {
+        let reference_exchanges = exchanges
+            .iter()
+            .filter(|exchange| {
+                exchange.process_idx == process.process_idx && exchange.is_reference_exchange
+            })
+            .collect::<Vec<_>>();
+        if reference_exchanges.len() != 1 {
+            return Err(anyhow::anyhow!(
+                "release evidence requires exactly one quantitative reference for process={}@{}",
+                process.process_id,
+                process.process_version
+            ));
+        }
+        let reference = reference_exchanges[0];
+        let metadata = flow_metadata.get(&reference.flow_id);
+        let reference_unit = metadata
+            .filter(|metadata| metadata.version == reference.flow_version)
+            .and_then(|metadata| metadata.reference_unit.clone())
+            .unwrap_or_default();
+        release_processes.push(CompiledReleaseProcess {
+            process_idx: process.process_idx,
+            process_id: process.process_id,
+            process_version: process.process_version.clone(),
+            quantitative_reference_exchange_internal_id: reference
+                .internal_id
+                .clone()
+                .unwrap_or_default(),
+            quantitative_reference_flow_id: reference.flow_id,
+            quantitative_reference_flow_version: reference.flow_version.clone(),
+            reference_unit,
+            normalized_mean_amount: reference.amount.unwrap_or(f64::NAN),
+        });
+    }
+    release_processes.sort_unstable_by_key(|process| process.process_idx);
+
+    let mut inventory_exchanges = Vec::with_capacity(exchanges.len());
+    let mut biosphere_edges = Vec::new();
+    for exchange in exchanges {
+        let Some(direction) = exchange.direction.map(compiled_exchange_direction) else {
+            continue;
+        };
+        let Some(amount) = exchange.amount else {
+            continue;
+        };
+        let metadata = flow_metadata.get(&exchange.flow_id);
+        let unit = metadata
+            .filter(|metadata| metadata.version == exchange.flow_version)
+            .and_then(|metadata| metadata.reference_unit.clone())
+            .unwrap_or_default();
+        let release_exchange = CompiledReleaseInventoryExchange {
+            process_idx: exchange.process_idx,
+            exchange_internal_id: exchange.internal_id.clone(),
+            flow_id: exchange.flow_id,
+            flow_version: exchange.flow_version.clone(),
+            direction,
+            unit,
+            location: exchange.location.clone(),
+            normalized_mean_amount: amount,
+            allocation_target_internal_id: exchange.allocation_target_internal_id.clone(),
+            allocation_fraction: exchange.allocation_fraction,
+        };
+        inventory_exchanges.push(release_exchange.clone());
+        if flow_kind_by_id.get(&exchange.flow_id) == Some(&CompiledFlowKind::Elementary)
+            && amount != 0.0
+        {
+            biosphere_edges.push(release_exchange);
+        }
+    }
+    inventory_exchanges.sort_by(compiled_release_inventory_order);
+    biosphere_edges.sort_by(compiled_release_inventory_order);
+    technosphere_edges.sort_by(|left, right| {
+        left.consumer_process_idx
+            .cmp(&right.consumer_process_idx)
+            .then_with(|| {
+                left.consumer_input_exchange_internal_id
+                    .cmp(&right.consumer_input_exchange_internal_id)
+            })
+            .then_with(|| left.provider_process_idx.cmp(&right.provider_process_idx))
+    });
+
+    Ok(CompiledReleaseEvidence {
+        processes: release_processes,
+        inventory_exchanges,
+        technosphere_edges,
+        biosphere_edges,
+    })
+}
+
+fn compiled_release_inventory_order(
+    left: &CompiledReleaseInventoryExchange,
+    right: &CompiledReleaseInventoryExchange,
+) -> std::cmp::Ordering {
+    left.process_idx
+        .cmp(&right.process_idx)
+        .then_with(|| left.direction.cmp(&right.direction))
+        .then_with(|| left.flow_id.cmp(&right.flow_id))
+        .then_with(|| left.exchange_internal_id.cmp(&right.exchange_internal_id))
+}
+
+fn compiled_exchange_direction(direction: ExchangeDirection) -> CompiledExchangeDirection {
+    match direction {
+        ExchangeDirection::Input => CompiledExchangeDirection::Input,
+        ExchangeDirection::Output => CompiledExchangeDirection::Output,
+    }
 }
 
 fn assemble_sparse_payload(
@@ -3972,6 +4159,7 @@ fn build_snapshot_impact_map(
         return Ok(vec![SnapshotImpactMapEntry {
             impact_id: snapshot_id,
             impact_index: 0,
+            impact_version: None,
             impact_key: "lcia-disabled".to_owned(),
             impact_name: "LCIA disabled (placeholder impact)".to_owned(),
             unit: "unknown".to_owned(),
@@ -3989,6 +4177,7 @@ fn build_snapshot_impact_map(
             impact_id: impact.impact_id,
             impact_index: i32::try_from(impact_idx)
                 .map_err(|_| anyhow::anyhow!("impact index overflow"))?,
+            impact_version: Some(impact.method_version.clone()),
             impact_key: impact.impact_key.clone(),
             impact_name: impact.impact_name.clone(),
             unit: impact.unit.clone(),
@@ -5206,6 +5395,10 @@ fn resolve_process_selection(
                             ),
                             amount: None,
                             allocation_state: AllocationFractionState::Missing,
+                            allocation_fraction: 1.0,
+                            allocation_target_internal_id: reference_internal_id
+                                .clone()
+                                .unwrap_or_default(),
                             location: parse_exchange_location(exchange),
                         },
                     ),
@@ -5233,6 +5426,10 @@ fn resolve_process_selection(
                     ),
                     amount: allocation_amount,
                     allocation_state,
+                    allocation_fraction: allocation_amount.unwrap_or(f64::NAN),
+                    allocation_target_internal_id: reference_internal_id
+                        .clone()
+                        .unwrap_or_default(),
                     location: parse_exchange_location(exchange),
                 });
             }
@@ -5858,6 +6055,180 @@ async fn fetch_flow_meta(
         out.insert(flow.id, flow);
     }
     Ok(out)
+}
+
+async fn fetch_flow_release_metadata(
+    pool: &PgPool,
+    flows: &HashMap<Uuid, FlowRow>,
+) -> anyhow::Result<HashMap<Uuid, FlowReleaseMetadata>> {
+    let flow_property_refs = flows
+        .iter()
+        .filter_map(|(flow_id, flow)| {
+            parse_flow_reference_property(&flow.json).map(|(id, version)| (*flow_id, id, version))
+        })
+        .collect::<Vec<_>>();
+    let flow_property_ids = flow_property_refs
+        .iter()
+        .map(|(_, id, _)| *id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    let mut flow_properties = HashMap::<(Uuid, String), Value>::new();
+    if !flow_property_ids.is_empty() {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, btrim(version::text) AS version, COALESCE(json, json_ordered::jsonb) AS json
+            FROM public.flowproperties
+            WHERE id = ANY($1)
+            "#,
+        )
+        .bind(&flow_property_ids)
+        .fetch_all(pool)
+        .await?;
+        for row in rows {
+            flow_properties.insert(
+                (
+                    row.try_get::<Uuid, _>("id")?,
+                    row.try_get::<String, _>("version")?,
+                ),
+                row.try_get::<Value, _>("json")?,
+            );
+        }
+    }
+
+    let unit_group_refs = flow_properties
+        .values()
+        .filter_map(parse_flow_property_reference_unit_group)
+        .collect::<BTreeSet<_>>();
+    let unit_group_ids = unit_group_refs
+        .iter()
+        .map(|(id, _)| *id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut unit_groups = HashMap::<(Uuid, String), Value>::new();
+    if !unit_group_ids.is_empty() {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, btrim(version::text) AS version, COALESCE(json, json_ordered::jsonb) AS json
+            FROM public.unitgroups
+            WHERE id = ANY($1)
+            "#,
+        )
+        .bind(&unit_group_ids)
+        .fetch_all(pool)
+        .await?;
+        for row in rows {
+            unit_groups.insert(
+                (
+                    row.try_get::<Uuid, _>("id")?,
+                    row.try_get::<String, _>("version")?,
+                ),
+                row.try_get::<Value, _>("json")?,
+            );
+        }
+    }
+
+    let mut out = HashMap::with_capacity(flows.len());
+    for (flow_id, flow) in flows {
+        let reference_unit = parse_flow_reference_property(&flow.json)
+            .and_then(|(property_id, property_version)| {
+                flow_properties.get(&(property_id, property_version))
+            })
+            .and_then(parse_flow_property_reference_unit_group)
+            .and_then(|unit_group_key| unit_groups.get(&unit_group_key))
+            .and_then(parse_unit_group_reference_unit_name);
+        out.insert(
+            *flow_id,
+            FlowReleaseMetadata {
+                version: flow.version.clone(),
+                reference_unit,
+            },
+        );
+    }
+    Ok(out)
+}
+
+fn parse_flow_reference_property(flow_json: &Value) -> Option<(Uuid, String)> {
+    let root = flow_json.get("flowDataSet")?;
+    let reference_id = root
+        .get("flowInformation")?
+        .get("quantitativeReference")?
+        .get("referenceToReferenceFlowProperty")?
+        .as_str()?
+        .trim();
+    let property = json_object_or_array_items(root.get("flowProperties")?.get("flowProperty")?)
+        .into_iter()
+        .find(|property| {
+            property
+                .get("@dataSetInternalID")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.trim() == reference_id)
+        })?;
+    parse_exact_global_reference(property.get("referenceToFlowPropertyDataSet")?)
+}
+
+fn parse_flow_property_reference_unit_group(value: &Value) -> Option<(Uuid, String)> {
+    parse_exact_global_reference(
+        value
+            .get("flowPropertyDataSet")?
+            .get("flowPropertiesInformation")?
+            .get("quantitativeReference")?
+            .get("referenceToReferenceUnitGroup")?,
+    )
+}
+
+fn parse_unit_group_reference_unit_name(value: &Value) -> Option<String> {
+    let root = value.get("unitGroupDataSet")?;
+    let reference_id = root
+        .get("unitGroupInformation")?
+        .get("quantitativeReference")?
+        .get("referenceToReferenceUnit")?
+        .as_str()?
+        .trim();
+    let unit = json_object_or_array_items(root.get("units")?.get("unit")?)
+        .into_iter()
+        .find(|unit| {
+            unit.get("@dataSetInternalID")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.trim() == reference_id)
+        })?;
+    parse_text_value(unit.get("name")?)
+}
+
+fn parse_exact_global_reference(value: &Value) -> Option<(Uuid, String)> {
+    let id = value
+        .get("@refObjectId")?
+        .as_str()
+        .and_then(|value| Uuid::parse_str(value.trim()).ok())?;
+    let version = value.get("@version")?.as_str()?.trim().to_owned();
+    (!version.is_empty()).then_some((id, version))
+}
+
+fn json_object_or_array_items(value: &Value) -> Vec<&Value> {
+    match value {
+        Value::Array(items) => items.iter().collect(),
+        Value::Object(_) => vec![value],
+        _ => Vec::new(),
+    }
+}
+
+fn parse_text_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_owned())
+        }
+        Value::Object(_) => value
+            .get("#text")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(ToOwned::to_owned),
+        Value::Array(items) => items.iter().find_map(parse_text_value),
+        _ => None,
+    }
 }
 
 fn validate_flow_row_visibility(row: &FlowRow, actor_user_id: Uuid) -> anyhow::Result<()> {
@@ -7452,6 +7823,7 @@ mod tests {
             },
             allocation_stats: CompiledAllocationStats::default(),
             matching_stats: CompiledMatchingStats::default(),
+            release_evidence: None,
         };
         let target = ProcessRow {
             id: target_id,
@@ -7555,6 +7927,7 @@ mod tests {
             reference_stats: CompiledReferenceStats::default(),
             allocation_stats: CompiledAllocationStats::default(),
             matching_stats: CompiledMatchingStats::default(),
+            release_evidence: None,
         };
         let factors = vec![ImpactFactorSet {
             impact_id: method_id,
@@ -8105,6 +8478,7 @@ mod tests {
             reference_stats: CompiledReferenceStats::default(),
             allocation_stats: CompiledAllocationStats::default(),
             matching_stats: CompiledMatchingStats::default(),
+            release_evidence: None,
         };
 
         let diagnostics = summarize_matching_diagnostics(&compiled_graph);
@@ -8445,6 +8819,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -8493,6 +8869,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -8534,6 +8912,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -8577,6 +8957,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: Some("GLO".to_owned()),
         };
 
@@ -8618,6 +9000,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -8658,6 +9042,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: Some("CN".to_owned()),
         };
 
@@ -8701,6 +9087,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: Some("not-a-location".to_owned()),
         };
 
@@ -9094,6 +9482,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -9163,6 +9553,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -9226,6 +9618,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -9291,6 +9685,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -9353,6 +9749,8 @@ mod tests {
             is_reference_exchange: false,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Present,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "reference".to_owned(),
             location: None,
         };
 
@@ -9598,6 +9996,8 @@ mod tests {
             is_reference_exchange: true,
             amount: Some(1.0),
             allocation_state: AllocationFractionState::Missing,
+            allocation_fraction: 1.0,
+            allocation_target_internal_id: "1".to_owned(),
             location: None,
         };
 
@@ -9743,6 +10143,8 @@ mod tests {
                 } else {
                     AllocationFractionState::Present
                 },
+                allocation_fraction: if amount == Some(0.0) { 0.0 } else { 1.0 },
+                allocation_target_internal_id: "1".to_owned(),
                 location: None,
             };
         let exchanges = [
@@ -10139,5 +10541,75 @@ mod tests {
             .expect("first finite factor");
         assert!(accumulate_finite_factor(&mut factors, Uuid::nil(), f64::MAX, method_id).is_err());
         assert!(factors[&Uuid::nil()].is_finite());
+    }
+
+    #[test]
+    fn release_metadata_resolves_exact_flow_property_and_reference_unit() {
+        let property_id = Uuid::new_v4();
+        let flow = json!({
+            "flowDataSet": {
+                "flowInformation": {
+                    "quantitativeReference": { "referenceToReferenceFlowProperty": "7" }
+                },
+                "flowProperties": {
+                    "flowProperty": [
+                        {
+                            "@dataSetInternalID": "3",
+                            "referenceToFlowPropertyDataSet": {
+                                "@refObjectId": Uuid::new_v4(),
+                                "@version": "01.00.000"
+                            }
+                        },
+                        {
+                            "@dataSetInternalID": "7",
+                            "referenceToFlowPropertyDataSet": {
+                                "@refObjectId": property_id,
+                                "@version": "03.00.003"
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+        assert_eq!(
+            super::parse_flow_reference_property(&flow),
+            Some((property_id, "03.00.003".to_owned()))
+        );
+
+        let unit_group = json!({
+            "unitGroupDataSet": {
+                "unitGroupInformation": {
+                    "quantitativeReference": { "referenceToReferenceUnit": "1" }
+                },
+                "units": {
+                    "unit": [
+                        { "@dataSetInternalID": "0", "name": "g" },
+                        { "@dataSetInternalID": "1", "name": "kg" }
+                    ]
+                }
+            }
+        });
+        assert_eq!(
+            super::parse_unit_group_reference_unit_name(&unit_group).as_deref(),
+            Some("kg")
+        );
+    }
+
+    #[test]
+    fn release_metadata_rejects_unversioned_flow_property_reference() {
+        let flow = json!({
+            "flowDataSet": {
+                "flowInformation": {
+                    "quantitativeReference": { "referenceToReferenceFlowProperty": "0" }
+                },
+                "flowProperties": {
+                    "flowProperty": {
+                        "@dataSetInternalID": "0",
+                        "referenceToFlowPropertyDataSet": { "@refObjectId": Uuid::new_v4() }
+                    }
+                }
+            }
+        });
+        assert!(super::parse_flow_reference_property(&flow).is_none());
     }
 }

--- a/crates/solver-worker/src/calculation_bundle.rs
+++ b/crates/solver-worker/src/calculation_bundle.rs
@@ -1,0 +1,1400 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::File,
+    io::{BufReader, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use flate2::{Compression, GzBuilder, write::GzEncoder};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use solver_core::SolveResult;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use crate::{
+    calculation_evidence::{
+        RELEASE_BUNDLE_MANIFEST_SHA256, RELEASE_BUNDLE_VERSION, RELEASE_FACTOR_MANIFEST_SHA256,
+        RELEASE_METHOD_COUNT, RELEASE_METHOD_IDENTITIES, RELEASE_METHOD_IDENTITY_MANIFEST_SHA256,
+        RELEASE_METHOD_MANIFEST_SHA256, RELEASE_SOURCE_SNAPSHOT_SHA256,
+    },
+    compiled_graph::{
+        CompiledExchangeDirection, CompiledReleaseEvidence, CompiledReleaseInventoryExchange,
+    },
+    snapshot_artifacts::{SnapshotBuildConfig, SnapshotCoverageReport},
+    snapshot_index::{SnapshotImpactMapEntry, SnapshotIndexDocument},
+    storage::ObjectStoreClient,
+};
+
+pub const CALCULATION_BUNDLE_FORMAT: &str = "tiangong.calculation-bundle.v1";
+pub const CALCULATION_BUNDLE_MANIFEST_CONTENT_TYPE: &str = "application/json";
+pub const CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT: usize = 256;
+const CALCULATION_CONTRACT_VERSION: &str = "1.0.0";
+const GZIP_LEVEL: u32 = 6;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculationBundleArtifact {
+    pub kind: String,
+    pub path: String,
+    pub schema_version: String,
+    pub media_type: String,
+    pub compression: String,
+    pub sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uncompressed_sha256: Option<String>,
+    pub byte_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uncompressed_byte_size: Option<u64>,
+    pub record_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_process_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_process_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derived: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculationBundleManifest {
+    pub schema_version: String,
+    pub calculation_contract_version: String,
+    pub calculation_id: Uuid,
+    pub bundle_content_hash: String,
+    pub scope: CalculationBundleScope,
+    pub snapshot: CalculationBundleSnapshot,
+    pub solver: Value,
+    pub method_set: Value,
+    pub artifacts: Vec<CalculationBundleArtifact>,
+    pub calculation_evidence: Value,
+    pub hashes: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculationBundleScope {
+    pub coverage_mode: String,
+    pub process_count: usize,
+    pub selection_manifest_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculationBundleSnapshot {
+    pub id: Uuid,
+    pub sha256: String,
+    pub process_count: usize,
+    pub flow_count: usize,
+    pub impact_count: usize,
+}
+
+#[derive(Debug)]
+pub struct LocalCalculationBundleArtifact {
+    pub metadata: CalculationBundleArtifact,
+    pub local_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct BuiltCalculationBundle {
+    _directory: TempDir,
+    pub calculation_id: Uuid,
+    pub bundle_content_hash: String,
+    pub manifest_sha256: String,
+    pub manifest_byte_size: u64,
+    pub manifest_path: PathBuf,
+    pub manifest: CalculationBundleManifest,
+    pub artifacts: Vec<LocalCalculationBundleArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculationBundleArtifactRef {
+    pub schema_version: String,
+    pub calculation_id: Uuid,
+    pub bundle_content_hash: String,
+    pub manifest_url: String,
+    pub manifest_sha256: String,
+    pub manifest_byte_size: u64,
+    pub artifact_count: usize,
+}
+
+pub async fn upload_built_calculation_bundle(
+    store: &ObjectStoreClient,
+    bundle: &BuiltCalculationBundle,
+) -> anyhow::Result<CalculationBundleArtifactRef> {
+    let relative_prefix = format!(
+        "calculation-bundles/{}/{}",
+        bundle.calculation_id, bundle.bundle_content_hash
+    );
+    for artifact in &bundle.artifacts {
+        let relative_key = format!("{relative_prefix}/{}", artifact.metadata.path);
+        let key = store.prefixed_object_key(&relative_key)?;
+        store
+            .upload_object_key_file(
+                &key,
+                artifact.metadata.media_type.as_str(),
+                &artifact.local_path,
+                artifact.metadata.byte_size,
+            )
+            .await?;
+    }
+
+    let manifest_relative_key = format!("{relative_prefix}/calculation-bundle.json");
+    let manifest_key = store.prefixed_object_key(&manifest_relative_key)?;
+    let uploaded = store
+        .upload_object_key_file(
+            &manifest_key,
+            CALCULATION_BUNDLE_MANIFEST_CONTENT_TYPE,
+            &bundle.manifest_path,
+            bundle.manifest_byte_size,
+        )
+        .await?;
+    Ok(CalculationBundleArtifactRef {
+        schema_version: CALCULATION_BUNDLE_FORMAT.to_owned(),
+        calculation_id: bundle.calculation_id,
+        bundle_content_hash: bundle.bundle_content_hash.clone(),
+        manifest_url: uploaded.object_url,
+        manifest_sha256: bundle.manifest_sha256.clone(),
+        manifest_byte_size: bundle.manifest_byte_size,
+        artifact_count: bundle.artifacts.len(),
+    })
+}
+
+#[derive(Debug)]
+pub struct CalculationBundleWriter {
+    directory: TempDir,
+    calculation_id: Uuid,
+    snapshot_id: Uuid,
+    snapshot_sha256: String,
+    snapshot_flow_count: usize,
+    config: SnapshotBuildConfig,
+    coverage: SnapshotCoverageReport,
+    calculation_evidence: Value,
+    processes: Vec<ReleaseProcessRecord>,
+    impacts: Vec<ReleaseImpact>,
+    biosphere_by_process: Vec<Vec<CompiledReleaseInventoryExchange>>,
+    artifacts: Vec<LocalCalculationBundleArtifact>,
+    completed_result_chunks: BTreeSet<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReleaseProcessRecord {
+    process_index: usize,
+    root_process: GlobalReference,
+    quantitative_reference: QuantitativeReference,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GlobalReference {
+    id: Uuid,
+    version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QuantitativeReference {
+    exchange_internal_id: String,
+    flow: GlobalReference,
+    direction: &'static str,
+    reference_unit: String,
+    mean_amount: f64,
+}
+
+#[derive(Debug, Clone)]
+struct ReleaseImpact {
+    index: usize,
+    id: Uuid,
+    version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct InventoryKey {
+    flow_id: Uuid,
+    flow_version: String,
+    direction: CompiledExchangeDirection,
+    unit: String,
+    location: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InventoryRecord<'a> {
+    process_index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exchange_internal_id: Option<&'a str>,
+    flow: GlobalReference,
+    direction: CompiledExchangeDirection,
+    unit: &'a str,
+    location: Option<&'a str>,
+    mean_amount: f64,
+    allocation_target_internal_id: &'a str,
+    allocation_fraction: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OwnedInventoryRecord {
+    process_index: usize,
+    flow: GlobalReference,
+    direction: CompiledExchangeDirection,
+    unit: String,
+    location: Option<String>,
+    mean_amount: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LciaRecord {
+    process_index: usize,
+    method: GlobalReference,
+    mean_amount: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TechnosphereRecord<'a> {
+    consumer_process_index: usize,
+    consumer_input_exchange_internal_id: &'a str,
+    provider_process_index: usize,
+    provider_output_exchange_internal_id: &'a str,
+    provider_weight: f64,
+    normalized_amount: f64,
+    flow: GlobalReference,
+    location: Option<&'a str>,
+}
+
+struct DeterministicGzipNdjsonWriter {
+    encoder: GzEncoder<File>,
+    plain_hasher: Sha256,
+    plain_byte_size: u64,
+    record_count: u64,
+    path: PathBuf,
+}
+
+impl DeterministicGzipNdjsonWriter {
+    fn create(path: &Path) -> anyhow::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = File::create(path)?;
+        let encoder = GzBuilder::new()
+            .mtime(0)
+            .write(file, Compression::new(GZIP_LEVEL));
+        Ok(Self {
+            encoder,
+            plain_hasher: Sha256::new(),
+            plain_byte_size: 0,
+            record_count: 0,
+            path: path.to_owned(),
+        })
+    }
+
+    fn write<T: Serialize>(&mut self, value: &T) -> anyhow::Result<()> {
+        let bytes = canonical_json_bytes(value)?;
+        self.encoder.write_all(bytes.as_slice())?;
+        self.encoder.write_all(b"\n")?;
+        self.plain_hasher.update(bytes.as_slice());
+        self.plain_hasher.update(b"\n");
+        self.plain_byte_size = self
+            .plain_byte_size
+            .checked_add(u64::try_from(bytes.len() + 1)?)
+            .ok_or_else(|| anyhow::anyhow!("Calculation Bundle uncompressed byte size overflow"))?;
+        self.record_count = self
+            .record_count
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("Calculation Bundle record count overflow"))?;
+        Ok(())
+    }
+
+    fn finish(self) -> anyhow::Result<FinishedNdjson> {
+        let Self {
+            encoder,
+            plain_hasher,
+            plain_byte_size,
+            record_count,
+            path,
+        } = self;
+        let file = encoder.finish()?;
+        file.sync_all()?;
+        let byte_size = file.metadata()?.len();
+        Ok(FinishedNdjson {
+            sha256: sha256_file(&path)?,
+            path,
+            uncompressed_sha256: hex::encode(plain_hasher.finalize()),
+            byte_size,
+            uncompressed_byte_size: plain_byte_size,
+            record_count,
+        })
+    }
+}
+
+struct FinishedNdjson {
+    path: PathBuf,
+    sha256: String,
+    uncompressed_sha256: String,
+    byte_size: u64,
+    uncompressed_byte_size: u64,
+    record_count: u64,
+}
+
+impl CalculationBundleWriter {
+    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        calculation_id: Uuid,
+        snapshot_id: Uuid,
+        snapshot_sha256: String,
+        snapshot_flow_count: usize,
+        config: SnapshotBuildConfig,
+        coverage: SnapshotCoverageReport,
+        snapshot_index: &SnapshotIndexDocument,
+        release_evidence: &CompiledReleaseEvidence,
+    ) -> anyhow::Result<Self> {
+        validate_sha256(&snapshot_sha256, "snapshot.sha256")?;
+        let process_count = usize::try_from(snapshot_index.process_count)
+            .map_err(|_| anyhow::anyhow!("negative snapshot process count"))?;
+        if process_count == 0 || release_evidence.processes.len() != process_count {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle process evidence mismatch: snapshot={process_count} evidence={}",
+                release_evidence.processes.len()
+            ));
+        }
+
+        let mut processes = release_evidence
+            .processes
+            .iter()
+            .map(|process| {
+                let process_index = usize::try_from(process.process_idx)
+                    .map_err(|_| anyhow::anyhow!("negative release process index"))?;
+                validate_version(&process.process_version, "process.version")?;
+                validate_version(
+                    &process.quantitative_reference_flow_version,
+                    "quantitativeReference.flow.version",
+                )?;
+                require_nonempty(
+                    &process.quantitative_reference_exchange_internal_id,
+                    "quantitativeReference.exchangeInternalId",
+                )?;
+                require_nonempty(
+                    &process.reference_unit,
+                    "quantitativeReference.referenceUnit",
+                )?;
+                ensure_finite_nonzero(
+                    process.normalized_mean_amount,
+                    "quantitativeReference.meanAmount",
+                )?;
+                Ok(ReleaseProcessRecord {
+                    process_index,
+                    root_process: GlobalReference {
+                        id: process.process_id,
+                        version: process.process_version.clone(),
+                    },
+                    quantitative_reference: QuantitativeReference {
+                        exchange_internal_id: process
+                            .quantitative_reference_exchange_internal_id
+                            .clone(),
+                        flow: GlobalReference {
+                            id: process.quantitative_reference_flow_id,
+                            version: process.quantitative_reference_flow_version.clone(),
+                        },
+                        direction: "Output",
+                        reference_unit: process.reference_unit.clone(),
+                        mean_amount: process.normalized_mean_amount,
+                    },
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        processes.sort_unstable_by_key(|process| process.process_index);
+        for (expected, process) in processes.iter().enumerate() {
+            if process.process_index != expected {
+                return Err(anyhow::anyhow!(
+                    "Calculation Bundle process index gap: expected={expected} got={}",
+                    process.process_index
+                ));
+            }
+        }
+
+        let impacts = validate_impacts(&snapshot_index.impact_map)?;
+        let calculation_evidence = snapshot_index
+            .calculation_evidence
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?
+            .unwrap_or_else(|| {
+                json!({
+                    "schemaVersion": "lca.calculation-evidence.legacy-snapshot.v1",
+                    "snapshotCoverage": coverage,
+                })
+            });
+
+        let mut biosphere_by_process = vec![Vec::new(); process_count];
+        for exchange in &release_evidence.biosphere_edges {
+            validate_inventory_exchange(exchange, process_count)?;
+            let process_index = usize::try_from(exchange.process_idx)?;
+            biosphere_by_process[process_index].push(exchange.clone());
+        }
+        for exchanges in &mut biosphere_by_process {
+            exchanges.sort_by(inventory_exchange_order);
+        }
+
+        let mut writer = Self {
+            directory: tempfile::Builder::new()
+                .prefix("tiangong-calculation-bundle-")
+                .tempdir()?,
+            calculation_id,
+            snapshot_id,
+            snapshot_sha256,
+            snapshot_flow_count,
+            config,
+            coverage,
+            calculation_evidence,
+            processes,
+            impacts,
+            biosphere_by_process,
+            artifacts: Vec::new(),
+            completed_result_chunks: BTreeSet::new(),
+        };
+        writer.write_static_artifacts(release_evidence)?;
+        Ok(writer)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub fn write_result_chunk(
+        &mut self,
+        first_process_index: usize,
+        items: &[SolveResult],
+    ) -> anyhow::Result<()> {
+        if !first_process_index.is_multiple_of(CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT) {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle result chunk must start on a 256-process boundary"
+            ));
+        }
+        if items.is_empty() || items.len() > CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle result chunk size is invalid"
+            ));
+        }
+        let end = first_process_index
+            .checked_add(items.len())
+            .ok_or_else(|| anyhow::anyhow!("Calculation Bundle result chunk index overflow"))?;
+        if end > self.processes.len() {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle result chunk exceeds process axis"
+            ));
+        }
+        if !self.completed_result_chunks.insert(first_process_index) {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle result chunk already written"
+            ));
+        }
+
+        let chunk_number = first_process_index / CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT;
+        let last_process_index = end - 1;
+        let lci_path = format!("results/lci-{chunk_number:06}.ndjson.gz");
+        let lcia_path = format!("results/lcia-{chunk_number:06}.ndjson.gz");
+        let mut lci_writer =
+            DeterministicGzipNdjsonWriter::create(&self.directory.path().join(lci_path.as_str()))?;
+        let mut lcia_writer =
+            DeterministicGzipNdjsonWriter::create(&self.directory.path().join(lcia_path.as_str()))?;
+
+        for (offset, item) in items.iter().enumerate() {
+            let process_index = first_process_index + offset;
+            let x = item.x.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("Calculation Bundle solve item[{process_index}] is missing x")
+            })?;
+            if x.len() != self.processes.len() {
+                return Err(anyhow::anyhow!(
+                    "Calculation Bundle x axis mismatch for process {process_index}: expected={} got={}",
+                    self.processes.len(),
+                    x.len()
+                ));
+            }
+            let h = item.h.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("Calculation Bundle solve item[{process_index}] is missing h")
+            })?;
+            if h.len() != self.impacts.len() {
+                return Err(anyhow::anyhow!(
+                    "Calculation Bundle h axis mismatch for process {process_index}: expected={} got={}",
+                    self.impacts.len(),
+                    h.len()
+                ));
+            }
+
+            let mut inventory = BTreeMap::<InventoryKey, f64>::new();
+            for (source_process_index, scale) in x.iter().copied().enumerate() {
+                ensure_finite(scale, "x")?;
+                if scale == 0.0 {
+                    continue;
+                }
+                for exchange in &self.biosphere_by_process[source_process_index] {
+                    let contribution = exchange.normalized_mean_amount * scale;
+                    ensure_finite(contribution, "directional LCI contribution")?;
+                    let key = InventoryKey {
+                        flow_id: exchange.flow_id,
+                        flow_version: exchange.flow_version.clone(),
+                        direction: exchange.direction,
+                        unit: exchange.unit.clone(),
+                        location: exchange.location.clone(),
+                    };
+                    let value = inventory.entry(key).or_insert(0.0);
+                    *value += contribution;
+                    ensure_finite(*value, "directional LCI aggregate")?;
+                }
+            }
+            for (key, mean_amount) in inventory {
+                if mean_amount == 0.0 {
+                    continue;
+                }
+                lci_writer.write(&OwnedInventoryRecord {
+                    process_index,
+                    flow: GlobalReference {
+                        id: key.flow_id,
+                        version: key.flow_version,
+                    },
+                    direction: key.direction,
+                    unit: key.unit,
+                    location: key.location,
+                    mean_amount,
+                })?;
+            }
+
+            for impact in &self.impacts {
+                let mean_amount = h[impact.index];
+                ensure_finite(mean_amount, "LCIA result")?;
+                lcia_writer.write(&LciaRecord {
+                    process_index,
+                    method: GlobalReference {
+                        id: impact.id,
+                        version: impact.version.clone(),
+                    },
+                    mean_amount,
+                })?;
+            }
+        }
+
+        self.push_finished_ndjson(
+            "lci",
+            "tiangong.calculation-bundle.lci.v1",
+            lci_path,
+            first_process_index,
+            last_process_index,
+            lci_writer.finish()?,
+        );
+        self.push_finished_ndjson(
+            "lcia",
+            "tiangong.calculation-bundle.lcia.v1",
+            lcia_path,
+            first_process_index,
+            last_process_index,
+            lcia_writer.finish()?,
+        );
+        Ok(())
+    }
+
+    pub fn finish(mut self) -> anyhow::Result<BuiltCalculationBundle> {
+        let expected_chunk_starts = (0..self.processes.len())
+            .step_by(CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT)
+            .collect::<BTreeSet<_>>();
+        if self.completed_result_chunks != expected_chunk_starts {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle result chunks incomplete: expected={expected_chunk_starts:?} got={:?}",
+                self.completed_result_chunks
+            ));
+        }
+
+        self.write_coverage_artifact()?;
+        self.artifacts
+            .sort_by(|left, right| left.metadata.path.cmp(&right.metadata.path));
+        let selection_manifest_hash = canonical_sha256(&json!({
+            "schemaVersion": "tiangong.calculation-bundle.selection.v1",
+            "processes": self.processes,
+        }))?;
+        let coverage_mode = if self.config.request_roots.is_empty() {
+            "global_eligible"
+        } else {
+            "subset"
+        };
+        let process_count = self.processes.len();
+        let impact_count = self.impacts.len();
+        let mut manifest = CalculationBundleManifest {
+            schema_version: CALCULATION_BUNDLE_FORMAT.to_owned(),
+            calculation_contract_version: CALCULATION_CONTRACT_VERSION.to_owned(),
+            calculation_id: self.calculation_id,
+            bundle_content_hash: "0".repeat(64),
+            scope: CalculationBundleScope {
+                coverage_mode: coverage_mode.to_owned(),
+                process_count,
+                selection_manifest_hash,
+            },
+            snapshot: CalculationBundleSnapshot {
+                id: self.snapshot_id,
+                sha256: self.snapshot_sha256,
+                process_count,
+                flow_count: self.snapshot_flow_count,
+                impact_count,
+            },
+            solver: json!({
+                "engineVersion": env!("CARGO_PKG_VERSION"),
+                "numericalPolicy": {
+                    "equation": "M=I-A; Mx=y",
+                    "backend": "umfpack",
+                    "unitDemandAmount": 1,
+                },
+                "providerPolicy": { "rule": self.config.provider_rule },
+                "allocationPolicy": {
+                    "semanticsVersion": self.config.allocation_semantics_version,
+                    "mode": self.config.allocation_fraction_mode,
+                },
+                "zeroPolicy": {
+                    "directionalLci": "retain_finite_nonzero",
+                    "lcia": "retain_finite_including_zero",
+                },
+            }),
+            method_set: json!({
+                "schemaVersion": "lcia.static_cache_bundle.v1",
+                "bundleVersion": RELEASE_BUNDLE_VERSION,
+                "methodCount": RELEASE_METHOD_COUNT,
+                "rawManifestSha256": RELEASE_BUNDLE_MANIFEST_SHA256,
+                "sourceSnapshotSha256": RELEASE_SOURCE_SNAPSHOT_SHA256,
+                "methodManifestSha256": RELEASE_METHOD_MANIFEST_SHA256,
+                "methodIdentityManifestSha256": RELEASE_METHOD_IDENTITY_MANIFEST_SHA256,
+                "factorManifestSha256": RELEASE_FACTOR_MANIFEST_SHA256,
+            }),
+            artifacts: self
+                .artifacts
+                .iter()
+                .map(|artifact| artifact.metadata.clone())
+                .collect(),
+            calculation_evidence: self.calculation_evidence,
+            hashes: json!({
+                "algorithm": "sha256",
+                "canonicalJson": "RFC8785/JCS",
+                "gzip": { "level": GZIP_LEVEL, "mtime": 0 },
+            }),
+        };
+        manifest.bundle_content_hash = bundle_content_hash(&manifest)?;
+        let manifest_bytes = canonical_json_bytes(&manifest)?;
+        let manifest_sha256 = sha256_bytes(manifest_bytes.as_slice());
+        let manifest_byte_size = u64::try_from(manifest_bytes.len())?;
+        let manifest_path = self.directory.path().join("calculation-bundle.json");
+        std::fs::write(&manifest_path, manifest_bytes)?;
+
+        Ok(BuiltCalculationBundle {
+            _directory: self.directory,
+            calculation_id: self.calculation_id,
+            bundle_content_hash: manifest.bundle_content_hash.clone(),
+            manifest_sha256,
+            manifest_byte_size,
+            manifest_path,
+            manifest,
+            artifacts: self.artifacts,
+        })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn write_static_artifacts(
+        &mut self,
+        release_evidence: &CompiledReleaseEvidence,
+    ) -> anyhow::Result<()> {
+        for first_process_index in
+            (0..self.processes.len()).step_by(CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT)
+        {
+            let end = (first_process_index + CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT)
+                .min(self.processes.len());
+            let last_process_index = end - 1;
+            let chunk_number = first_process_index / CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT;
+
+            let process_path = format!("axes/processes-{chunk_number:06}.ndjson.gz");
+            let mut process_writer = DeterministicGzipNdjsonWriter::create(
+                &self.directory.path().join(process_path.as_str()),
+            )?;
+            for process in &self.processes[first_process_index..end] {
+                process_writer.write(process)?;
+            }
+            self.push_finished_ndjson(
+                "process_axis",
+                "tiangong.calculation-bundle.process-axis.v1",
+                process_path,
+                first_process_index,
+                last_process_index,
+                process_writer.finish()?,
+            );
+
+            let inventory_path = format!("axes/inventory-{chunk_number:06}.ndjson.gz");
+            let mut inventory_writer = DeterministicGzipNdjsonWriter::create(
+                &self.directory.path().join(inventory_path.as_str()),
+            )?;
+            let mut inventory = release_evidence
+                .inventory_exchanges
+                .iter()
+                .filter(|exchange| {
+                    usize::try_from(exchange.process_idx)
+                        .is_ok_and(|index| index >= first_process_index && index < end)
+                })
+                .collect::<Vec<_>>();
+            inventory.sort_by(|left, right| inventory_exchange_order(left, right));
+            for exchange in inventory {
+                validate_inventory_exchange(exchange, self.processes.len())?;
+                inventory_writer.write(&inventory_record(exchange)?)?;
+            }
+            self.push_finished_ndjson(
+                "inventory_axis",
+                "tiangong.calculation-bundle.inventory-axis.v1",
+                inventory_path,
+                first_process_index,
+                last_process_index,
+                inventory_writer.finish()?,
+            );
+
+            let biosphere_path = format!("graph/biosphere-{chunk_number:06}.ndjson.gz");
+            let mut biosphere_writer = DeterministicGzipNdjsonWriter::create(
+                &self.directory.path().join(biosphere_path.as_str()),
+            )?;
+            let mut biosphere = release_evidence
+                .biosphere_edges
+                .iter()
+                .filter(|exchange| {
+                    usize::try_from(exchange.process_idx)
+                        .is_ok_and(|index| index >= first_process_index && index < end)
+                })
+                .collect::<Vec<_>>();
+            biosphere.sort_by(|left, right| inventory_exchange_order(left, right));
+            for exchange in biosphere {
+                validate_inventory_exchange(exchange, self.processes.len())?;
+                biosphere_writer.write(&inventory_record(exchange)?)?;
+            }
+            self.push_finished_ndjson(
+                "biosphere_edges",
+                "tiangong.calculation-bundle.biosphere-edges.v1",
+                biosphere_path,
+                first_process_index,
+                last_process_index,
+                biosphere_writer.finish()?,
+            );
+
+            let technosphere_path = format!("graph/technosphere-{chunk_number:06}.ndjson.gz");
+            let mut technosphere_writer = DeterministicGzipNdjsonWriter::create(
+                &self.directory.path().join(technosphere_path.as_str()),
+            )?;
+            let mut technosphere = release_evidence
+                .technosphere_edges
+                .iter()
+                .filter(|edge| {
+                    usize::try_from(edge.consumer_process_idx)
+                        .is_ok_and(|index| index >= first_process_index && index < end)
+                })
+                .collect::<Vec<_>>();
+            technosphere.sort_by(|left, right| {
+                left.consumer_process_idx
+                    .cmp(&right.consumer_process_idx)
+                    .then_with(|| {
+                        left.consumer_input_exchange_internal_id
+                            .cmp(&right.consumer_input_exchange_internal_id)
+                    })
+                    .then_with(|| left.provider_process_idx.cmp(&right.provider_process_idx))
+            });
+            for edge in technosphere {
+                validate_version(&edge.flow_version, "technosphere.flow.version")?;
+                require_nonempty(
+                    &edge.consumer_input_exchange_internal_id,
+                    "technosphere.consumerInputExchangeInternalId",
+                )?;
+                require_nonempty(
+                    &edge.provider_output_exchange_internal_id,
+                    "technosphere.providerOutputExchangeInternalId",
+                )?;
+                ensure_finite(edge.provider_weight, "technosphere.providerWeight")?;
+                ensure_finite(edge.normalized_amount, "technosphere.normalizedAmount")?;
+                let consumer_process_index = usize::try_from(edge.consumer_process_idx)?;
+                let provider_process_index = usize::try_from(edge.provider_process_idx)?;
+                if consumer_process_index >= self.processes.len()
+                    || provider_process_index >= self.processes.len()
+                {
+                    return Err(anyhow::anyhow!(
+                        "technosphere edge process index is outside process axis"
+                    ));
+                }
+                technosphere_writer.write(&TechnosphereRecord {
+                    consumer_process_index,
+                    consumer_input_exchange_internal_id: &edge.consumer_input_exchange_internal_id,
+                    provider_process_index,
+                    provider_output_exchange_internal_id: &edge
+                        .provider_output_exchange_internal_id,
+                    provider_weight: edge.provider_weight,
+                    normalized_amount: edge.normalized_amount,
+                    flow: GlobalReference {
+                        id: edge.flow_id,
+                        version: edge.flow_version.clone(),
+                    },
+                    location: edge.location.as_deref(),
+                })?;
+            }
+            self.push_finished_ndjson(
+                "technosphere_edges",
+                "tiangong.calculation-bundle.technosphere-edges.v1",
+                technosphere_path,
+                first_process_index,
+                last_process_index,
+                technosphere_writer.finish()?,
+            );
+        }
+        Ok(())
+    }
+
+    fn write_coverage_artifact(&mut self) -> anyhow::Result<()> {
+        let relative_path = "evidence/coverage.json";
+        let local_path = self.directory.path().join(relative_path);
+        if let Some(parent) = local_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let complete = self.coverage.matching.unmatched_no_provider == 0
+            && self.coverage.reference.missing_reference_count == 0
+            && self.coverage.reference.invalid_reference_count == 0;
+        let body = canonical_json_bytes(&json!({
+            "schemaVersion": "tiangong.calculation-bundle.coverage.v1",
+            "complete": complete,
+            "processCount": self.processes.len(),
+            "snapshotCoverage": self.coverage,
+            "calculationEvidence": self.calculation_evidence,
+        }))?;
+        std::fs::write(&local_path, &body)?;
+        self.artifacts.push(LocalCalculationBundleArtifact {
+            metadata: CalculationBundleArtifact {
+                kind: "coverage".to_owned(),
+                path: relative_path.to_owned(),
+                schema_version: "tiangong.calculation-bundle.coverage.v1".to_owned(),
+                media_type: "application/json".to_owned(),
+                compression: "none".to_owned(),
+                sha256: sha256_bytes(body.as_slice()),
+                uncompressed_sha256: None,
+                byte_size: u64::try_from(body.len())?,
+                uncompressed_byte_size: None,
+                record_count: 1,
+                first_process_index: None,
+                last_process_index: None,
+                derived: None,
+            },
+            local_path,
+        });
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn push_finished_ndjson(
+        &mut self,
+        kind: &str,
+        schema_version: &str,
+        relative_path: String,
+        first_process_index: usize,
+        last_process_index: usize,
+        finished: FinishedNdjson,
+    ) {
+        self.artifacts.push(LocalCalculationBundleArtifact {
+            metadata: CalculationBundleArtifact {
+                kind: kind.to_owned(),
+                path: relative_path,
+                schema_version: schema_version.to_owned(),
+                media_type: "application/x-ndjson".to_owned(),
+                compression: "gzip".to_owned(),
+                sha256: finished.sha256,
+                uncompressed_sha256: Some(finished.uncompressed_sha256),
+                byte_size: finished.byte_size,
+                uncompressed_byte_size: Some(finished.uncompressed_byte_size),
+                record_count: finished.record_count,
+                first_process_index: Some(first_process_index),
+                last_process_index: Some(last_process_index),
+                derived: None,
+            },
+            local_path: finished.path,
+        });
+    }
+}
+
+fn validate_impacts(items: &[SnapshotImpactMapEntry]) -> anyhow::Result<Vec<ReleaseImpact>> {
+    if items.len() != usize::try_from(RELEASE_METHOD_COUNT)? {
+        return Err(anyhow::anyhow!(
+            "Calculation Bundle requires the reviewed {RELEASE_METHOD_COUNT}-method set; got {}",
+            items.len()
+        ));
+    }
+    let mut impacts = items
+        .iter()
+        .map(|impact| {
+            let index = usize::try_from(impact.impact_index)
+                .map_err(|_| anyhow::anyhow!("negative impact index"))?;
+            let version = impact
+                .impact_version
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("Calculation Bundle impact version is missing"))?;
+            validate_version(version, "impact.version")?;
+            Ok(ReleaseImpact {
+                index,
+                id: impact.impact_id,
+                version: version.to_owned(),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    impacts.sort_unstable_by_key(|impact| impact.index);
+    for (expected, impact) in impacts.iter().enumerate() {
+        if impact.index != expected {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle impact index gap: expected={expected} got={}",
+                impact.index
+            ));
+        }
+    }
+    let actual = impacts
+        .iter()
+        .map(|impact| (impact.id.to_string(), impact.version.clone()))
+        .collect::<BTreeSet<_>>();
+    let expected = RELEASE_METHOD_IDENTITIES
+        .iter()
+        .map(|(method_id, version, _)| ((*method_id).to_owned(), (*version).to_owned()))
+        .collect::<BTreeSet<_>>();
+    if actual != expected {
+        return Err(anyhow::anyhow!(
+            "Calculation Bundle impact identities do not match the reviewed method set"
+        ));
+    }
+    Ok(impacts)
+}
+
+fn validate_inventory_exchange(
+    exchange: &CompiledReleaseInventoryExchange,
+    process_count: usize,
+) -> anyhow::Result<()> {
+    let process_index = usize::try_from(exchange.process_idx)
+        .map_err(|_| anyhow::anyhow!("negative inventory process index"))?;
+    if process_index >= process_count {
+        return Err(anyhow::anyhow!(
+            "inventory process index is outside process axis"
+        ));
+    }
+    validate_version(&exchange.flow_version, "inventory.flow.version")?;
+    require_nonempty(&exchange.unit, "inventory.unit")?;
+    require_nonempty(
+        &exchange.allocation_target_internal_id,
+        "inventory.allocationTargetInternalId",
+    )?;
+    ensure_finite(exchange.allocation_fraction, "inventory.allocationFraction")?;
+    ensure_finite(exchange.normalized_mean_amount, "inventory.meanAmount")
+}
+
+fn inventory_record(
+    exchange: &CompiledReleaseInventoryExchange,
+) -> anyhow::Result<InventoryRecord<'_>> {
+    Ok(InventoryRecord {
+        process_index: usize::try_from(exchange.process_idx)?,
+        exchange_internal_id: exchange.exchange_internal_id.as_deref(),
+        flow: GlobalReference {
+            id: exchange.flow_id,
+            version: exchange.flow_version.clone(),
+        },
+        direction: exchange.direction,
+        unit: exchange.unit.as_str(),
+        location: exchange.location.as_deref(),
+        mean_amount: exchange.normalized_mean_amount,
+        allocation_target_internal_id: exchange.allocation_target_internal_id.as_str(),
+        allocation_fraction: exchange.allocation_fraction,
+    })
+}
+
+fn inventory_exchange_order(
+    left: &CompiledReleaseInventoryExchange,
+    right: &CompiledReleaseInventoryExchange,
+) -> std::cmp::Ordering {
+    left.process_idx
+        .cmp(&right.process_idx)
+        .then_with(|| left.direction.cmp(&right.direction))
+        .then_with(|| left.flow_id.cmp(&right.flow_id))
+        .then_with(|| left.flow_version.cmp(&right.flow_version))
+        .then_with(|| left.unit.cmp(&right.unit))
+        .then_with(|| left.location.cmp(&right.location))
+        .then_with(|| left.exchange_internal_id.cmp(&right.exchange_internal_id))
+}
+
+fn bundle_content_hash(manifest: &CalculationBundleManifest) -> anyhow::Result<String> {
+    let mut value = serde_json::to_value(manifest)?;
+    value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Calculation Bundle manifest must be an object"))?
+        .remove("bundleContentHash");
+    canonical_sha256(&value)
+}
+
+fn canonical_sha256<T: Serialize>(value: &T) -> anyhow::Result<String> {
+    Ok(sha256_bytes(canonical_json_bytes(value)?.as_slice()))
+}
+
+fn canonical_json_bytes<T: Serialize>(value: &T) -> anyhow::Result<Vec<u8>> {
+    let bytes = serde_json::to_vec(value)?;
+    let parsed: Value = serde_json::from_slice(bytes.as_slice())?;
+    reject_non_finite_json(&parsed)?;
+    Ok(serde_json::to_vec(&parsed)?)
+}
+
+fn reject_non_finite_json(value: &Value) -> anyhow::Result<()> {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                reject_non_finite_json(item)?;
+            }
+        }
+        Value::Object(items) => {
+            for item in items.values() {
+                reject_non_finite_json(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn sha256_file(path: &Path) -> anyhow::Result<String> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn validate_sha256(value: &str, field: &str) -> anyhow::Result<()> {
+    if value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "{field} must be a lowercase SHA-256 digest"
+        ))
+    }
+}
+
+fn validate_version(value: &str, field: &str) -> anyhow::Result<()> {
+    let bytes = value.as_bytes();
+    if bytes.len() == 9
+        && bytes[2] == b'.'
+        && bytes[5] == b'.'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| index == 2 || index == 5 || byte.is_ascii_digit())
+    {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("{field} is not an ILCD version: {value}"))
+    }
+}
+
+fn require_nonempty(value: &str, field: &str) -> anyhow::Result<()> {
+    if value.trim().is_empty() {
+        Err(anyhow::anyhow!("{field} must not be empty"))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_finite(value: f64, field: &str) -> anyhow::Result<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("{field} must be finite"))
+    }
+}
+
+fn ensure_finite_nonzero(value: f64, field: &str) -> anyhow::Result<()> {
+    ensure_finite(value, field)?;
+    if value == 0.0 {
+        Err(anyhow::anyhow!("{field} must be non-zero"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use flate2::read::GzDecoder;
+    use solver_core::FactorizationState;
+
+    use super::*;
+    use crate::{
+        compiled_graph::{CompiledReleaseProcess, CompiledReleaseTechnosphereEdge},
+        snapshot_index::{SnapshotImpactMapEntry, SnapshotProcessMapEntry},
+    };
+
+    #[allow(clippy::too_many_lines)]
+    fn fixture_writer() -> CalculationBundleWriter {
+        let process_id = Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap();
+        let flow_id = Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap();
+        let elementary_id = Uuid::parse_str("33333333-3333-4333-8333-333333333333").unwrap();
+        let snapshot_id = Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+        let config: SnapshotBuildConfig = serde_json::from_value(json!({
+            "process_states": "100",
+            "selection_mode": "filtered_library",
+            "request_roots": [],
+            "process_limit": 0,
+            "provider_rule": "split_by_process_volume",
+            "provider_candidate_eligibility_mode": "reference_output_only",
+            "reference_normalization_mode": "strict",
+            "allocation_fraction_mode": "strict",
+            "allocation_semantics_version": "tidas-quantitative-reference-v2",
+            "biosphere_sign_mode": "gross",
+            "self_loop_cutoff": 0.999_999,
+            "singular_eps": 1e-12,
+            "has_lcia": true,
+            "method_id": null,
+            "method_version": null
+        }))
+        .unwrap();
+        let coverage: SnapshotCoverageReport = serde_json::from_value(json!({
+            "schema_version": "snapshot_coverage.v2",
+            "matching": {
+                "input_edges_total": 0,
+                "matched_unique_provider": 0,
+                "matched_multi_provider": 0,
+                "unmatched_no_provider": 0,
+                "unique_provider_match_pct": 100.0,
+                "any_provider_match_pct": 100.0
+            },
+            "reference": {
+                "process_total": 1,
+                "normalized_process_count": 1,
+                "missing_reference_count": 0,
+                "invalid_reference_count": 0
+            },
+            "allocation": {
+                "exchange_total": 1,
+                "allocation_fraction_present_pct": 100.0,
+                "allocation_fraction_missing_count": 0,
+                "allocation_fraction_invalid_count": 0
+            },
+            "singular_risk": {
+                "risk_level": "low",
+                "prefilter_diag_abs_ge_cutoff": 0,
+                "postfilter_a_diag_abs_ge_cutoff": 0,
+                "m_zero_diagonal_count": 0,
+                "m_min_abs_diagonal": 1.0
+            },
+            "matrix_scale": {
+                "process_count": 1,
+                "flow_count": 1,
+                "impact_count": 25,
+                "a_nnz": 0,
+                "b_nnz": 1,
+                "c_nnz": 25,
+                "m_nnz_estimated": 1,
+                "m_sparsity_estimated": 1.0
+            }
+        }))
+        .unwrap();
+        let impact_map = RELEASE_METHOD_IDENTITIES
+            .iter()
+            .enumerate()
+            .map(|(index, (method_id, version, _))| SnapshotImpactMapEntry {
+                impact_id: Uuid::parse_str(method_id).unwrap(),
+                impact_index: i32::try_from(index).unwrap(),
+                impact_version: Some((*version).to_owned()),
+                impact_key: format!("method:{index}"),
+                impact_name: format!("Method {index}"),
+                unit: "kg".to_owned(),
+            })
+            .collect();
+        let index = SnapshotIndexDocument {
+            version: 1,
+            snapshot_id,
+            process_count: 1,
+            impact_count: 25,
+            process_map: vec![SnapshotProcessMapEntry {
+                process_id,
+                process_index: 0,
+                process_version: "01.00.000".to_owned(),
+                process_name: None,
+                location: None,
+            }],
+            impact_map,
+            calculation_evidence: None,
+        };
+        let evidence = CompiledReleaseEvidence {
+            processes: vec![CompiledReleaseProcess {
+                process_idx: 0,
+                process_id,
+                process_version: "01.00.000".to_owned(),
+                quantitative_reference_exchange_internal_id: "0".to_owned(),
+                quantitative_reference_flow_id: flow_id,
+                quantitative_reference_flow_version: "01.00.000".to_owned(),
+                reference_unit: "kg".to_owned(),
+                normalized_mean_amount: 1.0,
+            }],
+            inventory_exchanges: vec![CompiledReleaseInventoryExchange {
+                process_idx: 0,
+                exchange_internal_id: Some("1".to_owned()),
+                flow_id: elementary_id,
+                flow_version: "01.00.000".to_owned(),
+                direction: CompiledExchangeDirection::Output,
+                unit: "kg".to_owned(),
+                location: Some("GLO".to_owned()),
+                normalized_mean_amount: 0.25,
+                allocation_target_internal_id: "0".to_owned(),
+                allocation_fraction: 1.0,
+            }],
+            technosphere_edges: vec![CompiledReleaseTechnosphereEdge {
+                consumer_process_idx: 0,
+                consumer_input_exchange_internal_id: "input-1".to_owned(),
+                provider_process_idx: 0,
+                provider_output_exchange_internal_id: "0".to_owned(),
+                provider_weight: 0.25,
+                normalized_amount: 2.0,
+                flow_id,
+                flow_version: "01.00.000".to_owned(),
+                location: Some("GLO".to_owned()),
+            }],
+            biosphere_edges: vec![CompiledReleaseInventoryExchange {
+                process_idx: 0,
+                exchange_internal_id: Some("1".to_owned()),
+                flow_id: elementary_id,
+                flow_version: "01.00.000".to_owned(),
+                direction: CompiledExchangeDirection::Output,
+                unit: "kg".to_owned(),
+                location: Some("GLO".to_owned()),
+                normalized_mean_amount: 0.25,
+                allocation_target_internal_id: "0".to_owned(),
+                allocation_fraction: 1.0,
+            }],
+        };
+        CalculationBundleWriter::new(
+            Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap(),
+            snapshot_id,
+            "1".repeat(64),
+            1,
+            config,
+            coverage,
+            &index,
+            &evidence,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn writes_directional_lci_lcia_and_stable_manifest() {
+        let mut writer = fixture_writer();
+        writer
+            .write_result_chunk(
+                0,
+                &[SolveResult {
+                    x: Some(vec![2.0]),
+                    g: None,
+                    h: Some((0..25).map(f64::from).collect()),
+                    factorization_state: FactorizationState::Ready,
+                }],
+            )
+            .unwrap();
+        let built = writer.finish().unwrap();
+        assert_eq!(built.manifest.schema_version, CALCULATION_BUNDLE_FORMAT);
+        assert_eq!(built.manifest.artifacts.len(), 7);
+        assert_eq!(built.bundle_content_hash.len(), 64);
+
+        let lci = built
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.metadata.kind == "lci")
+            .unwrap();
+        let mut decoder = GzDecoder::new(File::open(&lci.local_path).unwrap());
+        let mut body = String::new();
+        decoder.read_to_string(&mut body).unwrap();
+        assert!(body.contains("\"meanAmount\":0.5"));
+        assert!(body.contains("\"direction\":\"Output\""));
+
+        let technosphere = built
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.metadata.kind == "technosphere_edges")
+            .unwrap();
+        let mut decoder = GzDecoder::new(File::open(&technosphere.local_path).unwrap());
+        let mut body = String::new();
+        decoder.read_to_string(&mut body).unwrap();
+        assert!(body.contains("\"consumerInputExchangeInternalId\":\"input-1\""));
+        assert!(body.contains("\"providerOutputExchangeInternalId\":\"0\""));
+        assert!(body.contains("\"providerWeight\":0.25"));
+
+        let inventory = built
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.metadata.kind == "inventory_axis")
+            .unwrap();
+        let mut decoder = GzDecoder::new(File::open(&inventory.local_path).unwrap());
+        let mut body = String::new();
+        decoder.read_to_string(&mut body).unwrap();
+        assert!(body.contains("\"allocationTargetInternalId\":\"0\""));
+        assert!(body.contains("\"allocationFraction\":1.0"));
+    }
+
+    #[test]
+    fn rejects_missing_or_duplicate_result_chunks() {
+        let writer = fixture_writer();
+        assert!(writer.finish().is_err());
+
+        let mut writer = fixture_writer();
+        let result = SolveResult {
+            x: Some(vec![1.0]),
+            g: None,
+            h: Some(vec![0.0; 25]),
+            factorization_state: FactorizationState::Ready,
+        };
+        writer
+            .write_result_chunk(0, std::slice::from_ref(&result))
+            .unwrap();
+        assert!(writer.write_result_chunk(0, &[result]).is_err());
+    }
+
+    #[test]
+    fn identical_inputs_produce_identical_bundle_and_gzip_hashes() {
+        let solve = || SolveResult {
+            x: Some(vec![1.0]),
+            g: None,
+            h: Some(vec![0.0; 25]),
+            factorization_state: FactorizationState::Ready,
+        };
+        let build = || {
+            let mut writer = fixture_writer();
+            writer.write_result_chunk(0, &[solve()]).unwrap();
+            writer.finish().unwrap()
+        };
+        let first = build();
+        let second = build();
+        assert_eq!(first.bundle_content_hash, second.bundle_content_hash);
+        assert_eq!(first.manifest_sha256, second.manifest_sha256);
+        assert_eq!(
+            first
+                .manifest
+                .artifacts
+                .iter()
+                .map(|artifact| (&artifact.path, &artifact.sha256))
+                .collect::<Vec<_>>(),
+            second
+                .manifest
+                .artifacts
+                .iter()
+                .map(|artifact| (&artifact.path, &artifact.sha256))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/solver-worker/src/calculation_bundle.rs
+++ b/crates/solver-worker/src/calculation_bundle.rs
@@ -30,6 +30,7 @@ use crate::{
 pub const CALCULATION_BUNDLE_FORMAT: &str = "tiangong.calculation-bundle.v1";
 pub const CALCULATION_BUNDLE_MANIFEST_CONTENT_TYPE: &str = "application/json";
 pub const CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT: usize = 256;
+const CALCULATION_BUNDLE_GZIP_CONTENT_TYPE: &str = "application/gzip";
 const CALCULATION_CONTRACT_VERSION: &str = "1.0.0";
 const GZIP_LEVEL: u32 = 6;
 
@@ -131,10 +132,11 @@ pub async fn upload_built_calculation_bundle(
     for artifact in &bundle.artifacts {
         let relative_key = format!("{relative_prefix}/{}", artifact.metadata.path);
         let key = store.prefixed_object_key(&relative_key)?;
+        let storage_content_type = calculation_bundle_storage_content_type(&artifact.metadata)?;
         store
             .upload_object_key_file(
                 &key,
-                artifact.metadata.media_type.as_str(),
+                storage_content_type,
                 &artifact.local_path,
                 artifact.metadata.byte_size,
             )
@@ -160,6 +162,18 @@ pub async fn upload_built_calculation_bundle(
         manifest_byte_size: bundle.manifest_byte_size,
         artifact_count: bundle.artifacts.len(),
     })
+}
+
+fn calculation_bundle_storage_content_type(
+    artifact: &CalculationBundleArtifact,
+) -> anyhow::Result<&str> {
+    match artifact.compression.as_str() {
+        "gzip" => Ok(CALCULATION_BUNDLE_GZIP_CONTENT_TYPE),
+        "none" => Ok(artifact.media_type.as_str()),
+        compression => Err(anyhow::anyhow!(
+            "unsupported Calculation Bundle artifact compression: {compression}"
+        )),
+    }
 }
 
 #[derive(Debug)]
@@ -1395,6 +1409,46 @@ mod tests {
                 .iter()
                 .map(|artifact| (&artifact.path, &artifact.sha256))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn compressed_artifacts_use_gzip_storage_content_type() {
+        let mut writer = fixture_writer();
+        writer
+            .write_result_chunk(
+                0,
+                &[SolveResult {
+                    x: Some(vec![1.0]),
+                    g: None,
+                    h: Some(vec![0.0; 25]),
+                    factorization_state: FactorizationState::Ready,
+                }],
+            )
+            .unwrap();
+        let built = writer.finish().unwrap();
+        let lci = built
+            .manifest
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "lci")
+            .unwrap();
+        assert_eq!(lci.media_type, "application/x-ndjson");
+        assert_eq!(lci.compression, "gzip");
+        assert_eq!(
+            calculation_bundle_storage_content_type(lci).unwrap(),
+            CALCULATION_BUNDLE_GZIP_CONTENT_TYPE
+        );
+
+        let coverage = built
+            .manifest
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.kind == "coverage")
+            .unwrap();
+        assert_eq!(
+            calculation_bundle_storage_content_type(coverage).unwrap(),
+            "application/json"
         );
     }
 }

--- a/crates/solver-worker/src/compiled_graph.rs
+++ b/crates/solver-worker/src/compiled_graph.rs
@@ -10,6 +10,13 @@ pub enum CompiledFlowKind {
     Elementary,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum CompiledExchangeDirection {
+    Input,
+    Output,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CompiledEdgePartition {
@@ -266,6 +273,61 @@ pub struct CompiledGraph {
     pub reference_stats: CompiledReferenceStats,
     pub allocation_stats: CompiledAllocationStats,
     pub matching_stats: CompiledMatchingStats,
+    /// Exact source identities required to materialize directional LCI and one-hop release models.
+    /// Older snapshot artifacts do not contain this additive field and are intentionally not
+    /// eligible for canonical Calculation Bundle generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release_evidence: Option<CompiledReleaseEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompiledReleaseEvidence {
+    pub processes: Vec<CompiledReleaseProcess>,
+    pub inventory_exchanges: Vec<CompiledReleaseInventoryExchange>,
+    pub technosphere_edges: Vec<CompiledReleaseTechnosphereEdge>,
+    pub biosphere_edges: Vec<CompiledReleaseInventoryExchange>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompiledReleaseProcess {
+    pub process_idx: i32,
+    pub process_id: Uuid,
+    pub process_version: String,
+    pub quantitative_reference_exchange_internal_id: String,
+    pub quantitative_reference_flow_id: Uuid,
+    pub quantitative_reference_flow_version: String,
+    pub reference_unit: String,
+    pub normalized_mean_amount: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompiledReleaseInventoryExchange {
+    pub process_idx: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exchange_internal_id: Option<String>,
+    pub flow_id: Uuid,
+    pub flow_version: String,
+    pub direction: CompiledExchangeDirection,
+    pub unit: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    pub normalized_mean_amount: f64,
+    pub allocation_target_internal_id: String,
+    pub allocation_fraction: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompiledReleaseTechnosphereEdge {
+    pub consumer_process_idx: i32,
+    pub consumer_input_exchange_internal_id: String,
+    pub provider_process_idx: i32,
+    pub provider_output_exchange_internal_id: String,
+    pub provider_weight: f64,
+    pub normalized_amount: f64,
+    pub flow_id: Uuid,
+    pub flow_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/solver-worker/src/contribution_path.rs
+++ b/crates/solver-worker/src/contribution_path.rs
@@ -670,6 +670,7 @@ mod tests {
             impact_map: vec![SnapshotImpactMapEntry {
                 impact_id,
                 impact_index: 0,
+                impact_version: Some("01.00.000".to_owned()),
                 impact_key: "GWP".to_owned(),
                 impact_name: "Global warming".to_owned(),
                 unit: "kg CO2-eq".to_owned(),

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -21,6 +21,10 @@ use crate::{
         EncodedArtifact, encode_contribution_path_artifact, encode_solve_all_unit_query_artifact,
         encode_solve_batch_artifact, encode_solve_one_artifact,
     },
+    calculation_bundle::{
+        CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT, CalculationBundleArtifactRef,
+        CalculationBundleWriter, upload_built_calculation_bundle,
+    },
     calculation_evidence::{
         LcaCalculationEvidence, validate_calculation_evidence,
         validate_calculation_evidence_binding,
@@ -744,8 +748,9 @@ fn merge_job_status_update_timing(
 
 #[derive(Debug, Clone)]
 struct SnapshotArtifactMeta {
-    artifact_url: String,
-    artifact_format: String,
+    url: String,
+    format: String,
+    sha256: String,
 }
 
 /// Loads sparse snapshot data from snapshot artifact first, then falls back to `lca_*` tables.
@@ -761,7 +766,7 @@ pub async fn fetch_snapshot_sparse_data(
             Err(err) => {
                 warn!(
                     snapshot_id = %snapshot_id,
-                    artifact_format = %meta.artifact_format,
+                    artifact_format = %meta.format,
                     error = %err,
                     "failed to load snapshot artifact, falling back to table-backed sparse data"
                 );
@@ -860,7 +865,7 @@ async fn fetch_snapshot_artifact_meta(
 ) -> anyhow::Result<Option<SnapshotArtifactMeta>> {
     let row = match sqlx::query(
         r"
-        SELECT artifact_url, artifact_format
+        SELECT artifact_url, artifact_format, artifact_sha256
         FROM lca_snapshot_artifacts
         WHERE snapshot_id = $1
           AND status = 'ready'
@@ -879,8 +884,9 @@ async fn fetch_snapshot_artifact_meta(
 
     row.map(|r| {
         Ok(SnapshotArtifactMeta {
-            artifact_url: r.try_get::<String, _>("artifact_url")?,
-            artifact_format: r.try_get::<String, _>("artifact_format")?,
+            url: r.try_get::<String, _>("artifact_url")?,
+            format: r.try_get::<String, _>("artifact_format")?,
+            sha256: r.try_get::<String, _>("artifact_sha256")?,
         })
     })
     .transpose()
@@ -903,10 +909,7 @@ async fn fetch_decoded_snapshot_artifact_from_meta(
     snapshot_id: Uuid,
     meta: &SnapshotArtifactMeta,
 ) -> anyhow::Result<DecodedSnapshotArtifact> {
-    let bytes = state
-        .object_store
-        .download_object_url(&meta.artifact_url)
-        .await?;
+    let bytes = state.object_store.download_object_url(&meta.url).await?;
 
     let decoded = decode_snapshot_artifact(bytes.as_slice())?;
     if decoded.snapshot_id != snapshot_id {
@@ -937,7 +940,7 @@ pub(crate) async fn fetch_snapshot_index_document(
     let meta = fetch_snapshot_artifact_meta(&state.pool, snapshot_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("snapshot {snapshot_id} has no ready artifact"))?;
-    let snapshot_index_url = derive_snapshot_index_url(&meta.artifact_url);
+    let snapshot_index_url = derive_snapshot_index_url(&meta.url);
     let bytes = state
         .object_store
         .download_object_url(&snapshot_index_url)
@@ -975,7 +978,7 @@ fn is_undefined_table(err: &sqlx::Error) -> bool {
 /// Executes one queue payload end-to-end.
 #[instrument(skip(state))]
 pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow::Result<()> {
-    handle_job_payload_with_worker_lease(state, payload, None).await
+    Box::pin(handle_job_payload_with_worker_lease(state, payload, None)).await
 }
 
 pub(crate) async fn handle_worker_jobs_job_payload(
@@ -985,7 +988,7 @@ pub(crate) async fn handle_worker_jobs_job_payload(
     lease_token: Uuid,
     lease_seconds: i32,
 ) -> anyhow::Result<()> {
-    handle_job_payload_with_worker_lease(
+    Box::pin(handle_job_payload_with_worker_lease(
         state,
         payload,
         Some(BuildSnapshotWorkerLease {
@@ -993,7 +996,7 @@ pub(crate) async fn handle_worker_jobs_job_payload(
             lease_token,
             lease_seconds,
         }),
-    )
+    ))
     .await
 }
 
@@ -1149,6 +1152,7 @@ async fn handle_job_payload_with_worker_lease(
                 &solved,
                 "solve_batch",
                 calculation_evidence.clone(),
+                None,
             )
             .await?;
             let completed_diag = merge_job_status_update_timing(
@@ -1214,22 +1218,16 @@ async fn handle_job_payload_with_worker_lease(
                 ));
             }
             let batch_size = normalize_all_unit_batch_size(unit_batch_size, n);
-            let solve_options = resolve_solve_all_unit_options(solve)?;
-
-            let mut items = Vec::with_capacity(n);
-            for start in (0..n).step_by(batch_size) {
-                let end = (start + batch_size).min(n);
-                let rhs_batch = build_all_unit_rhs_batch(n, start, end);
-                let partial = state.solver.solve_batch(
-                    snapshot_id,
-                    NumericOptions { print_level: level },
-                    rhs_batch.as_slice(),
-                    solve_options,
-                )?;
-                items.extend(partial.items);
-            }
-
-            let solved = SolveBatchResult { items };
+            let _ = resolve_solve_all_unit_options(solve)?;
+            let (solved, calculation_bundle) = solve_all_unit_with_calculation_bundle(
+                state,
+                job_id,
+                snapshot_id,
+                n,
+                batch_size,
+                level,
+            )
+            .await?;
             let query_artifact_meta =
                 persist_solve_all_unit_query_artifact(state, job_id, snapshot_id, &solved)
                     .await
@@ -1250,6 +1248,7 @@ async fn handle_job_payload_with_worker_lease(
                 &solved,
                 "solve_all_unit",
                 calculation_evidence.clone(),
+                Some(calculation_bundle.clone()),
             )
             .await?;
             let completed_diag = merge_job_status_update_timing(
@@ -1260,6 +1259,7 @@ async fn handle_job_payload_with_worker_lease(
                         "process_count": n,
                         "unit_batch_size": batch_size,
                     },
+                    "calculation_bundle": calculation_bundle,
                     "calculation_evidence": calculation_evidence,
                 }),
                 "running",
@@ -1762,6 +1762,7 @@ async fn persist_solve_one_result(
             compute_timing: Some(timing_json),
             encode_artifact_sec,
             calculation_evidence,
+            calculation_bundle: None,
         },
     )
     .await
@@ -1774,6 +1775,7 @@ async fn persist_solve_batch_result(
     solved: &SolveBatchResult,
     suffix: &'static str,
     calculation_evidence: Option<LcaCalculationEvidence>,
+    calculation_bundle: Option<CalculationBundleArtifactRef>,
 ) -> anyhow::Result<Value> {
     let encode_started = Instant::now();
     let encoded = encode_solve_batch_artifact(snapshot_id, job_id, solved)?;
@@ -1789,9 +1791,88 @@ async fn persist_solve_batch_result(
             compute_timing: None,
             encode_artifact_sec,
             calculation_evidence,
+            calculation_bundle,
         },
     )
     .await
+}
+
+async fn solve_all_unit_with_calculation_bundle(
+    state: &AppState,
+    job_id: Uuid,
+    snapshot_id: Uuid,
+    process_count: usize,
+    solve_batch_size: usize,
+    print_level: f64,
+) -> anyhow::Result<(SolveBatchResult, CalculationBundleArtifactRef)> {
+    let snapshot_meta = fetch_snapshot_artifact_meta(&state.pool, snapshot_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("snapshot {snapshot_id} has no ready artifact"))?;
+    let decoded =
+        fetch_decoded_snapshot_artifact_from_meta(state, snapshot_id, &snapshot_meta).await?;
+    let release_evidence = decoded
+        .compiled_graph
+        .as_ref()
+        .and_then(|graph| graph.release_evidence.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "snapshot {snapshot_id} lacks exact Calculation Bundle release evidence; rebuild the snapshot"
+            )
+        })?;
+    let snapshot_index = fetch_snapshot_index_document(state, snapshot_id).await?;
+    if usize::try_from(decoded.payload.process_count)? != process_count {
+        return Err(anyhow::anyhow!(
+            "snapshot process count drift while building Calculation Bundle"
+        ));
+    }
+    let mut bundle_writer = CalculationBundleWriter::new(
+        job_id,
+        snapshot_id,
+        snapshot_meta.sha256,
+        usize::try_from(decoded.payload.flow_count)?,
+        decoded.config,
+        decoded.coverage,
+        &snapshot_index,
+        &release_evidence,
+    )?;
+
+    let mut legacy_items = Vec::with_capacity(process_count);
+    let internal_options = SolveOptions {
+        return_x: true,
+        return_g: false,
+        return_h: true,
+    };
+    for artifact_start in (0..process_count).step_by(CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT) {
+        let artifact_end =
+            (artifact_start + CALCULATION_BUNDLE_CHUNK_PROCESS_COUNT).min(process_count);
+        let mut artifact_items = Vec::with_capacity(artifact_end - artifact_start);
+        for solve_start in (artifact_start..artifact_end).step_by(solve_batch_size) {
+            let solve_end = (solve_start + solve_batch_size).min(artifact_end);
+            let rhs_batch = build_all_unit_rhs_batch(process_count, solve_start, solve_end);
+            let partial = state.solver.solve_batch(
+                snapshot_id,
+                NumericOptions { print_level },
+                rhs_batch.as_slice(),
+                internal_options,
+            )?;
+            artifact_items.extend(partial.items);
+        }
+        bundle_writer.write_result_chunk(artifact_start, artifact_items.as_slice())?;
+        legacy_items.extend(artifact_items.into_iter().map(|item| SolveResult {
+            x: None,
+            g: None,
+            h: item.h,
+            factorization_state: item.factorization_state,
+        }));
+    }
+    let built = bundle_writer.finish()?;
+    let bundle_ref = upload_built_calculation_bundle(&state.object_store, &built).await?;
+    Ok((
+        SolveBatchResult {
+            items: legacy_items,
+        },
+        bundle_ref,
+    ))
 }
 
 async fn persist_solve_all_unit_query_artifact(
@@ -1841,6 +1922,7 @@ async fn persist_contribution_path_result(
             compute_timing: None,
             encode_artifact_sec: 0.0,
             calculation_evidence,
+            calculation_bundle: None,
         },
     )
     .await
@@ -1900,6 +1982,7 @@ struct PersistArtifactInput {
     compute_timing: Option<Value>,
     encode_artifact_sec: f64,
     calculation_evidence: Option<LcaCalculationEvidence>,
+    calculation_bundle: Option<CalculationBundleArtifactRef>,
 }
 
 struct ArtifactMeta {
@@ -1939,6 +2022,7 @@ struct LciaResultPackageArtifacts {
     latest_all_unit_result_id: Uuid,
     result_diag: Value,
     query_artifact_meta: QueryArtifactMeta,
+    calculation_bundle: CalculationBundleArtifactRef,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1979,6 +2063,7 @@ struct PersistTimingContext {
     encode_artifact_sec: f64,
     upload_artifact_sec: f64,
     calculation_evidence: Option<LcaCalculationEvidence>,
+    calculation_bundle: Option<CalculationBundleArtifactRef>,
 }
 
 pub(crate) async fn run_review_submit_gate_snapshot_builder(
@@ -2086,7 +2171,8 @@ pub(crate) async fn handle_lcia_result_package_build_worker_job(
             "artifactSha256": artifacts.query_artifact_meta.sha256.clone(),
             "artifactByteSize": artifacts.query_artifact_meta.byte_size,
             "artifactFormat": artifacts.query_artifact_meta.format.clone(),
-        }
+        },
+        "calculationBundle": artifacts.calculation_bundle.clone(),
     });
 
     let mark_ready = mark_lcia_result_package_ready(
@@ -2194,22 +2280,16 @@ async fn persist_lcia_result_package_all_unit_artifacts(
         ));
     }
 
-    let mut items = Vec::with_capacity(n);
     let batch_size = normalize_all_unit_batch_size(None, n);
-    let solve_options = resolve_solve_all_unit_options(None)?;
-    for start in (0..n).step_by(batch_size) {
-        let end = (start + batch_size).min(n);
-        let rhs_batch = build_all_unit_rhs_batch(n, start, end);
-        let partial = state.solver.solve_batch(
-            snapshot_id,
-            NumericOptions { print_level: 0.0 },
-            rhs_batch.as_slice(),
-            solve_options,
-        )?;
-        items.extend(partial.items);
-    }
-
-    let solved = SolveBatchResult { items };
+    let (solved, calculation_bundle) = solve_all_unit_with_calculation_bundle(
+        state,
+        result_job_id,
+        snapshot_id,
+        n,
+        batch_size,
+        0.0,
+    )
+    .await?;
     let query_artifact_meta =
         persist_solve_all_unit_query_artifact(state, result_job_id, snapshot_id, &solved).await?;
     let result_diag = persist_solve_batch_result(
@@ -2219,6 +2299,7 @@ async fn persist_lcia_result_package_all_unit_artifacts(
         &solved,
         "solve_all_unit",
         None,
+        Some(calculation_bundle.clone()),
     )
     .await?;
     let result_id = latest_result_id_for_job(&state.pool, result_job_id)
@@ -2240,6 +2321,7 @@ async fn persist_lcia_result_package_all_unit_artifacts(
         latest_all_unit_result_id,
         result_diag,
         query_artifact_meta,
+        calculation_bundle,
     })
 }
 
@@ -2273,6 +2355,7 @@ async fn persist_result_artifact(
         compute_timing,
         encode_artifact_sec,
         calculation_evidence,
+        calculation_bundle,
     } = input;
     let EncodedArtifact {
         format,
@@ -2299,6 +2382,7 @@ async fn persist_result_artifact(
         encode_artifact_sec,
         upload_artifact_sec: upload_started.elapsed().as_secs_f64(),
         calculation_evidence,
+        calculation_bundle,
     };
     persist_object_storage_result(
         state,
@@ -2802,6 +2886,7 @@ async fn persist_object_storage_result(
         "artifact_bytes": artifact_meta.encoded_len,
         "artifact_url": artifact_url,
         "calculation_evidence": timing.calculation_evidence.clone(),
+        "calculation_bundle": timing.calculation_bundle.clone(),
         "compute_timing_sec": timing.compute_timing,
         "persistence_timing_sec": persistence_timing_json(
             Some(timing.encode_artifact_sec),
@@ -2834,6 +2919,7 @@ async fn persist_object_storage_result(
         "artifact_bytes": artifact_meta.encoded_len,
         "artifact_url": artifact_url,
         "calculation_evidence": timing.calculation_evidence.clone(),
+        "calculation_bundle": timing.calculation_bundle.clone(),
         "compute_timing_sec": timing.compute_timing,
         "persistence_timing_sec": persistence_timing_json(
             Some(timing.encode_artifact_sec),

--- a/crates/solver-worker/src/lib.rs
+++ b/crates/solver-worker/src/lib.rs
@@ -12,6 +12,7 @@ pub fn default_snapshot_process_states_arg() -> String {
 }
 
 pub mod artifacts;
+pub mod calculation_bundle;
 pub mod calculation_evidence;
 pub mod compiled_graph;
 pub mod config;

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -362,13 +362,13 @@ async fn process_solver_worker_job(state: &AppState, job: WorkerJob, lease_secon
                 .map(|_| ())
         }
         _ => {
-            handle_worker_jobs_job_payload(
+            Box::pin(handle_worker_jobs_job_payload(
                 state,
                 payload.clone(),
                 job.id,
                 job.lease_token,
                 lease_seconds,
-            )
+            ))
             .await
         }
     };

--- a/crates/solver-worker/src/readiness.rs
+++ b/crates/solver-worker/src/readiness.rs
@@ -1292,6 +1292,7 @@ mod tests {
                 reference_stats: CompiledReferenceStats::default(),
                 allocation_stats: CompiledAllocationStats::default(),
                 matching_stats: CompiledMatchingStats::default(),
+                release_evidence: None,
             }),
             policy: MatrixReadinessPolicy::default(),
         }

--- a/crates/solver-worker/src/review_submit_gate.rs
+++ b/crates/solver-worker/src/review_submit_gate.rs
@@ -1579,6 +1579,7 @@ mod tests {
                 reference_stats: CompiledReferenceStats::default(),
                 allocation_stats: CompiledAllocationStats::default(),
                 matching_stats: CompiledMatchingStats::default(),
+                release_evidence: None,
             }),
             target_process_indices: vec![1],
             process_records: vec![

--- a/crates/solver-worker/src/snapshot_artifacts.rs
+++ b/crates/solver-worker/src/snapshot_artifacts.rs
@@ -650,6 +650,7 @@ mod tests {
                 ..CompiledAllocationStats::default()
             },
             matching_stats: CompiledMatchingStats::default(),
+            release_evidence: None,
         };
         let encoded_with_graph = encode_snapshot_artifact_with_graph(
             snapshot_id,

--- a/crates/solver-worker/src/snapshot_index.rs
+++ b/crates/solver-worker/src/snapshot_index.rs
@@ -34,6 +34,8 @@ pub struct SnapshotProcessMapEntry {
 pub struct SnapshotImpactMapEntry {
     pub impact_id: Uuid,
     pub impact_index: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub impact_version: Option<String>,
     pub impact_key: String,
     pub impact_name: String,
     pub unit: String,

--- a/crates/solver-worker/src/storage.rs
+++ b/crates/solver-worker/src/storage.rs
@@ -276,6 +276,61 @@ impl ObjectStoreClient {
         self.upload_object(key, content_type, bytes, None).await
     }
 
+    /// Uploads a local file to an explicit bucket-relative object key with bounded multipart use.
+    pub async fn upload_object_key_file(
+        &self,
+        key: &str,
+        content_type: &str,
+        file_path: &Path,
+        artifact_byte_size: u64,
+    ) -> anyhow::Result<ObjectUploadResult> {
+        let key = key.trim_start_matches('/');
+        if key.is_empty()
+            || key
+                .split('/')
+                .any(|segment| segment.is_empty() || segment == "..")
+        {
+            return Err(anyhow::anyhow!(
+                "object key must be a normalized relative path"
+            ));
+        }
+        let upload_mode = if artifact_byte_size < MULTIPART_UPLOAD_THRESHOLD_BYTES {
+            "single_put"
+        } else {
+            "multipart"
+        };
+        self.ensure_upload_size_allowed(upload_mode, Some(artifact_byte_size))?;
+        if artifact_byte_size < MULTIPART_UPLOAD_THRESHOLD_BYTES {
+            return self
+                .upload_object(
+                    key,
+                    content_type,
+                    std::fs::read(file_path)?,
+                    Some(artifact_byte_size),
+                )
+                .await;
+        }
+        self.upload_object_multipart(key, content_type, file_path, artifact_byte_size)
+            .await
+    }
+
+    /// Returns the configured object-store prefix joined to a normalized relative key.
+    pub fn prefixed_object_key(&self, relative_key: &str) -> anyhow::Result<String> {
+        let relative_key = relative_key.trim_matches('/');
+        if relative_key.is_empty()
+            || relative_key
+                .split('/')
+                .any(|segment| segment.is_empty() || segment == "..")
+        {
+            return Err(anyhow::anyhow!("relative object key must be normalized"));
+        }
+        if self.prefix.is_empty() {
+            Ok(relative_key.to_owned())
+        } else {
+            Ok(format!("{}/{relative_key}", self.prefix))
+        }
+    }
+
     /// Uploads one package artifact from a local file and returns upload metadata.
     pub async fn upload_package_artifact_file(
         &self,

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,9 +33,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-13
-lastReviewedCommit: 0bdc10b85d6022a6f5a9ca8b0ff7014e8da96d9a
-lastReviewedNote: "Reviewed static LCIA cache ownership, streamed gap evidence, worker-only build projection, and exact snapshot diagnostic scope for Issues #116/#118."
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedNote: "Reviewed Calculation Bundle v1 ownership, exact release evidence in snapshot artifacts, and bounded directional LCI/LCIA chunk generation for Issue #123."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -143,6 +143,8 @@ It also owns package-job artifacts and diagnostics. The default `PACKAGE_QUEUE_B
 ### Result persistence
 
 Result artifacts are persisted through the worker and supporting runtime storage flows instead of inlining heavy compute payloads into the API layer.
+
+`crates/solver-worker/src/calculation_bundle.rs` owns canonical `tiangong.calculation-bundle.v1` generation. Snapshot compilation stores an additive exact `release_evidence` projection beside the sparse payload: quantitative references, source inventory identities, direct directional biosphere exchanges, and resolved technosphere edges with both exchange internal IDs and provider weights. New all-unit solves temporarily retain `x` only inside one fixed 256-process artifact chunk, derive directional LCI from those exact direct exchanges, retain H for the existing query view, and upload content-addressed sidecars before the manifest. Older snapshots without that projection must be rebuilt and are never guessed from A/B.
 
 ## Operational Baseline
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 7822f8988e0702faa745c0e97509f851450d81e7
 lastReviewedNote: "Reviewed Calculation Bundle v1 ownership, exact release evidence in snapshot artifacts, and bounded directional LCI/LCIA chunk generation for Issue #123."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,9 +38,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-15
-lastReviewedCommit: 19c4ddbf18a8792c939341ba97ab8393112b7be3
-lastReviewedNote: "Reviewed bounded targetless allocation compatibility and successful-task replay proof for Issue #121."
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedNote: "Reviewed Calculation Bundle deterministic artifact, directional numeric parity, bounded chunk, and exact-identity validation for Issue #123."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -70,6 +70,7 @@ The local `pre-push` hook runs the docpact gate first and then runs `make check`
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
 | --- | --- | --- | --- |
 | `crates/**` solver or worker code | `make check`; hard Clippy gate; hard format gate | run the narrow manual script that matches the touched area, such as snapshot build, full compute debug, or BW25 validation | Record which job family or worker path was exercised. |
+| Calculation Bundle / all-unit directional LCI | `cargo test -p solver-worker calculation_bundle`; `cargo test -p solver-worker --bin snapshot_builder`; `cargo check -p solver-worker --all-targets`; hard Clippy and format gates | with safe DB/S3 env, rebuild one snapshot, run `solve_all_unit`, verify manifest-last upload, all compressed/uncompressed hashes, exact 256-process boundaries, reviewed 25-method identities, directional LCI parity, and retry byte determinism | Old snapshots without `compiled_graph.release_evidence` must fail closed and be rebuilt. Never infer exchange IDs, versions, units, directions, or provider output IDs from matrix indices. |
 | solver `worker_jobs` queue backend | `cargo test -p solver-worker worker_jobs`; `cargo test -p solver-worker maps_worker_jobs`; `cargo check -p solver-worker`; hard Clippy gate; hard format gate | when DB/S3 env is available, enqueue one safe `worker_queue=solver` job and run `solver-worker --queue-backend worker-jobs --mode worker` to verify claim/heartbeat/result projection; for legacy-table retirement, run against a schema where `public.lca_jobs` is absent or ignored | Keep `docs/lca-api-contract.md` and `docs/edge-function-integration.md` aligned with job kind, payload schema, worker_jobs result_ref, and optional legacy `lca_jobs` compatibility expectations. |
 | versioned public-plus-owner-draft snapshot / LCIA evidence | `cargo test -p solver-worker calculation_evidence`; `cargo test -p solver-worker static_lcia_cache`; `cargo test -p solver-worker maps_exact_public_owner_draft_build_v2`; `cargo test -p solver-worker rejects_summary_only_lcia_manifest_before_build_execution`; `cargo test -p solver-worker --bin snapshot_builder`; `cargo check -p solver-worker --all-targets`; baseline hard gates | run ignored `verifies_reviewed_release_bundle_bytes` with `LCIA_STATIC_CACHE_RELEASE_DIR=<next-public-root>` whenever the reviewed static bundle changes; in a non-production environment with DB/S3 available, enqueue one v2 build and verify public `100`, owner `0`, foreign/nonzero/collaboration rejection, snapshot-index source/identity hashes, per-method JSONL gap count, worker-only build result projection, and solve binding drift rejection | Never use a production data mutation as validation. Keep the complete reviewed manifest plus Edge/Next/Worker v2 source, scope, matrix, and release hashes byte-for-byte aligned; reject summary-only manifests during queue payload validation, and reject v1 source/evidence/solve downgrade. |
 | snapshot-builder or provider-matching behavior | baseline gates plus `./scripts/build_snapshot_from_ilcd.sh` when safe | run provider-link diagnostics export helpers when the task changes matching logic | Keep `docs/provider-linking.md` and the implicit regional supply mix docs aligned with runtime semantics. Snapshot and provider diagnostics often need task-specific proof. |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 7822f8988e0702faa745c0e97509f851450d81e7
 lastReviewedNote: "Reviewed Calculation Bundle deterministic artifact, directional numeric parity, bounded chunk, and exact-identity validation for Issue #123."
 related:
   - ../../AGENTS.md

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -23,8 +23,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: 9b66c8714fbbe15c7e25418ac963dc2c764ed8e1
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -23,8 +23,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: 9b66c8714fbbe15c7e25418ac963dc2c764ed8e1
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,9 +22,9 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: 9b66c8714fbbe15c7e25418ac963dc2c764ed8e1
-lastReviewedNote: "Reviewed for Issues #116/#118: release-pinned static LCIA source, per-method coverage, worker-only build projection, and exact snapshot diagnostics."
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedNote: "Reviewed for Issue #123: immutable Calculation Bundle v1, directional LCI, exact graph identities, and bounded all-unit result chunks."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -142,6 +142,8 @@ legacy `lca_jobs.job_type` 与 worker payload `type` 必须一致。`worker_jobs
 
 - worker 会按 `unit_batch_size` 分块构造单位需求向量（每个 process 一条 `amount=1`）。
 - 为控制结果体积，`solve_all_unit` 仅支持 `return_h=true` 且 `return_x/return_g=false`。
+- 对调用者仍只返回/保留 H；worker 内部会在固定 256-process artifact chunk 内临时请求 `x+h`，用 snapshot 的 exact directional biosphere evidence 计算 LCI，写完该 chunk 后立即释放 `x`。完整 `x`、`G` 或 directional LCI 矩阵不会在内存中跨 chunk 聚合。
+- 每个成功的新 `solve_all_unit` 同时生成不可变 `tiangong.calculation-bundle.v1`。旧 snapshot 若没有 exact release evidence，任务以明确错误要求重建 snapshot；worker 不从 A/B 或数据库当前态猜测 exchange identity。
 
 ### 3.5 兼容字段
 
@@ -235,6 +237,29 @@ legacy pgmq/debug 路径语义：
 - `diagnostics.calculation_evidence`：versioned scoped snapshots 必须为非空，并与 snapshot-index binding 完全一致；legacy snapshots 为 `null`
 
 `snapshot` artifact 当前格式：`snapshot-hdf5:v1`。
+
+### 5.1 Calculation Bundle v1
+
+`solve_all_unit` 的 canonical release evidence 是 manifest + deterministic gzip NDJSON sidecars：
+
+```text
+calculation-bundle.json
+axes/processes-000000.ndjson.gz
+axes/inventory-000000.ndjson.gz
+graph/technosphere-000000.ndjson.gz
+graph/biosphere-000000.ndjson.gz
+results/lci-000000.ndjson.gz
+results/lcia-000000.ndjson.gz
+evidence/coverage.json
+```
+
+- 每个 canonical chunk 固定覆盖最多 256 个连续 process index；NDJSON record 使用 canonical JSON 和单个换行，gzip 固定 level 6、mtime 0、无文件名/comment。
+- manifest 的 `artifacts[]` 按 path 排序，记录 compressed/uncompressed SHA-256、byte size、record count 与 process-index boundary；`bundleContentHash` 不包含生成时间、对象存储 URL 或自身 hash。
+- process axis 固化 Process UUID/version 和唯一 quantitative reference 的 exchange internal ID、Flow UUID/version、reference unit 与归一化 amount；inventory axis 逐 exchange 保存 allocation target 与 selected fraction。
+- technosphere evidence 固化 consumer input / provider output exchange internal ID、provider weight、未分摊 normalized input amount、Flow UUID/version 和 location；split-provider 每个最终 provider 一条 edge。
+- directional LCI key 固定为 Flow UUID/version + Input/Output + reference unit + optional location；LCIA 固定绑定已审查 static-cache bundle 1.2.4 的 25 个 method UUID/version。
+- object path 使用 `calculation-bundles/<calculation-id>/<bundle-content-hash>/...`，先上传 sidecars，最后上传 manifest。job diagnostics 的 `calculation_bundle`（package build 中为 `artifactManifest.calculationBundle`）保存 manifest URL/hash/byte size 和 bundle content hash。
+- `hdf5:v1` 与 `all-unit-query:v1` 继续作为兼容/查询视图；它们不是 canonical release evidence。
 
 Snapshot 的 Process 身份契约是：一个完整 TIDAS Process revision 只代表其 `quantitativeReference.referenceToReferenceFlow`，并且只对应一个 process index / 矩阵列。非 reference co-product output 不生成派生 Process、矩阵列或 eligible provider；若 co-product `B` 需要参与计算，上游必须提供另一个完整、独立、以 `B` 为 quantitative reference 的 Process revision。
 

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,8 +22,8 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 7822f8988e0702faa745c0e97509f851450d81e7
 lastReviewedNote: "Reviewed for Issue #123: immutable Calculation Bundle v1, directional LCI, exact graph identities, and bounded all-unit result chunks."
 related:
   - AGENTS.md

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: 9b66c8714fbbe15c7e25418ac963dc2c764ed8e1
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: 9b66c8714fbbe15c7e25418ac963dc2c764ed8e1
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -29,8 +29,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-06-10
-lastReviewedCommit: 4546fb8fff034c84cd1b699cb049345b70eabe16
+lastReviewedAt: 2026-07-16
+lastReviewedCommit: 31f2bb4af9a73c39e548d9a0d8390ace92647ad5
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #123

## Summary

- persist a canonical, content-addressed Calculation Bundle for every all-unit LCIA package build
- retain exact process/quantitative-reference, allocated inventory, provider-edge, directional LCI, LCIA, coverage, and reviewed method-set evidence
- store bundle references in result diagnostics and package artifact manifests while preserving the legacy H-result read path
- make gzip NDJSON chunks deterministic and publish the manifest only after all sidecars upload successfully
- resolve exact Flow -> FlowProperty -> UnitGroup reference-unit metadata in snapshot compilation

## Key contracts

- `tiangong.calculation-bundle.v1`
- fixed 256-process chunks
- exact UUID + version references
- reviewed 25-method static-cache identity
- fail closed for legacy snapshots without release evidence
- allocation target/fraction retained per source exchange

## Validation

- `make check`
  - cargo fmt --check
  - clippy with warnings denied
  - full workspace tests (solver-worker: 183 passed; snapshot-builder: 66 passed)
- Docpact worktree lint: pass
- deterministic retry, directional LCI, graph identity, allocation evidence, and missing/duplicate chunk tests included

## Risk / rollout

Existing snapshot artifacts deserialize with `release_evidence = None`; canonical release bundle generation deliberately requires a newly rebuilt snapshot. Legacy H-result consumers remain unchanged.
