### PR TITLE
fix: remove lifecycle state blocking from review gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-20"
-lastReviewedCommit: "4001a5f367ba1eb3a2405e71042d1fe0987acf88"
+lastReviewedCommit: "7dbb9ced5ce00cec24c62334ca75cb12dbf18df8"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 4001a5f367ba1eb3a2405e71042d1fe0987acf88
-lastReviewedNote: "Reviewed worker ownership, validation, and governance boundaries for the signed-flow linking redesign in Issue #131; boundaries are unchanged."
+lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedNote: "Reviewed worker ownership and lifecycle-versus-numerical gate boundaries for Issue #133; repo boundaries are unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/review_submit_gate.rs
+++ b/crates/solver-worker/src/review_submit_gate.rs
@@ -39,6 +39,8 @@ pub struct ReviewSubmitGatePolicy {
     pub policy_profile: String,
     #[serde(default = "default_true")]
     pub require_revision_checksum_match: bool,
+    /// Compatibility-only lifecycle policy projection. The worker numerical gate does not
+    /// evaluate process state codes.
     #[serde(default = "default_allowed_scope_states")]
     pub allowed_scope_states: Vec<i32>,
     #[serde(default = "default_false")]
@@ -169,6 +171,8 @@ pub struct RevisionGateMetrics {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct ProcessScanMetrics {
     pub process_records_total: usize,
+    /// Compatibility-only report projection. Lifecycle states are not evaluated by the worker
+    /// numerical gate, so this remains zero.
     pub invalid_scope_state_count: usize,
     pub duplicate_process_version_groups: usize,
     pub invalid_exchange_amount_count: usize,
@@ -273,61 +277,10 @@ fn check_process_records(
     blockers: &mut Vec<ReadinessFinding>,
 ) {
     metrics.process_scan.process_records_total = input.process_records.len();
-    check_scope_states(input, metrics, blockers);
     check_duplicate_process_versions(input, metrics, blockers);
     check_exchanges(input, metrics, blockers);
     check_duplicate_exchange_fingerprints(input, metrics, blockers);
     check_service_loops(input, metrics, blockers);
-}
-
-fn check_scope_states(
-    input: &ReviewSubmitGateInput,
-    metrics: &mut ReviewSubmitGateMetrics,
-    blockers: &mut Vec<ReadinessFinding>,
-) {
-    if input.policy.allowed_scope_states.is_empty() {
-        return;
-    }
-    let allowed = input
-        .policy
-        .allowed_scope_states
-        .iter()
-        .copied()
-        .collect::<BTreeSet<_>>();
-    let invalid = input
-        .process_records
-        .iter()
-        .filter(|record| {
-            record
-                .state_code
-                .is_none_or(|state_code| !allowed.contains(&state_code))
-        })
-        .take(DETAIL_LIMIT)
-        .map(process_detail)
-        .collect::<Vec<_>>();
-
-    metrics.process_scan.invalid_scope_state_count = input
-        .process_records
-        .iter()
-        .filter(|record| {
-            record
-                .state_code
-                .is_none_or(|state_code| !allowed.contains(&state_code))
-        })
-        .count();
-
-    if metrics.process_scan.invalid_scope_state_count > 0 {
-        push_blocker(
-            blockers,
-            "invalid_scope_state",
-            "dataset revision contains processes outside the review-submit scope states",
-            json!({
-                "invalid_scope_state_count": metrics.process_scan.invalid_scope_state_count,
-                "allowed_scope_states": input.policy.allowed_scope_states,
-                "examples": invalid
-            }),
-        );
-    }
 }
 
 fn check_duplicate_process_versions(
@@ -1120,29 +1073,19 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_allows_draft_and_reviewed_scope_states() {
+    fn lifecycle_scope_states_do_not_block_numerical_gate() {
         let mut input = clean_input();
-        input.process_records[0].state_code = Some(0);
+        input.process_records[0].state_code = Some(20);
         input.process_records[1].state_code = Some(100);
+        input.policy.allowed_scope_states = vec![0, 100];
 
         let report = verify_review_submit_gate(&input);
 
         assert_eq!(report.status, ReviewSubmitGateStatus::Passed);
         assert!(!has_blocker(&report, "invalid_scope_state"));
         assert_eq!(report.metrics.process_scan.invalid_scope_state_count, 0);
-    }
-
-    #[test]
-    fn default_policy_blocks_under_review_scope_state() {
-        let mut input = clean_input();
-        input.process_records[0].state_code = Some(20);
-
-        let report = verify_review_submit_gate(&input);
-
-        assert_eq!(report.status, ReviewSubmitGateStatus::Blocked);
-        assert!(has_blocker(&report, "invalid_scope_state"));
-        assert_eq!(report.metrics.process_scan.invalid_scope_state_count, 1);
-        assert!(!report.metrics.probe.factorization_checked);
+        assert!(report.metrics.probe.factorization_checked);
+        assert_eq!(report.policy.allowed_scope_states, vec![0, 100]);
     }
 
     #[test]
@@ -1208,7 +1151,7 @@ mod tests {
         let report = verify_review_submit_gate(&input);
 
         assert_eq!(report.status, ReviewSubmitGateStatus::Blocked);
-        assert!(has_blocker(&report, "invalid_scope_state"));
+        assert!(!has_blocker(&report, "invalid_scope_state"));
         assert!(has_blocker(&report, "duplicate_process_version"));
         assert!(has_blocker(&report, "missing_or_zero_reference"));
         assert!(has_blocker(&report, "invalid_allocation_fraction"));

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,9 +33,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
-lastReviewedNote: "Reviewed frozen TIDAS source closure capture and Calculation Bundle materialization for Issue #127."
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedNote: "Reviewed review-submit gate ownership for Issue #133; the runtime family and crate map are unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,9 +38,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
-lastReviewedNote: "Reviewed frozen source-closure proof and reviewed LCIA method locator aliases for Issue #127."
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedNote: "Reviewed proof requirements for Issue #133; the existing review-submit and hard gate validation matrix remains sufficient."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,9 +22,9 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
-lastReviewedNote: "Reviewed for Issue #127: frozen TIDAS source closure in Calculation Bundle v1 and exact LCIA method identity aliases."
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedNote: "Reviewed shared job/result/status semantics for Issue #133; lifecycle eligibility remains outside the worker numerical report contract."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -29,8 +29,9 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedNote: "Removed lifecycle state blocking from the worker-owned numerical gate for Issue #133; lifecycle eligibility remains a consumer/coordinator responsibility."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -182,7 +183,7 @@ worker runtime 不调用 final submit，也不直接修改 review-submit domain 
 默认策略：
 
 - 要求 `expected_revision_checksum == actual_revision_checksum`。
-- `allowed_scope_states = [0] + 100..=199`；`0` 表示提交审核前 draft root，`100..=199` 用于已审核 / 可用依赖数据兼容；`20` 等审核中状态不允许，仍会触发 `invalid_scope_state`。
+- `allowed_scope_states` 与 `metrics.process_scan.invalid_scope_state_count` 仅作为 `v1` JSON 兼容投影保留。worker 数值 gate 不解释 process lifecycle state，也不产生 `invalid_scope_state`；生命周期准入由前端、Edge 或 database submit coordinator 负责，且不应依赖 worker 数值结论替代服务端权威校验。
 - provider missing、unresolved、equal fallback、allocation conservation 和 volume evidence 只记录在 `metrics.provider_scan`，不作为提交审核 blocker。
 - legacy provider policy 字段 `block_equal_fallback` / `block_provider_volume_fallback` 默认为 `false`；即使旧请求传入 `true`，review-submit gate 也不再据此产生 provider blocker。
 - 默认不要求 LCIA factors；review-submit submit-readiness 只验证 `M` factorization 和 targeted `x/g` 稳定性。
@@ -222,7 +223,6 @@ DB runner 生成两类 review-submit artifact：
 | Code | 触发条件 | 主要修复方向 |
 | --- | --- | --- |
 | `revision_report_stale` | revision checksum 缺失或不匹配 | 基于当前 revision 重跑 gate |
-| `invalid_scope_state` | process record 的 `state_code` 不在 policy 允许范围 | 修正计算 scope 或 process lifecycle state |
 | `duplicate_process_version` | 同一 process ID 多个版本同时进入 gate scope | 去重或明确只纳入目标版本 |
 | `missing_or_zero_reference` | quantitative reference 未精确命中一个 exchange、direction 不是 Input/Output、最终 amount 非 finite 或为零、声明多个 reference flow，或 coverage 有 reference failure | 修复 reference identity、direction 和 finite non-zero amount |
 | `invalid_exchange_amount` | exchange amount 缺失、不可解析、带非法文本、NaN 或 Infinity | 修复 exchange amount / 单位转换 |
@@ -246,7 +246,7 @@ Provider 相关信号仍会保留在 `metrics.provider_scan` 中，供 UI 展示
 DB runner 先对权威 `processes.json_ordered` 执行 allocation semantics preflight；invalid allocation 在任何 snapshot build / persistence 前直接阻断。通过 preflight 后，snapshot compile fail closed 地验证 quantitative reference，随后 Gate 按便宜到昂贵的顺序执行：
 
 1. revision freshness。
-2. process record scan：scope state、精确 signed reference pivot、finite non-zero 最终 amount、target-aware allocation、duplicate fingerprint、service-loop。
+2. process record scan：精确 signed reference pivot、finite non-zero 最终 amount、target-aware allocation、duplicate fingerprint、service-loop；`state_code` 不参与 worker 数值阻断。
 3. balance/provider compatibility scan：unresolved、equal fallback、allocation conservation、volume evidence，仅记录 metrics。
 4. flow / LCIA semantic scan。
 5. sparse structure scan：diagonal、duplicate sparse column。


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#133

## Summary
- Stop treating process lifecycle state codes, including `state_code=20`, as worker numerical-gate blockers.
- Retain `allowed_scope_states` and `invalid_scope_state_count` as v1 compatibility projections while removing `invalid_scope_state` from emitted blockers.

## Key Decisions
- Keep lifecycle eligibility in frontend/Edge/database submit coordination; the worker gate remains responsible for checksum, process data, sparse structure, factorization, and targeted solve stability.
- Preserve the v1 JSON fields to avoid a report/policy schema break.

## Validation
- `cargo test -p solver-worker review_submit_gate` (29 passed).
- `cargo check -p solver-worker --bin review_submit_gate`.
- `make check` (format, workspace Clippy, and workspace tests passed; 192 solver-worker tests passed, 1 environment-dependent test ignored).
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`.
- `cargo fmt --all -- --check`.
- `docpact validate-config --strict` and `docpact lint --worktree --mode enforce`.
- GitHub reports no automatic checks for this branch; this repository keeps ordinary CI push triggers disabled.

## Risks / Rollback
- Consumers that previously relied on worker-emitted `invalid_scope_state` must enforce lifecycle eligibility in their coordinator path; rollback is to restore `check_scope_states`.

## Follow-ups
- After merge, bump the `tiangong-lca-worker` submodule pointer through the workspace integration flow.
- The source branch is hosted on the renamed fork `chukeaa/tiangong-lca-calculator` because the authenticated account cannot push to the canonical repository.

## Workspace Integration
- Workspace Integration remains Pending until the merged worker commit is pinned by `lca-workspace`.
