### PR TITLE
fix: normalize database LCIA method identities

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-20"
-lastReviewedCommit: "d5c784169496114ef9c77eae61e6937fe6926923"
+lastReviewedAt: "2026-07-21"
+lastReviewedCommit: "bc40e015e60effd62fd159f1a61cb99b09a5556b"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: d5c784169496114ef9c77eae61e6937fe6926923
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 lastReviewedNote: "Reviewed worker ownership, validation, and governance boundaries for exact Flow revision binding and closure pruning in Issue #135; repo boundaries are unchanged."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -30,9 +30,9 @@ use solver_worker::calculation_evidence::{
     LcaCalculationEvidence, LcaMethodFactorSourceSnapshot, LciaFactorCoverageCounts,
     LciaFactorCoverageEvidence, LciaMethodFactorCoverage, LciaUncharacterizedEvidenceArtifact,
     LciaUncharacterizedRecord, MISSING_FACTOR_SEMANTICS, PUBLIC_PLUS_OWNER_DRAFT_SCOPE,
-    PublicOwnerDraftBuildRequest, UNCHARACTERIZED_ARTIFACT_FORMAT, ValidatedPublicOwnerDraftScope,
-    canonical_json_bytes, sha256_bytes, validate_calculation_evidence,
-    validate_public_owner_draft_build_request,
+    PublicOwnerDraftBuildRequest, RELEASE_METHOD_IDENTITIES, UNCHARACTERIZED_ARTIFACT_FORMAT,
+    ValidatedPublicOwnerDraftScope, canonical_json_bytes, sha256_bytes,
+    validate_calculation_evidence, validate_public_owner_draft_build_request,
 };
 use solver_worker::compiled_graph::{
     CompiledAllocationStats, CompiledBalanceResolution, CompiledBiosphereEdge,
@@ -259,6 +259,19 @@ struct MethodRow {
     json: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedLciaMethodIdentity {
+    method_id: Uuid,
+    method_version: String,
+    artifact_locator_id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedLciaMethodRow {
+    identity: ResolvedLciaMethodIdentity,
+    json: Value,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct SourceDatasetReference {
     dataset_type: CompiledReleaseSourceDatasetType,
@@ -422,7 +435,7 @@ struct MethodSelection {
     method_count: i64,
     factor_count: i64,
     source_evidence: Option<LcaMethodFactorSourceSnapshot>,
-    rows: Vec<MethodRow>,
+    rows: Vec<ResolvedLciaMethodRow>,
     static_bundle: Option<VerifiedStaticLciaBundle>,
 }
 
@@ -2245,6 +2258,104 @@ fn sorted_json(value: &Value) -> Value {
     }
 }
 
+fn reviewed_lcia_identity_matches(
+    method_id: Uuid,
+    method_version: &str,
+    artifact_locator_id: Uuid,
+) -> bool {
+    RELEASE_METHOD_IDENTITIES.iter().any(
+        |(reviewed_method_id, reviewed_version, reviewed_locator_id)| {
+            *reviewed_version == method_version
+                && Uuid::parse_str(reviewed_method_id)
+                    .expect("reviewed LCIA method id must be a valid UUID")
+                    == method_id
+                && Uuid::parse_str(reviewed_locator_id)
+                    .expect("reviewed LCIA artifact locator must be a valid UUID")
+                    == artifact_locator_id
+        },
+    )
+}
+
+fn reviewed_lcia_artifact_locator(
+    method_id: Uuid,
+    method_version: &str,
+) -> anyhow::Result<Option<Uuid>> {
+    let mut matches = RELEASE_METHOD_IDENTITIES.iter().filter_map(
+        |(reviewed_method_id, reviewed_version, reviewed_locator_id)| {
+            if *reviewed_version == method_version
+                && Uuid::parse_str(reviewed_method_id)
+                    .expect("reviewed LCIA method id must be a valid UUID")
+                    == method_id
+            {
+                Some(
+                    Uuid::parse_str(reviewed_locator_id)
+                        .expect("reviewed LCIA artifact locator must be a valid UUID"),
+                )
+            } else {
+                None
+            }
+        },
+    );
+    let locator = matches.next();
+    if matches.next().is_some() {
+        return Err(anyhow::anyhow!(
+            "reviewed LCIA method identity is ambiguous: method={method_id}@{method_version}"
+        ));
+    }
+    Ok(locator)
+}
+
+fn resolve_database_lcia_method_row(row: MethodRow) -> anyhow::Result<ResolvedLciaMethodRow> {
+    let method_id =
+        source_dataset_document_id(CompiledReleaseSourceDatasetType::LciaMethod, &row.json)?;
+    if method_id != row.id && !reviewed_lcia_identity_matches(method_id, &row.version, row.id) {
+        return Err(anyhow::anyhow!(
+            "database LCIA method identity alias is not reviewed: method={method_id}@{} locator={}",
+            row.version,
+            row.id
+        ));
+    }
+    Ok(ResolvedLciaMethodRow {
+        identity: ResolvedLciaMethodIdentity {
+            method_id,
+            method_version: row.version,
+            artifact_locator_id: row.id,
+        },
+        json: row.json,
+    })
+}
+
+fn validate_unique_database_lcia_method_identities(
+    rows: &[ResolvedLciaMethodRow],
+) -> anyhow::Result<()> {
+    let mut locators = BTreeMap::<(Uuid, String), Uuid>::new();
+    for row in rows {
+        let key = (row.identity.method_id, row.identity.method_version.clone());
+        if let Some(existing_locator) =
+            locators.insert(key.clone(), row.identity.artifact_locator_id)
+        {
+            return Err(anyhow::anyhow!(
+                "database LCIA method identity resolves more than once: method={}@{} locators={existing_locator},{}",
+                key.0,
+                key.1,
+                row.identity.artifact_locator_id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_database_lcia_method_rows(
+    rows: Vec<MethodRow>,
+) -> anyhow::Result<Vec<ResolvedLciaMethodRow>> {
+    let rows = rows
+        .into_iter()
+        .map(resolve_database_lcia_method_row)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    validate_unique_database_lcia_method_identities(&rows)?;
+    Ok(rows)
+}
+
 async fn resolve_method_identity(
     pool: &PgPool,
     cli: &Cli,
@@ -2307,7 +2418,7 @@ async fn resolve_method_identity(
         });
     }
 
-    let rows = fetch_selected_method_rows(pool, cli).await?;
+    let rows = resolve_database_lcia_method_rows(fetch_selected_method_rows(pool, cli).await?)?;
     if rows.is_empty() {
         return Err(anyhow::anyhow!("no lciamethods found"));
     }
@@ -2328,10 +2439,14 @@ async fn resolve_method_identity(
     })?;
     let source_evidence = None;
 
+    let selected_identity = cli
+        .method_id
+        .and_then(|_| rows.first().map(|row| &row.identity));
+
     Ok(MethodSelection {
         has_lcia: true,
-        method_id: cli.method_id,
-        method_version: cli.method_version.clone(),
+        method_id: selected_identity.map(|identity| identity.method_id),
+        method_version: selected_identity.map(|identity| identity.method_version.clone()),
         method_count,
         factor_count,
         source_evidence,
@@ -2343,6 +2458,9 @@ async fn resolve_method_identity(
 async fn fetch_selected_method_rows(pool: &PgPool, cli: &Cli) -> anyhow::Result<Vec<MethodRow>> {
     let rows = match cli.method_id {
         Some(method_id) => {
+            let method_version = cli.method_version.as_deref().unwrap_or_default();
+            let artifact_locator_id =
+                reviewed_lcia_artifact_locator(method_id, method_version)?.unwrap_or(method_id);
             sqlx::query(
                 r#"
                 SELECT id, version, json
@@ -2350,8 +2468,8 @@ async fn fetch_selected_method_rows(pool: &PgPool, cli: &Cli) -> anyhow::Result<
                 WHERE id = $1 AND version = $2::bpchar
                 "#,
             )
-            .bind(method_id)
-            .bind(cli.method_version.clone().unwrap_or_default())
+            .bind(artifact_locator_id)
+            .bind(method_version)
             .fetch_all(pool)
             .await?
         }
@@ -2530,6 +2648,7 @@ fn load_impact_factor_sets(method: &MethodSelection) -> anyhow::Result<Vec<Impac
 
     let mut out = Vec::with_capacity(method.rows.len());
     for row in &method.rows {
+        let identity = &row.identity;
         let mut factor_map: HashMap<Uuid, f64> = HashMap::new();
         let mut directional_factor_map: HashMap<(Uuid, ExchangeDirection), f64> = HashMap::new();
         for factor in method_factor_items(&row.json) {
@@ -2552,23 +2671,23 @@ fn load_impact_factor_sets(method: &MethodSelection) -> anyhow::Result<Vec<Impac
                     &mut directional_factor_map,
                     (flow_id, direction),
                     value,
-                    row.id,
+                    identity.method_id,
                 )?;
             }
             if value.abs() <= f64::EPSILON {
                 continue;
             }
-            accumulate_finite_factor(&mut factor_map, flow_id, value, row.id)?;
+            accumulate_finite_factor(&mut factor_map, flow_id, value, identity.method_id)?;
         }
         factor_map.retain(|_, value| value.abs() > f64::EPSILON);
 
         out.push(ImpactFactorSet {
-            impact_id: row.id,
-            method_version: row.version.clone(),
-            artifact_locator_id: row.id,
-            impact_key: format!("method:{}", row.id),
+            impact_id: identity.method_id,
+            method_version: identity.method_version.clone(),
+            artifact_locator_id: identity.artifact_locator_id,
+            impact_key: format!("method:{}", identity.method_id),
             impact_name: parse_lcia_method_name(&row.json)
-                .unwrap_or_else(|| format!("LCIA Method {}", row.id)),
+                .unwrap_or_else(|| format!("LCIA Method {}", identity.method_id)),
             unit: parse_lcia_method_unit(&row.json).unwrap_or_else(|| "unknown".to_owned()),
             factors_by_flow: factor_map,
             factors_by_flow_direction: directional_factor_map,
@@ -8363,22 +8482,25 @@ mod tests {
         AllocationFallbackState, AllocationFractionState, AllocationMode, Cli,
         DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS, ExchangeDirection, FlowRow, ImpactFactorSet,
         LciaExchangeObservation, MethodSelection, MultiProviderDecision, NormalizationMode,
-        ParsedExchange, ProcessMeta, ProcessRow, ProviderRule, SnapshotBuildConfig,
-        SnapshotSelectionMode, SourceDatasetReference, SourceSnapshotSummary,
-        accumulate_finite_factor, add_technosphere_edge, assemble_sparse_payload,
-        attach_artifact_lifecycle, biosphere_gross_value, build_compiled_release_evidence,
-        build_lcia_factor_coverage, build_review_submit_overlay_graph,
-        candidate_count_bucket_label, collect_source_dataset_references,
-        compute_review_submit_overlay_source_hash, compute_scope_hash,
-        compute_source_fingerprint_from_summary, geo_score, insert_compiled_source_dataset,
-        location_granularity_label, no_balancing_reference_failure_reason, normalize_request_roots,
-        parse_number, parse_process_annual_supply_or_production_volume, parse_process_states,
-        parse_provider_rule_list, resolve_allocation_fraction, resolve_lcia_method_source_row,
-        resolve_multi_provider, resolve_process_selection, resolve_reference_normalization,
-        review_submit_root_dependency_fingerprint, snapshot_db_statement_timeout,
-        source_dataset_document_id, source_reference_is_satisfied, summarize_matching_diagnostics,
-        time_score, unique_supported_direction_by_flow, validate_flow_row_visibility,
-        validate_process_row_visibility, validate_quantitative_references,
+        ParsedExchange, ProcessMeta, ProcessRow, ProviderRule, ResolvedLciaMethodIdentity,
+        ResolvedLciaMethodRow, SnapshotBuildConfig, SnapshotSelectionMode, SourceDatasetReference,
+        SourceSnapshotSummary, accumulate_finite_factor, add_technosphere_edge,
+        assemble_sparse_payload, attach_artifact_lifecycle, biosphere_gross_value,
+        build_compiled_release_evidence, build_lcia_factor_coverage,
+        build_review_submit_overlay_graph, candidate_count_bucket_label,
+        collect_source_dataset_references, compute_review_submit_overlay_source_hash,
+        compute_scope_hash, compute_source_fingerprint_from_summary, geo_score,
+        insert_compiled_source_dataset, load_impact_factor_sets, location_granularity_label,
+        no_balancing_reference_failure_reason, normalize_request_roots, parse_number,
+        parse_process_annual_supply_or_production_volume, parse_process_states,
+        parse_provider_rule_list, resolve_allocation_fraction, resolve_database_lcia_method_row,
+        resolve_database_lcia_method_rows, resolve_lcia_method_source_row, resolve_multi_provider,
+        resolve_process_selection, resolve_reference_normalization,
+        review_submit_root_dependency_fingerprint, reviewed_lcia_artifact_locator,
+        snapshot_db_statement_timeout, source_dataset_document_id, source_reference_is_satisfied,
+        summarize_matching_diagnostics, time_score, unique_supported_direction_by_flow,
+        validate_flow_row_visibility, validate_process_row_visibility,
+        validate_quantitative_references, validate_unique_database_lcia_method_identities,
     };
     use chrono::Utc;
     use clap::Parser;
@@ -12436,6 +12558,116 @@ mod tests {
             resolve_lcia_method_source_row(Uuid::new_v4(), method_version, locator_id, &rows)
                 .expect_err("unreviewed locator/document identity drift must fail closed");
         assert!(mismatch.to_string().contains("identity alias mismatch"));
+    }
+
+    #[test]
+    fn database_lcia_method_loading_normalizes_the_reviewed_locator_alias() {
+        let method_id = Uuid::parse_str("503699e0-eca9-4089-8bf8-e0f49c93e578").expect("method id");
+        let locator_id =
+            Uuid::parse_str("9ec743ea-6b00-400d-a53b-61547a3fc03c").expect("locator id");
+        let method_version = "01.01.000";
+        let document = json!({
+            "LCIAMethodDataSet": {
+                "LCIAMethodInformation": {
+                    "dataSetInformation": {
+                        "common:UUID": method_id.to_string()
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            reviewed_lcia_artifact_locator(method_id, method_version)
+                .expect("reviewed identity lookup"),
+            Some(locator_id)
+        );
+        let rows = resolve_database_lcia_method_rows(vec![super::MethodRow {
+            id: locator_id,
+            version: method_version.to_owned(),
+            json: document,
+        }])
+        .expect("reviewed database alias should normalize");
+        assert_eq!(rows[0].identity.method_id, method_id);
+        assert_eq!(rows[0].identity.method_version, method_version);
+        assert_eq!(rows[0].identity.artifact_locator_id, locator_id);
+
+        let impacts = load_impact_factor_sets(&MethodSelection {
+            has_lcia: true,
+            method_id: None,
+            method_version: None,
+            method_count: 1,
+            factor_count: 0,
+            source_evidence: None,
+            rows,
+            static_bundle: None,
+        })
+        .expect("impact factors should retain normalized identity");
+        assert_eq!(impacts[0].impact_id, method_id);
+        assert_eq!(impacts[0].method_version, method_version);
+        assert_eq!(impacts[0].artifact_locator_id, locator_id);
+        assert_eq!(impacts[0].impact_key, format!("method:{method_id}"));
+    }
+
+    #[test]
+    fn database_lcia_method_loading_accepts_self_identity_and_rejects_unreviewed_aliases() {
+        let method_id = Uuid::new_v4();
+        let method_version = "01.00.000";
+        let method_document = |document_id: Uuid| {
+            json!({
+                "LCIAMethodDataSet": {
+                    "LCIAMethodInformation": {
+                        "dataSetInformation": {
+                            "common:UUID": document_id.to_string()
+                        }
+                    }
+                }
+            })
+        };
+
+        let resolved = resolve_database_lcia_method_row(super::MethodRow {
+            id: method_id,
+            version: method_version.to_owned(),
+            json: method_document(method_id),
+        })
+        .expect("self-identical database method should remain valid");
+        assert_eq!(resolved.identity.method_id, method_id);
+        assert_eq!(resolved.identity.artifact_locator_id, method_id);
+
+        let mismatch = resolve_database_lcia_method_row(super::MethodRow {
+            id: Uuid::new_v4(),
+            version: method_version.to_owned(),
+            json: method_document(method_id),
+        })
+        .expect_err("unreviewed database locator alias must fail closed");
+        assert!(mismatch.to_string().contains("alias is not reviewed"));
+    }
+
+    #[test]
+    fn database_lcia_method_loading_rejects_duplicate_canonical_identities() {
+        let method_id = Uuid::new_v4();
+        let method_version = "01.00.000";
+        let rows = vec![
+            ResolvedLciaMethodRow {
+                identity: ResolvedLciaMethodIdentity {
+                    method_id,
+                    method_version: method_version.to_owned(),
+                    artifact_locator_id: Uuid::new_v4(),
+                },
+                json: json!({}),
+            },
+            ResolvedLciaMethodRow {
+                identity: ResolvedLciaMethodIdentity {
+                    method_id,
+                    method_version: method_version.to_owned(),
+                    artifact_locator_id: Uuid::new_v4(),
+                },
+                json: json!({}),
+            },
+        ];
+
+        let duplicate = validate_unique_database_lcia_method_identities(&rows)
+            .expect_err("duplicate canonical LCIA identities must fail closed");
+        assert!(duplicate.to_string().contains("resolves more than once"));
     }
 
     #[test]

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 lastReviewedNote: "Reviewed review-submit gate ownership for Issue #133; the runtime family and crate map are unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 lastReviewedNote: "Reviewed proof requirements for Issue #133; the existing review-submit and hard gate validation matrix remains sufficient."
 related:
   - ../../AGENTS.md

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -24,8 +24,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 4001a5f367ba1eb3a2405e71042d1fe0987acf88
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -24,8 +24,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 4001a5f367ba1eb3a2405e71042d1fe0987acf88
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -22,9 +22,9 @@ checkPaths:
   - docs/review-submit-fast-gate-contract.md
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
-lastReviewedNote: "Reviewed shared job/result/status semantics for Issue #133; lifecycle eligibility remains outside the worker numerical report contract."
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
+lastReviewedNote: "Documented database-backed LCIA canonical method identity and artifact locator normalization for Issue #137."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -189,6 +189,8 @@ For this scope, `lca.solve_one.request.v2`, `lca.solve_all_unit.request.v2`, and
 
 `lcia_result.package_build` 不是普通求解 API 的用户请求类型，而是 data product manager command 创建的后台构建任务。payload 必须来自数据库/Edge 的 service-role command 边界，包含 `buildId`、`requestedBy`、published-only `inputManifest`、`inputManifestHash`、`coverageMode`、`eligibleInputCount`、`includedInputCount`、`lciaMethodSet` 和可选 `defaultImpactCategory`。worker 只接受 `inputManifest.processes` 中 `stateCode/state_code` 为 `100..199` 的已发布过程；不会纳入 draft data。
 
+该 package build 的 legacy database-backed LCIA 路径在读取 factors 前必须把每个方法归一化为 `(canonical method UUID, exact version, artifact locator UUID)`：文档内 `common:UUID` 是 matrix axis、calculation evidence、result key 和 source-closure identity，`public.lciamethods.id` 只作为精确读取该文档的 artifact locator。Locator 与文档 UUID 相同时可直接使用；不相同时必须与 reviewed `RELEASE_METHOD_IDENTITIES` 中的完整三元组精确匹配，否则在矩阵构建前 fail closed。单方法选择若使用 canonical UUID，worker 可通过同一 reviewed mapping 定位 locator，但写入 snapshot/result 的仍是 canonical UUID。
+
 On success, the worker records a terminal `worker_jobs` result with:
 
 - `result_json.lcaJobId`
@@ -260,7 +262,7 @@ evidence/coverage.json
 - process axis 固化 Process UUID/version 和唯一 quantitative reference 的 exchange internal ID、Flow UUID/version、reference unit、raw direction/amount/coefficient 与 signed normalized pivot；inventory axis逐 exchange 保存 raw/signed/normalized coefficient、allocation target 与 selected fraction。Snapshot flow axis 使用 `(Flow UUID, resolved version)`；同一 UUID 的多个实际引用 revision 可共存并获得独立连续 `flow_idx`，未被最终 process closure 引用的历史 revision 不进入矩阵或 bundle。
 - 普通 fresh snapshot 与 review-submit overlay snapshot 都必须把 `compiled_graph.release_evidence` 及 `source_datasets` 写入 snapshot artifact。source closure 从本次 snapshot 精确选择的 Process/Flow revision 和已审 LCIA Method identity 出发，递归解析 Contact、Flow Property、Source、Unit Group 与 LCIA Method reference；显式版本只允许 exact match，省略的 support version 选择最高 fixed-width ILCD version，缺失、歧义、无效 UUID/version 或同 identity/version 内容漂移均 fail closed。Process/Flow 仍受 snapshot scope 约束；被这些可发布根文档精确引用的 support document 按 UUID/version 展开，不在 solve 时重新查询。
 - 若 exchange 的 Flow 引用省略 `@version`，release evidence 使用本次 snapshot 实际选择并冻结的 Flow metadata version；若引用显式给出版本，则 worker 精确查询并保持该版本绑定，且 unit metadata 只允许来自同一版本，不能静默回退到另一版本。同一 UUID 的不同显式 revision 作为不同 identity 参与 provider lookup 与 flow axis；任何缺失或不可见的 exact revision 都在 snapshot compilation 时 fail closed。
-- 已审 LCIA static-cache 中方法 UUID 与 artifact locator 不同的已知 alias，只允许 locator 用于精确读取源文档；source closure、LCIA axis 与最终发布始终使用文档内的 canonical method UUID/version。25 个方法任一 identity/locator/document UUID 不一致都 fail closed。
+- 已审 LCIA 方法中 UUID 与 artifact locator 不同的已知 alias，无论来自 static cache 还是 legacy database-backed package build，都只允许 locator 用于精确读取源文档；source closure、LCIA axis 与最终发布始终使用文档内的 canonical method UUID/version。25 个方法任一 identity/version/locator/document UUID 不符合 reviewed mapping 都 fail closed。
 - technosphere evidence 使用中性字段固化 `dependent_process_idx`、`residual_exchange_internal_id`、`balancing_process_idx`、`balancing_reference_exchange_internal_id`、residual/reference coefficient、routing weight、activity requirement、Flow UUID/version 和 location；每个最终 balancing reference port 一条 edge。
 - directional LCI key 固定为 Flow UUID/version + Input/Output + reference unit + optional location；LCIA 固定绑定已审查 static-cache bundle 1.2.4 的 25 个 method UUID/version。
 - object path 使用 `calculation-bundles/<calculation-id>/<bundle-content-hash>/...`，先上传 sidecars，最后上传 manifest。job diagnostics 的 `calculation_bundle`（package build 中为 `artifactManifest.calculationBundle`）保存 manifest URL/hash/byte size 和 bundle content hash。

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: 6d61068445ebfad0fb3e07469f6d0468d692574a
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: bc40e015e60effd62fd159f1a61cb99b09a5556b
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#137

## Summary
- Normalize database-backed LCIA method rows into canonical document UUID, exact version, and artifact locator before factor aggregation and source closure.
- Fix production package build failure 75e3816d-7d8d-4dc3-9132-22610a44ced5 without changing LCIA source data or weakening closure checks.

## Key Decisions
- Use document common:UUID for impact axes, factor diagnostics, calculation evidence, result keys, and snapshot metadata; use lciamethods.id only as artifact locator.
- Accept self-identical rows and require an exact RELEASE_METHOD_IDENTITIES tuple for locator/document mismatches.
- Allow a canonical single-method CLI selection to resolve its reviewed locator while preserving fail-closed behavior for unknown aliases and duplicate canonical identities.

## Validation
- cargo test -p solver-worker calculation_evidence (12 passed).
- cargo test -p solver-worker --bin snapshot_builder (84 passed).
- cargo check -p solver-worker --all-targets passed.
- make check passed, including rustfmt, workspace Clippy with -D warnings, and all workspace tests (one pre-existing external-asset test remains ignored).
- docpact validate-config --strict and docpact lint --worktree passed after required document reviews were recorded.

## Risks / Rollback
- Low-to-moderate runtime scope: changes only database-backed LCIA identity assembly. Static-cache loading, source data, schemas, and source-closure validation are unchanged; rollback is a single commit revert.

## Follow-ups
- tiangong-lca/workspace#449 tracks exact cross-repo lciaMethodSet materialization and request-time method pruning.

## Workspace Integration
- After merge, bump tiangong-lca-worker in lca-workspace and deploy the merged Worker commit to all three machines.