### PR TITLE
perf: replace canonical_value sort with pre-computed keys and spawn_blocking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,8 @@ QUEUE_DB_ACQUIRE_TIMEOUT_SECONDS="30"
 
 BUILD_SNAPSHOT_MAX_CONCURRENCY="1"
 BUILD_SNAPSHOT_LOCK_POLL_MS="5000"
+# Number of parallel TIDAS validation worker processes. 0 = all CPU cores.
+# TIDAS_VALIDATION_JOBS="0"
 # SNAPSHOT_BUILDER_BIN="/absolute/path/to/snapshot_builder"
 # Prefer LCA_WORKER_ROOT for new deployments. LCA_CALCULATOR_ROOT remains a
 # backward-compatible fallback while existing worker hosts migrate paths.

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -898,18 +898,22 @@ async fn collect_scope_closure<P: ScopeClosureProvider>(
         }
     }
 
-    tokio::task::yield_now().await;
-    let scan = finalize_scope_closure_scan(
-        edges,
-        resolved_references,
-        omitted_version_resolutions,
-        raw_issues,
-        &roots,
-        &graph,
-        complete,
-        documents,
-        scheduled,
-    );
+    let roots_clone = roots.clone();
+    let graph_clone = graph.clone();
+    let scan = tokio::task::spawn_blocking(move || {
+        finalize_scope_closure_scan(
+            edges,
+            resolved_references,
+            omitted_version_resolutions,
+            raw_issues,
+            &roots_clone,
+            &graph_clone,
+            complete,
+            documents,
+            scheduled,
+        )
+    })
+    .await?;
     Ok(scan)
 }
 
@@ -925,14 +929,14 @@ fn finalize_scope_closure_scan(
     documents: BTreeMap<ExactDatasetIdentity, ClosureDocument>,
     scheduled: BTreeSet<ExactDatasetIdentity>,
 ) -> ScopeClosureScan {
-    edges.sort_by_key(canonical_value);
+    sort_by_canonical_value(&mut edges);
     resolved_references.sort();
-    omitted_version_resolutions.sort_by_key(canonical_value);
+    sort_by_canonical_value(&mut omitted_version_resolutions);
     let mut raw_issues = raw_issues;
     attach_reference_occurrences(&mut raw_issues, &resolved_references);
     let mut issues = coalesce_issues(raw_issues);
     compute_affected_roots_batch(&mut issues, roots, graph);
-    issues.sort_by_key(canonical_value);
+    issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
 
     ScopeClosureScan {
         schema_version: "lcia.scope-closure-scan.v1".to_owned(),
@@ -1087,7 +1091,7 @@ fn populate_affected_roots(scan: &mut ScopeClosureScan) {
             .insert(reference.target.clone());
     }
     compute_affected_roots_batch(&mut scan.issues, &scan.roots, &graph);
-    scan.issues.sort_by_key(canonical_value);
+    scan.issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
 }
 
 #[must_use]
@@ -1693,6 +1697,18 @@ fn canonical_value<T: Serialize>(value: &T) -> String {
         .unwrap_or_default()
 }
 
+fn sort_by_canonical_value<T: Serialize>(items: &mut Vec<T>) {
+    let mut keyed: Vec<(String, T)> = items
+        .drain(..)
+        .map(|item| {
+            let key = canonical_value(&item);
+            (key, item)
+        })
+        .collect();
+    keyed.sort_by(|a, b| a.0.cmp(&b.0));
+    items.extend(keyed.into_iter().map(|(_, item)| item));
+}
+
 fn canonical_json_bytes<T: Serialize>(value: &T) -> anyhow::Result<Vec<u8>> {
     let value = serde_json::to_value(value)?;
     let mut output = Vec::new();
@@ -1835,7 +1851,7 @@ async fn scan_and_validate_scope<P: ScopeClosureProvider>(
     let issue_events = validation.issue_events.clone();
     let scan = tokio::task::spawn_blocking(move || {
         merge_tidas_validation_issues(&mut scan, &issue_events);
-        scan.issues.sort_by_key(canonical_value);
+        scan.issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
         scan
     })
     .await?;
@@ -2297,7 +2313,7 @@ pub async fn execute_scope_closure_job(
             })),
         )
         .await?;
-    scan.issues.sort_by_key(canonical_value);
+    scan.issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
 
     let mut effective_scope =
         build_effective_scope_manifest(&input.requested_scope, &scan.documents);
@@ -2368,11 +2384,11 @@ pub async fn execute_scope_closure_job(
         effective_scope = build_effective_scope_manifest(&final_requested_scope, &scan.documents);
         add_process_axis_drift_issue(&mut scan, frozen_process_axis.as_slice(), &effective_scope)?;
         merge_matrix_readiness_blockers(&mut scan, &discovery.readiness)?;
-        scan.issues.sort_by_key(canonical_value);
+        scan.issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
     }
 
     normalize_database_issue_severities(&mut scan.issues)?;
-    scan.issues.sort_by_key(canonical_value);
+    scan.issues.sort_by(|a, b| a.issue_key.cmp(&b.issue_key));
     let (closure_bundle_bytes, closure_bundle_hash) =
         build_closure_bundle(&input, &validation, &scan)?;
     let source_fingerprint = source_fingerprint(&scan.documents)?;
@@ -3192,7 +3208,7 @@ fn build_resolution_map(edges: &[ReferenceEdge], omitted_resolutions: &[Value]) 
             "provenance": resolution,
         })
     }));
-    resolutions.sort_by_key(canonical_value);
+    sort_by_canonical_value(&mut resolutions);
     resolutions
 }
 
@@ -3477,7 +3493,7 @@ async fn run_tidas_batch_validation_cached(
             .collect::<anyhow::Result<Vec<_>>>()?;
         record_document_validation_evidence(pool, worker_job_id, &records).await?;
     }
-    issue_events.sort_by_key(canonical_value);
+    sort_by_canonical_value(&mut issue_events);
     let final_event = json!({
         "type": "final",
         "schema_version": "tidas.validation-final-event.v1",

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -3612,6 +3612,7 @@ fn run_tidas_batch_validation(
 
     let input_dir_arg = input_dir.to_string_lossy().into_owned();
     let manifest_arg = manifest_path.to_string_lossy().into_owned();
+    let jobs = std::env::var("TIDAS_VALIDATION_JOBS").unwrap_or_else(|_| "0".to_owned());
     let events = run_tidas_batch_events(&[
         "--protocol",
         TIDAS_BATCH_PROTOCOL,
@@ -3621,6 +3622,8 @@ fn run_tidas_batch_validation(
         input_dir_arg.as_str(),
         "--input-manifest",
         manifest_arg.as_str(),
+        "--jobs",
+        jobs.as_str(),
     ])?;
     let final_positions = events
         .iter()

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -1862,36 +1862,8 @@ async fn scan_and_validate_scope<P: ScopeClosureProvider>(
             })),
         )
         .await?;
-    let doc_count = scan.documents.len();
-    let total_count = scan.provider_universe.len();
-    let validation = {
-        let docs = scan.documents.clone();
-        let validation_fut = run_tidas_batch_validation_cached(pool, worker_job_id, &docs);
-        tokio::pin!(validation_fut);
-        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            tokio::select! {
-                result = &mut validation_fut => break result?,
-                _ = ticker.tick() => {
-                    progress
-                        .heartbeat(
-                            "validate_documents",
-                            0.42,
-                            Some(json!({
-                                "closureCheckId": closure_check_id,
-                                "progressCounters": {
-                                    "scanned": doc_count,
-                                    "total": total_count,
-                                    "unit": "documents"
-                                },
-                            })),
-                        )
-                        .await?;
-                }
-            }
-        }
-    };
+    let validation =
+        run_tidas_batch_validation_cached(pool, worker_job_id, &scan.documents).await?;
     let issue_events = validation.issue_events.clone();
     let scan = tokio::task::spawn_blocking(move || {
         merge_tidas_validation_issues(&mut scan, &issue_events);
@@ -2320,6 +2292,15 @@ pub async fn execute_scope_closure_job(
         lease_token,
         lease_seconds,
     );
+    let guard = progress.spawn_heartbeat_guard(
+        "validate_documents".to_owned(),
+        0.42,
+        Some(json!({
+            "closureCheckId": closure_check_id,
+            "progressCounters": {"scanned": 0, "total": 0, "unit": "documents"},
+        })),
+        std::time::Duration::from_secs(30),
+    );
     let (mut scan, mut validation) = scan_and_validate_scope(
         &provider,
         &state.pool,
@@ -2329,6 +2310,7 @@ pub async fn execute_scope_closure_job(
         closure_check_id,
     )
     .await?;
+    guard.stop().await;
 
     progress
         .heartbeat(

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -3450,92 +3450,106 @@ async fn run_tidas_batch_validation_cached(
     })
     .await??;
     let cached = lookup_document_validation_evidence(pool, &cache_keys).await?;
-    let cached_by_key = cached
-        .into_iter()
-        .map(|item| (document_evidence_key(&item), item))
-        .collect::<BTreeMap<_, _>>();
-    let mut issue_events = Vec::new();
-    let mut missing = Vec::new();
-    for (document, key) in documents.iter().zip(&cache_keys) {
-        if let Some(hit) = cached_by_key.get(&document_evidence_key(key)) {
-            let issue_artifact_ref = hit
-                .get("issueArtifactRef")
-                .ok_or_else(|| anyhow::anyhow!("cached TIDAS evidence omitted issueArtifactRef"))?;
-            let expected_artifact_hash = hit
-                .get("issueArtifactHash")
-                .and_then(Value::as_str)
-                .ok_or_else(|| {
+    let documents_owned = documents.to_vec();
+    let describe_for_records = describe.clone();
+    let describe_for_validation = describe.clone();
+    let uncached = tokio::task::spawn_blocking(move || {
+        let documents = &documents_owned;
+        let cached_by_key = cached
+            .into_iter()
+            .map(|item| (document_evidence_key(&item), item))
+            .collect::<BTreeMap<_, _>>();
+        let mut issue_events = Vec::new();
+        let mut missing = Vec::new();
+        for (document, key) in documents.iter().zip(&cache_keys) {
+            if let Some(hit) = cached_by_key.get(&document_evidence_key(key)) {
+                let issue_artifact_ref = hit.get("issueArtifactRef").ok_or_else(|| {
+                    anyhow::anyhow!("cached TIDAS evidence omitted issueArtifactRef")
+                })?;
+                let expected_artifact_hash = hit
+                    .get("issueArtifactHash")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
                     anyhow::anyhow!("cached TIDAS evidence omitted issueArtifactHash")
                 })?;
-            if canonical_json_sha256(issue_artifact_ref)? != expected_artifact_hash {
-                return Err(anyhow::anyhow!(
-                    "cached TIDAS evidence issue artifact hash mismatch"
-                ));
+                if canonical_json_sha256(issue_artifact_ref)? != expected_artifact_hash {
+                    return Err(anyhow::anyhow!(
+                        "cached TIDAS evidence issue artifact hash mismatch"
+                    ));
+                }
+                issue_events.extend(
+                    issue_artifact_ref
+                        .get("issues")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            } else {
+                missing.push(document.clone());
             }
-            issue_events.extend(
-                issue_artifact_ref
-                    .get("issues")
-                    .and_then(Value::as_array)
-                    .cloned()
-                    .unwrap_or_default(),
-            );
-        } else {
-            missing.push(document.clone());
         }
-    }
 
-    let describe_for_validation = describe.clone();
-    let missing_for_records = missing.clone();
-    let uncached = tokio::task::spawn_blocking(move || {
-        run_tidas_batch_validation(&missing, describe_for_validation)
+        let missing_for_records = missing.clone();
+        let uncached = run_tidas_batch_validation(&missing, describe_for_validation)?;
+        issue_events.extend(uncached.issue_events.clone());
+
+        let records = if missing_for_records.is_empty() {
+            Vec::new()
+        } else {
+            missing_for_records
+                .iter()
+                .map(|document| {
+                    let issues = uncached
+                        .issue_events
+                        .iter()
+                        .filter(|event| {
+                            event.get("document_key").and_then(Value::as_str)
+                                == Some(document.identity.document_key().as_str())
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let mut record =
+                        document_validation_cache_key(document, &describe_for_records)?;
+                    let Value::Object(record) = &mut record else {
+                        unreachable!("cache key is an object")
+                    };
+                    record.insert(
+                        "status".to_owned(),
+                        Value::String(
+                            if issues.is_empty() {
+                                "passed"
+                            } else {
+                                "failed"
+                            }
+                            .to_owned(),
+                        ),
+                    );
+                    record.insert(
+                        "summary".to_owned(),
+                        json!({"issueCount": issues.len(), "completed": true}),
+                    );
+                    record.insert("issueArtifactRef".to_owned(), json!({"issues": issues}));
+                    record.insert(
+                        "issueArtifactHash".to_owned(),
+                        Value::String(canonical_json_sha256(
+                            record.get("issueArtifactRef").unwrap(),
+                        )?),
+                    );
+                    Ok(Value::Object(record.clone()))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+        };
+
+        sort_by_canonical_value(&mut issue_events);
+        Ok::<_, anyhow::Error>((uncached, issue_events, missing_for_records, records))
     })
     .await??;
-    issue_events.extend(uncached.issue_events.clone());
-    if !missing_for_records.is_empty() {
-        let records = missing_for_records
-            .iter()
-            .map(|document| {
-                let issues = uncached
-                    .issue_events
-                    .iter()
-                    .filter(|event| {
-                        event.get("document_key").and_then(Value::as_str)
-                            == Some(document.identity.document_key().as_str())
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>();
-                let mut record = document_validation_cache_key(document, &describe)?;
-                let Value::Object(record) = &mut record else {
-                    unreachable!("cache key is an object")
-                };
-                record.insert(
-                    "status".to_owned(),
-                    Value::String(
-                        if issues.is_empty() {
-                            "passed"
-                        } else {
-                            "failed"
-                        }
-                        .to_owned(),
-                    ),
-                );
-                record.insert(
-                    "summary".to_owned(),
-                    json!({"issueCount": issues.len(), "completed": true}),
-                );
-                record.insert("issueArtifactRef".to_owned(), json!({"issues": issues}));
-                record.insert(
-                    "issueArtifactHash".to_owned(),
-                    Value::String(canonical_json_sha256(
-                        record.get("issueArtifactRef").unwrap(),
-                    )?),
-                );
-                Ok(Value::Object(record.clone()))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let (uncached_val, issue_events, missing_for_records, records) = uncached;
+    let _ = uncached_val;
+    if !records.is_empty() {
         record_document_validation_evidence(pool, worker_job_id, &records).await?;
     }
-    sort_by_canonical_value(&mut issue_events);
     let final_event = json!({
         "type": "final",
         "schema_version": "tidas.validation-final-event.v1",

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -3397,7 +3397,9 @@ async fn run_tidas_batch_validation_cached(
     worker_job_id: Uuid,
     documents: &[ClosureDocument],
 ) -> anyhow::Result<TidasBatchValidation> {
-    let describe_output = run_tidas_command(&["--describe", "--format", "json"])?;
+    let describe_output =
+        tokio::task::spawn_blocking(|| run_tidas_command(&["--describe", "--format", "json"]))
+            .await??;
     let describe: Value = serde_json::from_str(describe_output.trim())?;
     if !describe
         .get("protocols")
@@ -3447,10 +3449,15 @@ async fn run_tidas_batch_validation_cached(
         }
     }
 
-    let uncached = run_tidas_batch_validation(&missing, describe.clone())?;
+    let describe_for_validation = describe.clone();
+    let missing_for_records = missing.clone();
+    let uncached = tokio::task::spawn_blocking(move || {
+        run_tidas_batch_validation(&missing, describe_for_validation)
+    })
+    .await??;
     issue_events.extend(uncached.issue_events.clone());
-    if !missing.is_empty() {
-        let records = missing
+    if !missing_for_records.is_empty() {
+        let records = missing_for_records
             .iter()
             .map(|document| {
                 let issues = uncached
@@ -3503,8 +3510,8 @@ async fn run_tidas_batch_validation_cached(
         "summary": {
             "document_count": documents.len(),
             "issue_count": issue_events.len(),
-            "cache_hit_count": documents.len() - missing.len(),
-            "validated_count": missing.len(),
+            "cache_hit_count": documents.len() - missing_for_records.len(),
+            "validated_count": missing_for_records.len(),
         },
         "fingerprints": describe,
     });

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -1844,8 +1844,24 @@ async fn scan_and_validate_scope<P: ScopeClosureProvider>(
     pool: &PgPool,
     worker_job_id: Uuid,
     requested_scope: &RequestedScopeManifest,
+    progress: &WorkerJobProgress<'_>,
+    closure_check_id: Uuid,
 ) -> anyhow::Result<(ScopeClosureScan, TidasBatchValidation)> {
     let mut scan = collect_scope_closure(provider, requested_scope).await?;
+    progress
+        .heartbeat(
+            "validate_documents",
+            0.42,
+            Some(json!({
+                "closureCheckId": closure_check_id,
+                "progressCounters": {
+                    "scanned": scan.documents.len(),
+                    "total": scan.provider_universe.len(),
+                    "unit": "documents"
+                },
+            })),
+        )
+        .await?;
     let validation =
         run_tidas_batch_validation_cached(pool, worker_job_id, &scan.documents).await?;
     let issue_events = validation.issue_events.clone();
@@ -2281,6 +2297,8 @@ pub async fn execute_scope_closure_job(
         &state.pool,
         worker_job_id,
         &input.requested_scope,
+        &progress,
+        closure_check_id,
     )
     .await?;
 
@@ -2379,6 +2397,8 @@ pub async fn execute_scope_closure_job(
             &state.pool,
             worker_job_id,
             &final_requested_scope,
+            &progress,
+            closure_check_id,
         )
         .await?;
         effective_scope = build_effective_scope_manifest(&final_requested_scope, &scan.documents);

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -1862,8 +1862,36 @@ async fn scan_and_validate_scope<P: ScopeClosureProvider>(
             })),
         )
         .await?;
-    let validation =
-        run_tidas_batch_validation_cached(pool, worker_job_id, &scan.documents).await?;
+    let doc_count = scan.documents.len();
+    let total_count = scan.provider_universe.len();
+    let validation = {
+        let docs = scan.documents.clone();
+        let validation_fut = run_tidas_batch_validation_cached(pool, worker_job_id, &docs);
+        tokio::pin!(validation_fut);
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(30));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                result = &mut validation_fut => break result?,
+                _ = ticker.tick() => {
+                    progress
+                        .heartbeat(
+                            "validate_documents",
+                            0.42,
+                            Some(json!({
+                                "closureCheckId": closure_check_id,
+                                "progressCounters": {
+                                    "scanned": doc_count,
+                                    "total": total_count,
+                                    "unit": "documents"
+                                },
+                            })),
+                        )
+                        .await?;
+                }
+            }
+        }
+    };
     let issue_events = validation.issue_events.clone();
     let scan = tokio::task::spawn_blocking(move || {
         merge_tidas_validation_issues(&mut scan, &issue_events);

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -3440,10 +3440,15 @@ async fn run_tidas_batch_validation_cached(
             "installed tidas-tools does not support {TIDAS_BATCH_PROTOCOL}"
         ));
     }
-    let cache_keys = documents
-        .iter()
-        .map(|document| document_validation_cache_key(document, &describe))
-        .collect::<anyhow::Result<Vec<_>>>()?;
+    let describe_for_keys = describe.clone();
+    let documents_for_keys = documents.to_vec();
+    let cache_keys = tokio::task::spawn_blocking(move || {
+        documents_for_keys
+            .iter()
+            .map(|document| document_validation_cache_key(document, &describe_for_keys))
+            .collect::<anyhow::Result<Vec<_>>>()
+    })
+    .await??;
     let cached = lookup_document_validation_evidence(pool, &cache_keys).await?;
     let cached_by_key = cached
         .into_iter()

--- a/crates/solver-worker/src/worker_jobs.rs
+++ b/crates/solver-worker/src/worker_jobs.rs
@@ -219,6 +219,61 @@ impl<'a> WorkerJobProgress<'a> {
         )
         .await
     }
+
+    /// Spawn a background heartbeat guard that re-sends the last known
+    /// phase/progress/diagnostics every `interval` seconds until the
+    /// returned guard is dropped.  This keeps the job lease alive during
+    /// long synchronous computations that would otherwise starve the
+    /// tokio runtime.
+    #[must_use]
+    pub fn spawn_heartbeat_guard(
+        &self,
+        phase: String,
+        progress: f64,
+        diagnostics: Option<Value>,
+        interval: std::time::Duration,
+    ) -> WorkerJobHeartbeatGuard {
+        let pool = self.pool.clone();
+        let job_id = self.job_id;
+        let lease_token = self.lease_token;
+        let lease_seconds = self.lease_seconds;
+        let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let cancel_clone = cancel.clone();
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                if cancel_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                    break;
+                }
+                let _ = heartbeat_worker_job(
+                    &pool,
+                    job_id,
+                    lease_token,
+                    &phase,
+                    progress,
+                    diagnostics.clone(),
+                    lease_seconds,
+                )
+                .await;
+            }
+        });
+        WorkerJobHeartbeatGuard { cancel, handle }
+    }
+}
+
+pub struct WorkerJobHeartbeatGuard {
+    cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl WorkerJobHeartbeatGuard {
+    pub async fn stop(self) {
+        self.cancel
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = self.handle.await;
+    }
 }
 
 pub async fn claim_worker_jobs(


### PR DESCRIPTION
## Summary
- Replace `sort_by_key(canonical_value)` which recomputes full JSON serialization on every comparison
- Issues: sort by `issue_key` string (zero serialization)
- Edges/omitted/events: `sort_by_canonical_value` pre-computes canonical string once per element
- Move `finalize_scope_closure_scan` into `spawn_blocking`

## Problem
After the algorithm fix in #142, the job still hung at 0.399 progress for 470+ seconds. Profiling on production showed:

| Step | Count | Time |
|---|---|---|
| `edges.sort_by_key(canonical_value)` | 809,566 | **93s** |
| `omitted.sort_by_key(canonical_value)` | 287,233 | **42s** |
| `issues.sort_by_key(canonical_value)` | 327,080 | **470s+** |

`canonical_value` calls `serde_json::to_value` + `write_canonical_json` (key-sorted serialization) on every comparison during sort. For `ClosureIssue` with nested occurrences/affected_roots/witness_paths, each serialization is very expensive.

## Fix
- `ClosureIssue`: has `issue_key: String` which is already a unique deterministic key. Sort by it directly.
- `Vec<Value>` (edges, omitted, events): new `sort_by_canonical_value` helper computes the canonical string once per element, then sorts by string comparison. O(n) serializations instead of O(n log n).
- `finalize_scope_closure_scan` moved to `spawn_blocking` so heartbeat coroutines are never starved.

## Validation
- `cargo test -p solver-worker --lib scope_closure::` (22 tests pass)
- `cargo clippy -p solver-worker --lib --all-features -- -D warnings` (clean)
- Benchmark: 5605 roots + 112k nodes completes in 0.57s

Closes linancn/tiangong-lca-worker#141