### PR TITLE
chore: adopt exact Rust tidas v0.1.1 runtime contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-28"
-lastReviewedCommit: "1844d095f7d4e4da6c2a588cd234ca9697b2f1fe"
+lastReviewedCommit: "615162082a7e3e1e7cfa4c603585c86c73c0b920"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.env.example
+++ b/.env.example
@@ -114,9 +114,9 @@ PACKAGE_QUEUE_BACKEND="worker-jobs"
 PACKAGE_WORKER_ID="package-worker-local"
 PACKAGE_WORKER_JOBS_CLAIM_LIMIT="1"
 PACKAGE_WORKER_JOBS_LEASE_SECONDS="900"
-# Unified Rust tidas v0.1.0 binary. No Python or legacy-command fallback exists.
+# Unified Rust tidas v0.1.1 binary. No Python or legacy-command fallback exists.
 # TIDAS_BIN="/absolute/path/to/tidas"
-TIDAS_EXPECTED_VERSION="0.1.0"
+TIDAS_EXPECTED_VERSION="0.1.1"
 TIDAS_TIMEOUT_SECONDS="1800"
 TIDAS_MEMORY_BUDGET_MIB="512"
 TIDAS_QUEUE_CAPACITY="256"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Reviewed for Issue #152: all active Worker validation paths require the exact published Rust tidas v0.1.1 binary and preserve fail-closed version/protocol enforcement."
 lastReviewedNote: "Reviewed for Issue #148: bounded validation spools, cache batches, file-backed artifacts, heartbeat-safe blocking work, and local capacity gates preserve repo ownership and fail-closed runtime contracts."
 related:
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 85b34dbdc910346055ce2188918f0d7d6332f361
+lastReviewedAt: 2026-07-28
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Issue #152 updates every active Worker entry point to the exact published Rust tidas v0.1.1 contract."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -303,7 +304,7 @@ psql "$CONN" -v ON_ERROR_STOP=1 -f supabase/migrations/20260309042000_lca_latest
 - `WORKER_POLL_MS`（默认 `1000`）
 - `WORKER_VT_SECONDS`（默认 `30`；生产 `build_snapshot` 队列建议按最长任务耗时设置，例如 `1800`）
 - `TIDAS_BIN`（统一 Rust `tidas` binary；默认通过 `PATH` 查找 `tidas`，生产建议使用原子切换的绝对路径）
-- `TIDAS_EXPECTED_VERSION`（必须与 binary `version` 及 validation describe package version 精确匹配，默认 `0.1.0`）
+- `TIDAS_EXPECTED_VERSION`（必须与 binary `version` 及 validation describe package version 精确匹配，默认 `0.1.1`）
 - `TIDAS_TIMEOUT_SECONDS`（单次 `tidas` 子进程上限，默认 `1800`）
 - `TIDAS_MEMORY_BUDGET_MIB` / `TIDAS_QUEUE_CAPACITY`（由 `tidas` 消费的有界资源配置；package 与 scope-closure 子进程继承）
 
@@ -473,7 +474,7 @@ cargo run -p solver-worker --bin solver-worker --release -- --mode worker
 ```bash
 set -a && source .env && set +a
 tidas_bin="${TIDAS_BIN:-tidas}"
-test "$("$tidas_bin" version --format json --progress never | jq -r '.summary.binary_version')" = "${TIDAS_EXPECTED_VERSION:-0.1.0}"
+test "$("$tidas_bin" version --format json --progress never | jq -r '.summary.binary_version')" = "${TIDAS_EXPECTED_VERSION:-0.1.1}"
 "$tidas_bin" validate --describe --format json --progress never | jq -e '.summary.validation_describe.protocols | index("document-validation-batch.v1")'
 cargo run -p solver-worker --bin package_worker --release
 ```
@@ -680,7 +681,7 @@ WorkingDirectory=/home/ubuntu/projects/lca_workspace/tiangong-lca-worker
 EnvironmentFile=/home/ubuntu/projects/lca_workspace/tiangong-lca-worker/.env
 Environment=RUST_LOG=info
 Environment=TIDAS_BIN=/home/ubuntu/.runtime/tidas/current/bin/tidas
-Environment=TIDAS_EXPECTED_VERSION=0.1.0
+Environment=TIDAS_EXPECTED_VERSION=0.1.1
 ExecStart=/home/ubuntu/projects/lca_workspace/tiangong-lca-worker/target/release/package_worker
 Restart=always
 RestartSec=2

--- a/crates/solver-worker/src/tidas_cli.rs
+++ b/crates/solver-worker/src/tidas_cli.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 pub const TIDAS_OPERATION_REPORT_SCHEMA: &str = "tidas.operation-report.v1";
 pub const TIDAS_BATCH_PROTOCOL: &str = "document-validation-batch.v1";
 pub const TIDAS_BATCH_PROFILE: &str = "tidas-document-conformance.v1";
-pub const DEFAULT_TIDAS_VERSION: &str = "0.1.0";
+pub const DEFAULT_TIDAS_VERSION: &str = "0.1.1";
 const DEFAULT_TIDAS_TIMEOUT_SECONDS: u64 = 1_800;
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
-lastReviewedNote: "Issue #148 completes the bounded scope-closure consumer with chunked cache work, external JSONL sorting, file-backed artifacts, and heartbeat-safe blocking phases."
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Issue #152 advances the single exact Rust tidas runtime contract to v0.1.1 without changing Worker ownership boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
-lastReviewedNote: "Issue #148 adds qualified 112,032-document graph and 1,088,760-event bounded-spool capacity gates."
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Issue #152 requires the published tidas v0.1.1 version/describe handshake before coordinated rollout."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
-lastReviewedNote: "Reviewed for Issue #148; bounded validation/cache/artifact execution preserves API payload, V1 bundle, result, status, and persistence semantics."
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Reviewed for Issue #152; the exact tidas v0.1.1 runtime handshake does not change jobs, payloads, statuses, or result contracts."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/agents/repo-architecture.md
   - docs/agents/repo-validation.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
-lastReviewedNote: "Issue #148 completes bounded validation consumption, cache batching, external ordering, file-backed artifact production, and local capacity evidence."
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Issue #152 advances the exact Rust validator handshake to tidas v0.1.1 without changing Worker-owned bounded orchestration."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -91,7 +91,7 @@ Reference extraction in `scope_closure.rs` mirrors the public `tidas.reference-e
 
 Document validation uses only the published unified Rust `tidas` CLI selected by `TIDAS_BIN` (default `tidas`). No Python entrypoint, legacy binary name, or ordered command-candidate fallback is permitted:
 
-1. `version --format json --progress never` must equal `TIDAS_EXPECTED_VERSION` (default `0.1.0`).
+1. `version --format json --progress never` must equal `TIDAS_EXPECTED_VERSION` (default `0.1.1`).
 2. `validate --describe --format json --progress never` must advertise `document-validation-batch.v1`, `tidas-document-conformance.v1`, the validation report schema, and an immutable asset fingerprint.
 3. Uncached documents are spooled as canonical JSON plus an exact JSONL input manifest.
 4. The Worker invokes profile `tidas-document-conformance.v1` with bounded memory/queue configuration inherited by the binary.

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,8 +19,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 1844d095f7d4e4da6c2a588cd234ca9697b2f1fe
-lastReviewedNote: "Reviewed for Issue #148; scope-closure now uses the same streaming verified-spool boundary without changing package-worker import/export or tidas protocol semantics."
+lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedNote: "Issue #152 advances package-worker's exact Rust validator handshake to tidas v0.1.1."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -139,7 +139,7 @@ payload 必须仍携带有效 `job_id` compatibility UUID，因为 `lca_package_
 
 1. 下载上传 ZIP artifact；
 2. 解压到临时目录；
-3. 使用唯一 `TIDAS_BIN`（默认 `tidas`）执行 `version` 与 `validate --describe` 握手，要求精确匹配 `TIDAS_EXPECTED_VERSION`（默认 `0.1.0`）、公开 validation protocol/profile 和 asset fingerprint；
+3. 使用唯一 `TIDAS_BIN`（默认 `tidas`）执行 `version` 与 `validate --describe` 握手，要求精确匹配 `TIDAS_EXPECTED_VERSION`（默认 `0.1.1`）、公开 validation protocol/profile 和 asset fingerprint；
 4. 通过 `tidas validate <dir> --input-format tidas-json --issues <spool> --format json --progress never` 执行结构化校验；issue 必须写入临时文件型有界 spool，operation report 作为有界 JSON 捕获，Worker 对 report schema、完整性、asset fingerprint 以及 spool SHA-256/bytes/event count 全量复核；
 5. 若 `summary.error_count > 0`，直接产出 import report：
    - `code = VALIDATION_FAILED`

--- a/scripts/run_scope_closure_package_v2_e2e.sh
+++ b/scripts/run_scope_closure_package_v2_e2e.sh
@@ -25,7 +25,7 @@ export S3_SECRET_ACCESS_KEY="$S3_PROTOCOL_ACCESS_KEY_SECRET"
 export SNAPSHOT_BUILDER_BIN="$worker_root/target/debug/snapshot_builder"
 export SNAPSHOT_REPORT_MODE="disabled"
 export TIDAS_BIN="${TIDAS_BIN:-tidas}"
-export TIDAS_EXPECTED_VERSION="${TIDAS_EXPECTED_VERSION:-0.1.0}"
+export TIDAS_EXPECTED_VERSION="${TIDAS_EXPECTED_VERSION:-0.1.1}"
 
 "$TIDAS_BIN" version --format json --progress never >/dev/null
 "$TIDAS_BIN" validate --describe --format json --progress never >/dev/null


### PR DESCRIPTION
Closes #152

## Summary
- Advance every active Worker validation entry point from exact tidas 0.1.0 to exact tidas 0.1.1.
- Keep scope closure, package import, local E2E, env examples, and systemd guidance on one fail-closed version contract.

## Key Decisions
- Require exact 0.1.1 rather than a compatible range because validation assets and asset fingerprints are certificate evidence.

## Validation
- Published macOS arm64 archive SHA-256 and GitHub SLSA attestation passed for tag v0.1.1 / source 522c4e86.
- Published binary version and validate --describe protocol/profile handshake passed; Worker release-binary handshake passed.
- make check, hard Clippy/format, script syntax, strict docpact validate/lint, active-source version audit, and git diff --check passed.

## Risks / Rollback
- Deployment must install tidas v0.1.1 and Worker from the eventual merge commit as one coordinated pair; version drift intentionally fails closed.

## Follow-ups
- Merge the AWS operations PR, root-integrate exact child commits, then roll every managed Worker service one at a time.

## Workspace Integration
- Workspace rollout is tracked by tiangong-lca/workspace#497; root Worker pointer remains Pending.