### PR TITLE
fix: stop worker_jobs from probing retired lca_jobs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-28"
-lastReviewedCommit: "615162082a7e3e1e7cfa4c603585c86c73c0b920"
+lastReviewedCommit: "31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedCommit: 31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1
 lastReviewedNote: "Reviewed for Issue #152: all active Worker validation paths require the exact published Rust tidas v0.1.1 binary and preserve fail-closed version/protocol enforcement."
 lastReviewedNote: "Reviewed for Issue #148: bounded validation spools, cache batches, file-backed artifacts, heartbeat-safe blocking work, and local capacity gates preserve repo ownership and fail-closed runtime contracts."
 related:

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -473,9 +473,9 @@ pub async fn archive_queue_message(
     Ok(())
 }
 
-/// Updates `lca_jobs` status and diagnostics.
+/// Updates `lca_jobs` status and diagnostics for the explicit legacy backend.
 #[instrument(skip(pool, diagnostics))]
-pub async fn update_job_status(
+pub async fn update_legacy_lca_job_status(
     pool: &PgPool,
     job_id: Uuid,
     status: &str,
@@ -988,7 +988,13 @@ fn is_undefined_table(err: &sqlx::Error) -> bool {
 /// Executes one queue payload end-to-end.
 #[instrument(skip(state))]
 pub async fn handle_job_payload(state: &AppState, payload: JobPayload) -> anyhow::Result<()> {
-    Box::pin(handle_job_payload_with_worker_lease(state, payload, None)).await
+    Box::pin(handle_job_payload_with_worker_lease(
+        state,
+        payload,
+        None,
+        JobLifecycleBackend::LegacyLcaJobs,
+    ))
+    .await
 }
 
 pub(crate) async fn handle_worker_jobs_job_payload(
@@ -1006,8 +1012,34 @@ pub(crate) async fn handle_worker_jobs_job_payload(
             lease_token,
             lease_seconds,
         }),
+        JobLifecycleBackend::WorkerJobs,
     ))
     .await
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum JobLifecycleBackend {
+    LegacyLcaJobs,
+    WorkerJobs,
+}
+
+impl JobLifecycleBackend {
+    fn writes_legacy_lca_jobs(self) -> bool {
+        matches!(self, Self::LegacyLcaJobs)
+    }
+}
+
+async fn update_job_status_for_backend(
+    pool: &PgPool,
+    backend: JobLifecycleBackend,
+    job_id: Uuid,
+    status: &str,
+    diagnostics: Value,
+) -> anyhow::Result<f64> {
+    if !backend.writes_legacy_lca_jobs() {
+        return Ok(0.0);
+    }
+    update_legacy_lca_job_status(pool, job_id, status, diagnostics).await
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1015,6 +1047,7 @@ async fn handle_job_payload_with_worker_lease(
     state: &AppState,
     payload: JobPayload,
     build_snapshot_worker_lease: Option<BuildSnapshotWorkerLease>,
+    lifecycle_backend: JobLifecycleBackend,
 ) -> anyhow::Result<()> {
     match payload {
         JobPayload::PrepareFactorization {
@@ -1022,8 +1055,9 @@ async fn handle_job_payload_with_worker_lease(
             snapshot_id,
             print_level,
         } => {
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({"phase": "prepare"}),
@@ -1043,7 +1077,14 @@ async fn handle_job_payload_with_worker_lease(
                 "running",
                 running_db_write_sec,
             );
-            let _ = update_job_status(&state.pool, job_id, "ready", ready_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "ready",
+                ready_diag,
+            )
+            .await?;
         }
         JobPayload::SolveOne {
             job_id,
@@ -1053,8 +1094,9 @@ async fn handle_job_payload_with_worker_lease(
             print_level,
             calculation_evidence_binding,
         } => {
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({"phase": "solve_one"}),
@@ -1103,7 +1145,14 @@ async fn handle_job_payload_with_worker_lease(
                 "running",
                 running_db_write_sec,
             );
-            let _ = update_job_status(&state.pool, job_id, "completed", completed_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "completed",
+                completed_diag,
+            )
+            .await?;
 
             if let Some(result_id) = latest_result_id_for_job(&state.pool, job_id).await?
                 && let Err(err) = mark_result_cache_ready(&state.pool, job_id, result_id).await
@@ -1124,8 +1173,9 @@ async fn handle_job_payload_with_worker_lease(
             print_level,
             calculation_evidence_binding,
         } => {
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({"phase": "solve_batch"}),
@@ -1174,7 +1224,14 @@ async fn handle_job_payload_with_worker_lease(
                 "running",
                 running_db_write_sec,
             );
-            let _ = update_job_status(&state.pool, job_id, "completed", completed_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "completed",
+                completed_diag,
+            )
+            .await?;
 
             if let Some(result_id) = latest_result_id_for_job(&state.pool, job_id).await?
                 && let Err(err) = mark_result_cache_ready(&state.pool, job_id, result_id).await
@@ -1195,8 +1252,9 @@ async fn handle_job_payload_with_worker_lease(
             print_level,
             calculation_evidence_binding,
         } => {
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({"phase": "solve_all_unit"}),
@@ -1275,7 +1333,14 @@ async fn handle_job_payload_with_worker_lease(
                 "running",
                 running_db_write_sec,
             );
-            let _ = update_job_status(&state.pool, job_id, "completed", completed_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "completed",
+                completed_diag,
+            )
+            .await?;
 
             if let Some(result_id) = latest_result_id_for_job(&state.pool, job_id).await? {
                 if let Err(err) = mark_result_cache_ready(&state.pool, job_id, result_id).await {
@@ -1319,8 +1384,9 @@ async fn handle_job_payload_with_worker_lease(
             print_level,
             calculation_evidence_binding,
         } => {
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({"phase": "analyze_contribution_path"}),
@@ -1418,7 +1484,14 @@ async fn handle_job_payload_with_worker_lease(
                 "running",
                 running_db_write_sec,
             );
-            let _ = update_job_status(&state.pool, job_id, "completed", completed_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "completed",
+                completed_diag,
+            )
+            .await?;
 
             if let Some(result_id) = latest_result_id_for_job(&state.pool, job_id).await?
                 && let Err(err) = mark_result_cache_ready(&state.pool, job_id, result_id).await
@@ -1436,8 +1509,9 @@ async fn handle_job_payload_with_worker_lease(
             snapshot_id,
         } => {
             let invalidated = state.solver.invalidate(snapshot_id);
-            let _ = update_job_status(
+            let _ = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "completed",
                 serde_json::json!({"invalidated": invalidated}),
@@ -1457,8 +1531,9 @@ async fn handle_job_payload_with_worker_lease(
                     print_level: print_level.unwrap_or(0.0),
                 },
             )?;
-            let _ = update_job_status(
+            let _ = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "ready",
                 serde_json::to_value(prepared)?,
@@ -1501,8 +1576,9 @@ async fn handle_job_payload_with_worker_lease(
             } else {
                 "postgres_transaction_advisory_lock"
             };
-            let running_db_write_sec = update_job_status(
+            let running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({
@@ -1541,8 +1617,9 @@ async fn handle_job_payload_with_worker_lease(
             if let Some(lock_payload) = build_snapshot_lock.as_object_mut() {
                 lock_payload.insert("waiting".to_owned(), Value::Bool(false));
             }
-            let _lock_running_db_write_sec = update_job_status(
+            let _lock_running_db_write_sec = update_job_status_for_backend(
                 &state.pool,
+                lifecycle_backend,
                 job_id,
                 "running",
                 serde_json::json!({
@@ -1687,7 +1764,13 @@ async fn handle_job_payload_with_worker_lease(
                 })?;
             }
             if resolved_snapshot_id != snapshot_id {
-                set_job_snapshot_id(&state.pool, job_id, resolved_snapshot_id).await?;
+                set_legacy_lca_job_snapshot_id_for_backend(
+                    &state.pool,
+                    lifecycle_backend,
+                    job_id,
+                    resolved_snapshot_id,
+                )
+                .await?;
             }
 
             let source_hash = fetch_snapshot_source_hash(&state.pool, resolved_snapshot_id).await?;
@@ -1719,7 +1802,14 @@ async fn handle_job_payload_with_worker_lease(
             }
             let completed_diag =
                 merge_job_status_update_timing(completed_payload, "running", running_db_write_sec);
-            let _ = update_job_status(&state.pool, job_id, "completed", completed_diag).await?;
+            let _ = update_job_status_for_backend(
+                &state.pool,
+                lifecycle_backend,
+                job_id,
+                "completed",
+                completed_diag,
+            )
+            .await?;
         }
         JobPayload::LciaResultPackageBuild { .. } => {
             return Err(anyhow::anyhow!(
@@ -3490,7 +3580,11 @@ async fn fetch_snapshot_source_hash(
     }
 }
 
-async fn set_job_snapshot_id(pool: &PgPool, job_id: Uuid, snapshot_id: Uuid) -> anyhow::Result<()> {
+async fn set_legacy_lca_job_snapshot_id(
+    pool: &PgPool,
+    job_id: Uuid,
+    snapshot_id: Uuid,
+) -> anyhow::Result<()> {
     let result = sqlx::query(
         r"
         UPDATE lca_jobs
@@ -3508,6 +3602,18 @@ async fn set_job_snapshot_id(pool: &PgPool, job_id: Uuid, snapshot_id: Uuid) -> 
         Err(err) if is_undefined_table(&err) => Ok(()),
         Err(err) => Err(err.into()),
     }
+}
+
+async fn set_legacy_lca_job_snapshot_id_for_backend(
+    pool: &PgPool,
+    backend: JobLifecycleBackend,
+    job_id: Uuid,
+    snapshot_id: Uuid,
+) -> anyhow::Result<()> {
+    if !backend.writes_legacy_lca_jobs() {
+        return Ok(());
+    }
+    set_legacy_lca_job_snapshot_id(pool, job_id, snapshot_id).await
 }
 
 async fn upsert_active_snapshot(
@@ -3826,7 +3932,7 @@ fn _assert_result_types(_a: SolveResult, _b: SolveBatchResult) {}
 #[cfg(test)]
 mod tests {
     use super::{
-        PackageSnapshotExecutionMode, SolveOptionsPayload,
+        JobLifecycleBackend, PackageSnapshotExecutionMode, SolveOptionsPayload,
         acquire_build_snapshot_worker_jobs_slot_sql, build_all_unit_rhs_batch,
         build_snapshot_heartbeat_interval, lcia_result_package_request_roots,
         lcia_result_package_version, missing_legacy_tables_sparse_data_error,
@@ -3839,6 +3945,12 @@ mod tests {
     use uuid::Uuid;
 
     use crate::graph_types::RequestRootProcess;
+
+    #[test]
+    fn worker_jobs_backend_never_writes_legacy_lca_jobs() {
+        assert!(!JobLifecycleBackend::WorkerJobs.writes_legacy_lca_jobs());
+        assert!(JobLifecycleBackend::LegacyLcaJobs.writes_legacy_lca_jobs());
+    }
 
     #[test]
     fn build_snapshot_worker_jobs_slot_sql_uses_short_transaction_and_lease_fencing() {

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -16,7 +16,7 @@ use crate::{
         AppState, archive_queue_message, fetch_snapshot_index_document, handle_job_payload,
         handle_lcia_result_package_build_worker_job, handle_worker_jobs_job_payload,
         latest_result_id_for_job, mark_result_cache_failed, read_one_queue_message,
-        update_job_status,
+        update_legacy_lca_job_status,
     },
     scope_closure::{
         SCOPE_CLOSURE_JOB_KIND, SCOPE_CLOSURE_REQUEST_SCHEMA_VERSION, execute_scope_closure_job,
@@ -726,7 +726,6 @@ async fn record_solver_worker_job_failure(
     }
 
     let diagnostics = build_failure_diagnostics(state, payload, err_message).await;
-    let _ = update_job_status(&state.pool, lca_job_id, "failed", diagnostics.clone()).await;
     let _ = mark_result_cache_failed(&state.pool, lca_job_id, "job_execution_failed", err_message)
         .await;
     if let Err(err) = link_lca_worker_job_domain_refs(&state.pool, job.id, lca_job_id).await {
@@ -927,21 +926,16 @@ async fn build_solver_worker_job_result(
 
     let lca_job_id = extract_job_id(payload);
     link_lca_worker_job_domain_refs(&state.pool, worker_job_id, lca_job_id).await?;
-    let job_projection = fetch_lca_job_projection(&state.pool, lca_job_id).await?;
     let result_id = latest_result_id_for_job(&state.pool, lca_job_id).await?;
     let result_ref = solver_worker_result_ref(worker_job_id, lca_job_id, result_id);
-    let snapshot_id = job_projection
-        .get("snapshotId")
-        .cloned()
-        .filter(|value| !value.is_null())
-        .or_else(|| extract_snapshot_id(payload).map(|id| json!(id)))
-        .unwrap_or(Value::Null);
+    let snapshot_id = extract_snapshot_id(payload).map_or(Value::Null, |id| json!(id));
+    let legacy_job_projection = skipped_legacy_lca_job_projection(lca_job_id);
     let result_json = json!({
         "workerJobId": worker_job_id,
         "lcaJobId": lca_job_id,
         "payloadType": payload_type_name(payload),
         "snapshotId": snapshot_id,
-        "lcaJobStatus": job_projection.get("status").cloned().unwrap_or(Value::Null),
+        "lcaJobStatus": Value::Null,
         "resultId": result_id,
         "calculationEvidence": calculation_evidence_binding_for_payload(payload),
     });
@@ -952,7 +946,7 @@ async fn build_solver_worker_job_result(
         result_schema_version: Some(result_schema_version_for_payload(payload).to_owned()),
         result_ref: Some(result_ref),
         diagnostics: Some(json!({
-            "lcaJob": job_projection,
+            "lcaJob": legacy_job_projection,
             "calculationEvidence": calculation_evidence_binding_for_payload(payload),
         })),
         error_code: None,
@@ -1070,66 +1064,37 @@ fn lcia_result_package_worker_result_ref(
     })
 }
 
+const CANONICAL_LCA_WORKER_JOB_DOMAIN_REF_UPDATES: [&str; 4] = [
+    r"
+        UPDATE public.lca_results
+           SET worker_job_id = $1
+         WHERE job_id = $2
+        ",
+    r"
+        UPDATE public.lca_result_cache
+           SET worker_job_id = $1
+         WHERE job_id = $2
+        ",
+    r"
+        UPDATE public.lca_latest_all_unit_results
+           SET worker_job_id = $1
+         WHERE job_id = $2
+        ",
+    r"
+        UPDATE public.lca_factorization_registry
+           SET prepared_worker_job_id = $1
+         WHERE prepared_job_id = $2
+        ",
+];
+
 async fn link_lca_worker_job_domain_refs(
     pool: &sqlx::PgPool,
     worker_job_id: Uuid,
     lca_job_id: Uuid,
 ) -> anyhow::Result<()> {
-    execute_optional_worker_job_ref_update(
-        pool,
-        r"
-        UPDATE public.lca_jobs
-           SET worker_job_id = $1
-         WHERE id = $2
-        ",
-        worker_job_id,
-        lca_job_id,
-    )
-    .await?;
-    execute_optional_worker_job_ref_update(
-        pool,
-        r"
-        UPDATE public.lca_results
-           SET worker_job_id = $1
-         WHERE job_id = $2
-        ",
-        worker_job_id,
-        lca_job_id,
-    )
-    .await?;
-    execute_optional_worker_job_ref_update(
-        pool,
-        r"
-        UPDATE public.lca_result_cache
-           SET worker_job_id = $1
-         WHERE job_id = $2
-        ",
-        worker_job_id,
-        lca_job_id,
-    )
-    .await?;
-    execute_optional_worker_job_ref_update(
-        pool,
-        r"
-        UPDATE public.lca_latest_all_unit_results
-           SET worker_job_id = $1
-         WHERE job_id = $2
-        ",
-        worker_job_id,
-        lca_job_id,
-    )
-    .await?;
-    execute_optional_worker_job_ref_update(
-        pool,
-        r"
-        UPDATE public.lca_factorization_registry
-           SET prepared_worker_job_id = $1
-         WHERE prepared_job_id = $2
-        ",
-        worker_job_id,
-        lca_job_id,
-    )
-    .await?;
+    for statement in CANONICAL_LCA_WORKER_JOB_DOMAIN_REF_UPDATES {
+        execute_optional_worker_job_ref_update(pool, statement, worker_job_id, lca_job_id).await?;
+    }
 
     Ok(())
 }
@@ -1168,42 +1133,11 @@ fn solver_worker_result_ref(
     })
 }
 
-async fn fetch_lca_job_projection(pool: &sqlx::PgPool, job_id: Uuid) -> anyhow::Result<Value> {
-    let result = sqlx::query(
-        r"
-        SELECT status, job_type, snapshot_id, diagnostics
-        FROM public.lca_jobs
-        WHERE id = $1
-        ",
-    )
-    .bind(job_id)
-    .fetch_optional(pool)
-    .await;
-
-    let row = match result {
-        Ok(row) => row,
-        Err(err) if is_undefined_table(&err) => {
-            return Ok(json!({
-                "id": job_id,
-                "missing": true,
-                "legacyTableMissing": true,
-            }));
-        }
-        Err(err) => return Err(err.into()),
-    };
-
-    Ok(row.map_or_else(
-        || json!({"id": job_id, "missing": true}),
-        |row| {
-            json!({
-                "id": job_id,
-                "status": row.try_get::<String, _>("status").ok(),
-                "jobType": row.try_get::<String, _>("job_type").ok(),
-                "snapshotId": row.try_get::<Uuid, _>("snapshot_id").ok(),
-                "diagnostics": row.try_get::<Value, _>("diagnostics").ok(),
-            })
-        },
-    ))
+fn skipped_legacy_lca_job_projection(job_id: Uuid) -> Value {
+    json!({
+        "id": job_id,
+        "projectionSkipped": true,
+    })
 }
 
 fn is_undefined_table(err: &sqlx::Error) -> bool {
@@ -1767,8 +1701,13 @@ pub async fn run_worker_loop(
                             let err_message = err.to_string();
                             let diagnostics =
                                 build_failure_diagnostics(&state, &payload, &err_message).await;
-                            let _ =
-                                update_job_status(&state.pool, job_id, "failed", diagnostics).await;
+                            let _ = update_legacy_lca_job_status(
+                                &state.pool,
+                                job_id,
+                                "failed",
+                                diagnostics,
+                            )
+                            .await;
                             let _ = mark_result_cache_failed(
                                 &state.pool,
                                 job_id,
@@ -1784,7 +1723,7 @@ pub async fn run_worker_loop(
                         warn!(error = %err, "invalid job payload");
                         if let Some(job_id) = extract_job_id_from_raw_payload(&message.payload) {
                             let err_message = format!("invalid job payload: {err}");
-                            let _ = update_job_status(
+                            let _ = update_legacy_lca_job_status(
                                 &state.pool,
                                 job_id,
                                 "failed",
@@ -1863,15 +1802,38 @@ mod tests {
             method_factor_source_contract_fixture,
         },
         queue::{
-            AuthoritativePackageClosureBinding, lcia_result_package_worker_result_ref,
-            parse_build_snapshot_worker_projection, payload_type_name,
-            result_schema_version_for_payload, snapshot_diagnostic_scope_pairs,
+            AuthoritativePackageClosureBinding, CANONICAL_LCA_WORKER_JOB_DOMAIN_REF_UPDATES,
+            lcia_result_package_worker_result_ref, parse_build_snapshot_worker_projection,
+            payload_type_name, result_schema_version_for_payload,
+            skipped_legacy_lca_job_projection, snapshot_diagnostic_scope_pairs,
             solver_worker_job_payload, solver_worker_result_ref,
             validate_authoritative_package_closure_binding,
         },
         types::JobPayload,
         worker_jobs::WorkerJob,
     };
+
+    #[test]
+    fn canonical_worker_job_domain_links_never_reference_legacy_lca_jobs() {
+        assert!(
+            CANONICAL_LCA_WORKER_JOB_DOMAIN_REF_UPDATES
+                .iter()
+                .all(|statement| !statement.contains("lca_jobs")),
+            "canonical worker_jobs domain linking must not query the retired lca_jobs table"
+        );
+    }
+
+    #[test]
+    fn canonical_legacy_job_projection_is_a_non_querying_compatibility_placeholder() {
+        let lca_job_id = Uuid::new_v4();
+        assert_eq!(
+            skipped_legacy_lca_job_projection(lca_job_id),
+            json!({
+                "id": lca_job_id,
+                "projectionSkipped": true,
+            })
+        );
+    }
 
     fn worker_job(
         job_kind: &str,

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedCommit: 31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1
 lastReviewedNote: "Issue #152 advances the single exact Rust tidas runtime contract to v0.1.1 without changing Worker ownership boundaries."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,7 +40,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedCommit: 31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1
 lastReviewedNote: "Issue #152 requires the published tidas v0.1.1 version/describe handshake before coordinated rollout."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -213,13 +213,13 @@ On success, the worker records a terminal `worker_jobs` result with:
 - `result_json.snapshotId`
 - `result_json.resultId` when a `lca_results` row was produced
 - `result_ref = {"domainSource":"worker_jobs","workerJobId":"<uuid>","lcaJobId":"<uuid>","result":{"table":"lca_results","id":"<uuid>"}}` for solve/result-producing jobs
-- `diagnostics.lcaJob` as an optional legacy `lca_jobs` projection; if the table is absent, the projection reports `legacyTableMissing=true`
+- `diagnostics.lcaJob = {"id":"<uuid>","projectionSkipped":true}` and `result_json.lcaJobStatus = null` are non-querying compatibility placeholders; canonical result diagnostics come from `worker_jobs` and domain result tables, and the `worker_jobs` runtime does not query optional `lca_jobs`
 
 `build_snapshot` is projected independently from `worker_jobs.diagnostics.build_snapshot_result`: it always returns the resolved snapshot ID (including reuse) and scoped calculation evidence without reading optional `lca_jobs`. Its `result_ref.snapshot` points at the resolved `lca_network_snapshots` row.
 
 Singular/factorization failure diagnostics load the exact `(process_id, process_version)` pairs from `snapshot-index.process_map`. Duplicate-exchange and service-loop scans join only those pairs; they do not reconstruct scope from broad owner/state filters.
 
-On success or failure, the worker links `lca_results`, `lca_result_cache`, `lca_latest_all_unit_results`, and `lca_factorization_registry` rows back to the canonical `worker_jobs.id` where those rows exist. If optional `lca_jobs` exists, the worker also backfills `lca_jobs.worker_job_id`; if it does not exist, the compatibility write is skipped. On failure, the worker records `worker_jobs.status=failed` with `error_code=solver_worker_job_failed` and updates `lca_result_cache` failed state where a cache row exists; retained `lca_jobs.status/diagnostics` are best-effort compatibility only.
+On success or failure, the worker links `lca_results`, `lca_result_cache`, `lca_latest_all_unit_results`, and `lca_factorization_registry` rows back to the canonical `worker_jobs.id` where those rows exist. The canonical path never probes or backfills optional `lca_jobs`. On failure, the worker records `worker_jobs.status=failed` with `error_code=solver_worker_job_failed` and updates `lca_result_cache` failed state where a cache row exists. Retained `lca_jobs.status/diagnostics` writes are limited to the explicitly enabled legacy pgmq/debug backend.
 
 For `lcia_result.package_build`, worker builds a published-only snapshot using the package `buildId` as the requested snapshot/result compatibility key, computes and persists the all-unit LCIA result artifact plus query artifact, then calls service-role RPC `public.cmd_lcia_result_package_mark_ready(...)`. Success `result_ref` uses `{"domainSource":"worker_jobs","workerJobId":"<uuid>","buildId":"<uuid>","package":{"table":"lcia_result_packages","id":"<uuid>"}}`; failures use package-specific error codes and do not update `lca_result_cache` or optional legacy `lca_jobs`.
 
@@ -325,7 +325,7 @@ Provider-link 的运行时决策顺序、默认 provider rule、candidate eligib
 - `requested_location_granularity_counts`：目标供应区域粒度总计，例如 `subnational`、`country`、`region`、`global`、`unspecified`。
 - `requested_location_granularity_counts_by_strategy`：按 resolved strategy 拆分的目标供应区域粒度。
 
-`build_snapshot` job 运行和完成时，worker 会在 `worker_jobs.diagnostics/result_json` 中记录全局构建并发锁与构建耗时信息；如果 optional `lca_jobs` 存在，也会 best-effort 写入 `lca_jobs.diagnostics.build_snapshot_lock` 与 `build_timing_sec`。这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
+`build_snapshot` job 运行和完成时，worker 会在 `worker_jobs.diagnostics/result_json` 中记录全局构建并发锁与构建耗时信息。Canonical `worker_jobs` execution never mirrors these diagnostics into optional `lca_jobs`; only the explicitly enabled legacy pgmq/debug backend writes legacy diagnostics. 这些字段属于诊断信息，不改变 job payload、状态机或 result artifact 主契约。
 
 ### 5.1 Matrix-readiness verification report
 
@@ -442,6 +442,6 @@ legacy pgmq 路径：
 1. 先创建或复用 `lca_result_cache` domain row，并生成 `lcaJobId` compatibility UUID；不要求创建 `lca_jobs` row。
 2. 调 `public.worker_enqueue_job(...)` 创建 `job_kind=lca.*`、`worker_queue=solver` 的 job，payload 带 `lcaJobId` 和标准化求解参数。
 3. 返回 `workerJobId` 与 `lcaJobId` 给 Edge / Next projection。
-4. worker 使用 `worker_claim_jobs('solver', ...)` claim、heartbeat，并通过 `worker_record_job_result(...)` 写 canonical 终态；同时维护 `lca_results`、`lca_result_cache` domain/cache metadata，并回填 `worker_job_id`。optional `lca_jobs` 只做 best-effort compatibility update。
+4. worker 使用 `worker_claim_jobs('solver', ...)` claim、heartbeat，并通过 `worker_record_job_result(...)` 写 canonical 终态；同时维护 `lca_results`、`lca_result_cache` domain/cache metadata，并回填 `worker_job_id`。Canonical path does not query or update optional `lca_jobs`; legacy table access is restricted to the explicitly enabled pgmq/debug backend。
 
 不建议前端直接调用 `pgmq.send`、直接写 `lca_jobs` 或直接写 `worker_jobs`。

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -25,7 +25,7 @@ checkPaths:
   - docs/agents/repo-architecture.md
   - docs/agents/repo-validation.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedCommit: 31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1
 lastReviewedNote: "Issue #152 advances the exact Rust validator handshake to tidas v0.1.1 without changing Worker-owned bounded orchestration."
 related:
   - AGENTS.md

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,7 +19,7 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
 lastReviewedAt: 2026-07-28
-lastReviewedCommit: 615162082a7e3e1e7cfa4c603585c86c73c0b920
+lastReviewedCommit: 31c5c0a12d62fa1176c8fa7ea2a76d8d09f415f1
 lastReviewedNote: "Issue #152 advances package-worker's exact Rust validator handshake to tidas v0.1.1."
 related:
   - AGENTS.md


### PR DESCRIPTION
Closes #154

## Summary
- Separate canonical worker_jobs execution from legacy lca_jobs lifecycle writes so the production path never issues SQL against the retired table.
- Remove canonical success projection, failure cleanup, snapshot reuse, and domain-link probes while keeping the explicit pgmq/debug backend behavior intact.

## Key Decisions
- Model legacy table access as an explicit JobLifecycleBackend capability passed only to the legacy queue handler.
- Preserve lcaJobStatus and diagnostics.lcaJob field shapes as non-querying compatibility placeholders.
- Keep result/cache/factorization worker_job_id backfills on canonical domain tables.

## Validation
- make check (workspace fmt, Clippy with -D warnings, full workspace tests): passed.
- docpact validate-config --strict and worktree lint: passed with zero findings.
- Pre-push hook reran Docpact and make check successfully.

## Risks / Rollback
- Low-to-moderate compatibility risk: legacy projection fields remain present but no longer contain lca_jobs status/diagnostics; they explicitly report projectionSkipped=true and lcaJobStatus=null.

## Follow-ups
- After merge, deploy/restart the worker and run a representative worker_jobs job against production to confirm no new 42P01 lca_jobs log entries.

## Workspace Integration
- After the worker PR merges to main and runtime smoke passes, update the lca-workspace submodule pointer through the normal integration flow.