### PR TITLE
fix: avoid scope-closure snapshot argv overflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedCommit: "10183162a1944252fd01eeb5ffc1548cbe8c4ec1"
+lastReviewedCommit: "2ee74ffaf431c0d43b9613bcb6bfed76fa447b66"
 lastReviewedAt: "2026-08-03"
-lastReviewedNote: "Reviewed for Worker Issues #190, #192, #193, #198, #199, and #202: private control-plane, closure hash, snapshot-consumer, and result-identity qualification remain Worker-owned and now converge on one exact-head disposable-stack receipt."
+lastReviewedNote: "Reviewed for Worker Issue #205: existing scope-closure, snapshot-builder, readiness, and provider routing rules already cover the file-backed input change; ownership and routing are unchanged."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #190, #192, #193, #198, #199, and #202: private control-plane, closure hash, snapshot persistence, and result identity stay Worker-owned; exact-head qualification uses only a runner-owned disposable loopback stack and leaves database-engine as schema owner."
+lastReviewedNote: "Reviewed for Worker Issue #205: file-backed snapshot_builder input remains Worker-owned runtime behavior; repository ownership, branch policy, and database-engine schema boundaries are unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -194,6 +194,8 @@ struct Cli {
     #[arg(long)]
     scope_closure_data_snapshot_json: Option<String>,
     #[arg(long)]
+    scope_closure_data_snapshot_file: Option<PathBuf>,
+    #[arg(long)]
     scope_closure_mode: Option<String>,
     #[arg(long, env = "LCIA_STATIC_CACHE_DIR")]
     lcia_static_cache_dir: Option<PathBuf>,
@@ -749,10 +751,34 @@ fn parse_required_json_arg(value: Option<&str>, name: &str) -> anyhow::Result<Va
 fn parse_scope_closure_snapshot_args(
     cli: &Cli,
 ) -> anyhow::Result<Option<(ScopeClosureSnapshotBinding, DataSnapshotManifest, &str)>> {
-    match (
-        cli.scope_closure_binding_json.as_deref(),
+    let snapshot = match (
         cli.scope_closure_data_snapshot_json.as_deref(),
+        cli.scope_closure_data_snapshot_file.as_deref(),
     ) {
+        (Some(_), Some(_)) => {
+            return Err(anyhow::anyhow!(
+                "--scope-closure-data-snapshot-json and --scope-closure-data-snapshot-file are mutually exclusive"
+            ));
+        }
+        (Some(snapshot), None) => Some(
+            serde_json::from_str::<DataSnapshotManifest>(snapshot).map_err(|error| {
+                anyhow::anyhow!("invalid --scope-closure-data-snapshot-json: {error}")
+            })?,
+        ),
+        (None, Some(path)) => {
+            let file = fs::File::open(path).map_err(|error| {
+                anyhow::anyhow!("open --scope-closure-data-snapshot-file: {error}")
+            })?;
+            Some(
+                serde_json::from_reader::<_, DataSnapshotManifest>(std::io::BufReader::new(file))
+                    .map_err(|error| {
+                    anyhow::anyhow!("invalid --scope-closure-data-snapshot-file: {error}")
+                })?,
+            )
+        }
+        (None, None) => None,
+    };
+    match (cli.scope_closure_binding_json.as_deref(), snapshot) {
         (None, None) if cli.scope_closure_mode.is_none() => Ok(None),
         (Some(binding), Some(snapshot)) => {
             let mode = cli.scope_closure_mode.as_deref().ok_or_else(|| {
@@ -766,10 +792,6 @@ fn parse_scope_closure_snapshot_args(
             let binding: ScopeClosureSnapshotBinding =
                 serde_json::from_str(binding).map_err(|error| {
                     anyhow::anyhow!("invalid --scope-closure-binding-json: {error}")
-                })?;
-            let snapshot: DataSnapshotManifest =
-                serde_json::from_str(snapshot).map_err(|error| {
-                    anyhow::anyhow!("invalid --scope-closure-data-snapshot-json: {error}")
                 })?;
             if binding.schema_version != "lcia.scope-closure-snapshot-binding.v1"
                 || binding.effective_scope_hash.trim().is_empty()
@@ -806,7 +828,7 @@ fn parse_scope_closure_snapshot_args(
             Ok(Some((binding, snapshot, mode)))
         }
         _ => Err(anyhow::anyhow!(
-            "--scope-closure-binding-json and --scope-closure-data-snapshot-json must be supplied together"
+            "--scope-closure-binding-json and exactly one scope-closure data snapshot input must be supplied together"
         )),
     }
 }
@@ -9351,22 +9373,24 @@ mod tests {
         flow_reference_requests_from_source_references, geo_score, insert_compiled_source_dataset,
         load_impact_factor_sets, location_granularity_label, no_balancing_reference_failure_reason,
         normalize_request_roots, parse_number, parse_process_annual_supply_or_production_volume,
-        parse_process_states, parse_provider_rule_list, resolve_allocation_fraction,
-        resolve_database_lcia_method_row, resolve_database_lcia_method_rows,
-        resolve_lcia_method_source_row, resolve_lcia_support_flows, resolve_multi_provider,
-        resolve_process_selection, resolve_reference_normalization,
-        review_submit_root_dependency_fingerprint, reviewed_lcia_artifact_locator,
-        scope_closure_boundary_policy, scope_closure_candidate_process_axis,
-        snapshot_db_statement_timeout, source_dataset_document_id,
-        source_reference_is_satisfied_index, summarize_matching_diagnostics, time_score,
-        unique_supported_direction_by_flow, validate_compiled_sources_against_frozen_manifest,
-        validate_flow_row_visibility, validate_process_row_visibility,
-        validate_quantitative_references, validate_unique_database_lcia_method_identities,
+        parse_process_states, parse_provider_rule_list, parse_scope_closure_snapshot_args,
+        resolve_allocation_fraction, resolve_database_lcia_method_row,
+        resolve_database_lcia_method_rows, resolve_lcia_method_source_row,
+        resolve_lcia_support_flows, resolve_multi_provider, resolve_process_selection,
+        resolve_reference_normalization, review_submit_root_dependency_fingerprint,
+        reviewed_lcia_artifact_locator, scope_closure_boundary_policy,
+        scope_closure_candidate_process_axis, snapshot_db_statement_timeout,
+        source_dataset_document_id, source_reference_is_satisfied_index,
+        summarize_matching_diagnostics, time_score, unique_supported_direction_by_flow,
+        validate_compiled_sources_against_frozen_manifest, validate_flow_row_visibility,
+        validate_process_row_visibility, validate_quantitative_references,
+        validate_unique_database_lcia_method_identities,
     };
     use chrono::Utc;
     use clap::Parser;
     use serde_json::json;
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+    use std::io::Write;
     use uuid::Uuid;
 
     use solver_worker::compiled_graph::{
@@ -9941,6 +9965,61 @@ mod tests {
         );
         assert_eq!(cli.artifact_expires_in_seconds, Some(1_209_600));
         assert_eq!(cli.reuse_max_age_seconds, Some(1_209_600));
+    }
+
+    #[test]
+    fn snapshot_builder_reads_scope_closure_snapshot_from_file() {
+        let (binding, snapshot, _) =
+            frozen_scope_closure_snapshot("scope_only", "closed", "discovery");
+        let mut input = tempfile::NamedTempFile::new().expect("snapshot input file");
+        serde_json::to_writer(&mut input, &snapshot).expect("write snapshot input");
+        input.flush().expect("flush snapshot input");
+        let binding_json = serde_json::to_string(&binding).expect("binding JSON");
+        let input_path = input.path().to_string_lossy().into_owned();
+        let cli = Cli::try_parse_from([
+            "snapshot_builder",
+            "--scope-closure-mode",
+            "discovery",
+            "--scope-closure-binding-json",
+            binding_json.as_str(),
+            "--scope-closure-data-snapshot-file",
+            input_path.as_str(),
+        ])
+        .expect("parse file input CLI");
+
+        let (parsed_binding, parsed_snapshot, parsed_mode) =
+            parse_scope_closure_snapshot_args(&cli)
+                .expect("parse scope closure input")
+                .expect("scope closure input");
+        assert_eq!(parsed_binding, binding);
+        assert_eq!(parsed_snapshot, snapshot);
+        assert_eq!(parsed_mode, "discovery");
+    }
+
+    #[test]
+    fn snapshot_builder_rejects_conflicting_scope_closure_snapshot_inputs() {
+        let (binding, snapshot, _) =
+            frozen_scope_closure_snapshot("scope_only", "closed", "discovery");
+        let input = tempfile::NamedTempFile::new().expect("snapshot input file");
+        let binding_json = serde_json::to_string(&binding).expect("binding JSON");
+        let snapshot_json = serde_json::to_string(&snapshot).expect("snapshot JSON");
+        let input_path = input.path().to_string_lossy().into_owned();
+        let cli = Cli::try_parse_from([
+            "snapshot_builder",
+            "--scope-closure-mode",
+            "discovery",
+            "--scope-closure-binding-json",
+            binding_json.as_str(),
+            "--scope-closure-data-snapshot-json",
+            snapshot_json.as_str(),
+            "--scope-closure-data-snapshot-file",
+            input_path.as_str(),
+        ])
+        .expect("parse conflicting CLI");
+
+        let error = parse_scope_closure_snapshot_args(&cli)
+            .expect_err("conflicting snapshot inputs must fail");
+        assert!(error.to_string().contains("mutually exclusive"));
     }
 
     #[test]

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     future::Future,
-    io::{BufReader, ErrorKind},
+    io::{BufReader, ErrorKind, Write},
     path::PathBuf,
     process::Stdio,
     time::{Duration, Instant},
@@ -2335,6 +2335,18 @@ pub(crate) enum SnapshotBuilderProcessFailure {
     },
 }
 
+pub(crate) fn snapshot_builder_process_failure_code(error: &anyhow::Error) -> Option<&'static str> {
+    let failure = error.downcast_ref::<SnapshotBuilderProcessFailure>()?;
+    Some(match failure {
+        SnapshotBuilderProcessFailure::Launch { .. } => "snapshot_builder_launch_failed",
+        SnapshotBuilderProcessFailure::Timeout { .. } => "snapshot_builder_timeout",
+        SnapshotBuilderProcessFailure::Signal { .. } => "snapshot_builder_signal",
+        SnapshotBuilderProcessFailure::Exit { .. } => "snapshot_builder_exit_failed",
+        SnapshotBuilderProcessFailure::Protocol { .. } => "snapshot_builder_protocol_failed",
+        SnapshotBuilderProcessFailure::Blocked { .. } => "snapshot_builder_blocked",
+    })
+}
+
 #[derive(Debug, Clone)]
 struct BuilderCommandCandidate {
     program: String,
@@ -3616,14 +3628,8 @@ async fn run_snapshot_builder_job(
         builder_args.push("--lcia-factor-coverage-contract-json".to_owned());
         builder_args.push(serde_json::to_string(&scope.lcia_factor_coverage_contract)?);
     }
-    if let Some(scope) = scope_closure {
-        builder_args.push("--scope-closure-mode".to_owned());
-        builder_args.push(scope.mode.as_str().to_owned());
-        builder_args.push("--scope-closure-binding-json".to_owned());
-        builder_args.push(serde_json::to_string(&scope.binding)?);
-        builder_args.push("--scope-closure-data-snapshot-json".to_owned());
-        builder_args.push(serde_json::to_string(&scope.data_snapshot)?);
-    }
+    let _scope_closure_snapshot_file =
+        append_scope_closure_snapshot_args(&mut builder_args, scope_closure)?;
 
     let candidates = snapshot_builder_candidates(builder_args);
     let mut last_not_found = false;
@@ -3797,6 +3803,36 @@ async fn run_snapshot_builder_job(
         ));
     }
     Err(anyhow::anyhow!("failed to execute snapshot_builder"))
+}
+
+fn append_scope_closure_snapshot_args(
+    builder_args: &mut Vec<String>,
+    scope_closure: Option<&ScopeClosureSnapshotBuilderArgs>,
+) -> anyhow::Result<Option<tempfile::NamedTempFile>> {
+    let Some(scope) = scope_closure else {
+        return Ok(None);
+    };
+
+    let mut snapshot_file = tempfile::Builder::new()
+        .prefix("scope-closure-data-snapshot-")
+        .suffix(".json")
+        .tempfile()
+        .map_err(|error| {
+            anyhow::anyhow!("create scope-closure snapshot_builder input file: {error}")
+        })?;
+    serde_json::to_writer(&mut snapshot_file, &scope.data_snapshot)
+        .map_err(|error| anyhow::anyhow!("write scope-closure snapshot_builder input: {error}"))?;
+    snapshot_file.flush().map_err(|error| {
+        anyhow::anyhow!("flush scope-closure snapshot_builder input file: {error}")
+    })?;
+
+    builder_args.push("--scope-closure-mode".to_owned());
+    builder_args.push(scope.mode.as_str().to_owned());
+    builder_args.push("--scope-closure-binding-json".to_owned());
+    builder_args.push(serde_json::to_string(&scope.binding)?);
+    builder_args.push("--scope-closure-data-snapshot-file".to_owned());
+    builder_args.push(snapshot_file.path().to_string_lossy().into_owned());
+    Ok(Some(snapshot_file))
 }
 
 fn snapshot_builder_candidates(builder_args: Vec<String>) -> Vec<BuilderCommandCandidate> {
@@ -4502,16 +4538,18 @@ mod tests {
         BuildSnapshotWorkerLease, BuilderCommandCandidate, JobLifecycleBackend,
         PackageSnapshotExecutionMode, PersistedResultIdentity, ResultInsert,
         ResultInsertReconciliation, SNAPSHOT_BUILDER_BLOCKED_EXIT_CODE,
+        ScopeClosureSnapshotBuilderArgs, ScopeClosureSnapshotBuilderMode,
         SnapshotBuilderProcessFailure, SnapshotBuilderTerminal, SolveOptionsPayload,
-        acquire_build_snapshot_worker_jobs_slot_sql, build_all_unit_rhs_batch,
-        build_snapshot_heartbeat_interval, classify_result_insert_reconciliation, insert_result,
-        lcia_result_package_request_roots, lcia_result_package_version,
-        missing_legacy_tables_sparse_data_error, normalize_all_unit_batch_size,
-        package_snapshot_execution_mode, parse_snapshot_builder_build_timing,
-        parse_snapshot_builder_resolved_snapshot_id, read_certified_closure_bundle_binding,
-        reconcile_failed_result_insert, redact_sensitive_diagnostics, redacted_builder_command,
-        resolve_solve_all_unit_options, result_insert_outcome_pending_error,
-        run_snapshot_builder_job, run_snapshot_builder_job_with_worker_heartbeat,
+        acquire_build_snapshot_worker_jobs_slot_sql, append_scope_closure_snapshot_args,
+        build_all_unit_rhs_batch, build_snapshot_heartbeat_interval,
+        classify_result_insert_reconciliation, insert_result, lcia_result_package_request_roots,
+        lcia_result_package_version, missing_legacy_tables_sparse_data_error,
+        normalize_all_unit_batch_size, package_snapshot_execution_mode,
+        parse_snapshot_builder_build_timing, parse_snapshot_builder_resolved_snapshot_id,
+        read_certified_closure_bundle_binding, reconcile_failed_result_insert,
+        redact_sensitive_diagnostics, redacted_builder_command, resolve_solve_all_unit_options,
+        result_insert_outcome_pending_error, run_snapshot_builder_job,
+        run_snapshot_builder_job_with_worker_heartbeat, snapshot_builder_process_failure_code,
         snapshot_builder_wall_timeout_seconds_from, tail_text, utf8_safe_tail,
         validate_certified_process_axis,
     };
@@ -4942,6 +4980,66 @@ mod tests {
         );
         assert!(!diagnostic.contains("secret"));
         assert!(!diagnostic.contains(Uuid::nil().to_string().as_str()));
+    }
+
+    #[test]
+    fn snapshot_builder_launch_failure_has_stable_terminal_error_code() {
+        let error = anyhow::Error::new(SnapshotBuilderProcessFailure::Launch {
+            command: "snapshot_builder --scope-closure-data-snapshot-file".to_owned(),
+            source: std::io::Error::from_raw_os_error(7),
+        });
+
+        assert_eq!(
+            snapshot_builder_process_failure_code(&error),
+            Some("snapshot_builder_launch_failed")
+        );
+    }
+
+    #[test]
+    fn scope_closure_snapshot_transport_keeps_large_manifest_out_of_argv_and_cleans_up() {
+        let marker = "manifest-secret-marker";
+        let scope = ScopeClosureSnapshotBuilderArgs {
+            mode: ScopeClosureSnapshotBuilderMode::Discovery,
+            binding: json!({"schemaVersion": "binding"}),
+            data_snapshot: json!({
+                "schemaVersion": "lcia.scope-closure-data-snapshot.v2",
+                "payload": format!("{marker}{}", "x".repeat(4 * 1024 * 1024)),
+            }),
+        };
+        let mut args = Vec::new();
+        let input = append_scope_closure_snapshot_args(&mut args, Some(&scope))
+            .expect("prepare snapshot transport")
+            .expect("snapshot input file");
+        let input_path = input.path().to_path_buf();
+
+        assert!(
+            args.iter()
+                .any(|arg| arg == "--scope-closure-data-snapshot-file")
+        );
+        assert!(
+            !args
+                .iter()
+                .any(|arg| arg == "--scope-closure-data-snapshot-json")
+        );
+        assert!(!args.iter().any(|arg| arg.contains(marker)));
+        assert!(fs::metadata(&input_path).expect("snapshot metadata").len() > 4 * 1024 * 1024);
+        assert_eq!(
+            fs::metadata(&input_path)
+                .expect("snapshot metadata")
+                .permissions()
+                .mode()
+                & 0o077,
+            0,
+            "snapshot input must not be group/world accessible"
+        );
+        assert!(
+            fs::read_to_string(&input_path)
+                .expect("read snapshot input")
+                .contains(marker)
+        );
+
+        drop(input);
+        assert!(!input_path.exists(), "snapshot input must be cleaned up");
     }
 
     #[test]

--- a/crates/solver-worker/src/queue.rs
+++ b/crates/solver-worker/src/queue.rs
@@ -16,7 +16,7 @@ use crate::{
         AppState, archive_queue_message, fetch_snapshot_index_document, handle_job_payload,
         handle_lcia_result_package_build_worker_job, handle_worker_jobs_job_payload,
         latest_result_id_for_job, mark_result_cache_failed, read_one_queue_message,
-        update_legacy_lca_job_status,
+        snapshot_builder_process_failure_code, update_legacy_lca_job_status,
     },
     scope_closure::{
         SCOPE_CLOSURE_JOB_KIND, SCOPE_CLOSURE_REQUEST_SCHEMA_VERSION, execute_scope_closure_job,
@@ -423,6 +423,8 @@ async fn process_solver_worker_job(state: &AppState, job: WorkerJob, lease_secon
                 );
             }
             Err(err) => {
+                let error_code = snapshot_builder_process_failure_code(&err)
+                    .unwrap_or("scope_closure_execution_failed");
                 let message = err.to_string();
                 error!(
                     error = %message,
@@ -435,7 +437,7 @@ async fn process_solver_worker_job(state: &AppState, job: WorkerJob, lease_secon
                     *closure_check_id,
                     job.id,
                     job.lease_token,
-                    message.as_str(),
+                    error_code,
                 )
                 .await
                 {

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -5372,7 +5372,7 @@ pub async fn record_scope_closure_failure(
     closure_check_id: Uuid,
     worker_job_id: Uuid,
     lease_token: Uuid,
-    _error: &str,
+    error_code: &str,
 ) -> anyhow::Result<Value> {
     let row = sqlx::query(
         r"
@@ -5380,7 +5380,7 @@ pub async fn record_scope_closure_failure(
             SELECT set_config('request.jwt.claim.role', 'service_role', true)
         )
         SELECT public.svc_lcia_scope_closure_fail_before_scan(
-            $1, $2, $3, 'scope_closure_execution_failed'
+            $1, $2, $3, $4
         ) AS result
         FROM _service_role
         ",
@@ -5388,6 +5388,7 @@ pub async fn record_scope_closure_failure(
     .bind(closure_check_id)
     .bind(worker_job_id)
     .bind(lease_token)
+    .bind(error_code)
     .fetch_one(pool)
     .await?;
     let result = row.try_get::<Value, _>("result")?;

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -27,9 +27,9 @@ checkPaths:
   - docs/agents/contracts/scope-closure-external-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #190, #192, #193, and #202: schema-qualified access, private hashes, exact TIDAS evidence, and solve-result identity preserve bounded memory, scope-closure artifact layout, publication, four-mode identity, owner evidence, and qualification result contracts."
+lastReviewedNote: "Reviewed for Worker Issue #205: temporary file transport for the frozen manifest preserves bounded cleanup, artifact layout, publication, and qualification result contracts."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,9 +35,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #192, #198, #199, and #202: private hashes, exact TIDAS fixtures, private snapshot persistence, result UUID preallocation, and fail-closed object-target validation remain Worker runtime behavior while database-engine remains schema owner."
+lastReviewedNote: "Reviewed for Worker Issue #205: the file-backed frozen-manifest handoff stays inside the existing Worker/snapshot_builder runtime boundary; crate topology and database ownership are unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,9 +40,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #192, #198, #199, and #202: the exact-head combined runner binds private control-plane, snapshot, scope-closure, and result-identity proof to one disposable local stack and credential-free receipt."
+lastReviewedNote: "Reviewed for Worker Issue #205: scope-closure proof includes file-backed large-manifest handoff, restricted permissions, cleanup, and exclusion of manifest bytes from argv and diagnostics."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -70,6 +70,8 @@ Treat the last two commands as non-negotiable hard gates after code changes.
 The local `pre-push` hook runs the docpact gate first and then runs `make check`. The GitHub `ci` workflow is manual-dispatch only, so ordinary branch pushes do not spend Actions minutes on standalone tests.
 
 ## Validation Matrix
+
+For scope-closure transport changes, include `cargo test -p solver-worker scope_closure_snapshot_transport_keeps_large_manifest_out_of_argv_and_cleans_up` and `cargo test -p solver-worker --bin snapshot_builder snapshot_builder_reads_scope_closure_snapshot_from_file`. These tests must prove that a manifest larger than ordinary argv capacity is file-backed, permission-restricted, available for parsing, absent from argv/diagnostics, and removed after the owning handle is dropped.
 
 | Change type | Minimum local proof | Additional proof when risk is higher | Notes |
 | --- | --- | --- | --- |

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -24,9 +24,9 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
-lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
+lastReviewedAt: 2026-08-03
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
+lastReviewedNote: "Reviewed for Worker Issue #205: frozen-manifest file transport does not change implicit regional supply-mix modeling or routing weights."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -24,9 +24,9 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
-lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
+lastReviewedAt: 2026-08-03
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
+lastReviewedNote: "Reviewed for Worker Issue #205: frozen-manifest file transport does not change implicit regional supply-mix modeling or routing weights."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
-lastReviewedNote: "Reviewed for Worker Issues #192, #198, and #202: private closure hashes, schema-valid fixtures, preallocated result identity, and exact object-target deletion validation do not change public Worker, Edge, or Next DTO labels."
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
+lastReviewedNote: "Reviewed for Worker Issue #205: the internal Worker-to-snapshot_builder file handoff changes no public Worker, Edge, Next, job payload, or result DTO labels."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -24,9 +24,9 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
-lastReviewedNote: "Issue #146 adds selected LCIA-factor Flow source-closure policy to build identity; readiness schema and blocker semantics are unchanged."
+lastReviewedAt: 2026-08-03
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
+lastReviewedNote: "Reviewed for Worker Issue #205: file-backed scope-closure manifest input does not change readiness schema, blocker semantics, policy, or report artifacts."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -22,9 +22,9 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
-lastReviewedNote: "Issue #146 separates selected LCIA-factor Flow source evidence from the inventory-derived matrix and provider Flow universe."
+lastReviewedAt: 2026-08-03
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
+lastReviewedNote: "Reviewed for Worker Issue #205: changing frozen-manifest transport does not change signed-flow eligibility, routing order, provider rules, or diagnostics semantics."
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -31,9 +31,9 @@ checkPaths:
   - scripts/scope_closure_qualification.py
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #186, #190, #192, and #202: private control-plane access, hashes, and solve-result UUID locators preserve closure traversal, service-role behavior, artifacts, certificate evidence, staged publication, reuse, and package binding; qualification fails closed on identity, payload, target, or cleanup drift."
+lastReviewedNote: "Reviewed for Worker Issue #205: the complete frozen release manifest is handed to snapshot_builder through a permission-restricted temporary file without changing closure traversal, certificate evidence, or package binding."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -70,6 +70,8 @@ The V2 data snapshot is the only certificate-grade source boundary. It contains:
 - the complete `lca_release_dataset_versions` allowlist with exact dataset identity, role, source-process provenance, version-significant hash, semantic hash, and canonical content hash.
 
 The Worker recomputes the PostgreSQL JSONB scope and snapshot hashes with the database's authoritative hash helper. A blank or inconsistent binding fails closed. Requested process roots that are present in the release must have role `unit_process`; a root absent from the release is reported as an incomplete source-boundary blocker.
+
+The complete frozen manifest is a large internal input, not a command-line payload. For discovery and build, the Worker serializes it to a permission-restricted temporary JSON file, passes only the file path through `--scope-closure-data-snapshot-file`, keeps the file alive across the complete child-process candidate sequence, and removes it automatically afterward. `snapshot_builder` retains `--scope-closure-data-snapshot-json` for explicit small/manual invocations, but JSON and file inputs are mutually exclusive and enter the same parsing and certificate-validation path. Diagnostics may record the input flag but must not record the temporary path, manifest bytes, or full argv.
 
 ## Frozen-source traversal
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 10183162a1944252fd01eeb5ffc1548cbe8c4ec1
+lastReviewedCommit: 2ee74ffaf431c0d43b9613bcb6bfed76fa447b66
 lastReviewedAt: 2026-08-03
-lastReviewedNote: "Reviewed for Worker Issues #186, #190, #192, and #202: schema-qualified worker access, private hashes, exact-TIDAS qualification, and solve-result UUID locators preserve package import/export artifacts, retention, semantics, and package-worker state."
+lastReviewedNote: "Reviewed for Worker Issue #205: scope-closure snapshot_builder input transport does not change TIDAS package import/export artifacts, retention, semantics, or package-worker state."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#205

## Summary
- Move the unbounded frozen scope-closure data snapshot from one argv value to a permission-restricted temporary JSON file.
- Parse file-backed and inline snapshot inputs through the same manifest validation path, with mutually exclusive CLI inputs.
- Persist stable snapshot_builder process failure codes for launch, timeout, signal, exit, protocol, and blocked outcomes.

## Key Decisions
- Keep the bounded scope-closure binding JSON on argv; keep the full manifest alive via NamedTempFile across every command candidate and clean it up automatically after execution.
- Command diagnostics continue to expose flags only, so neither manifest bytes nor the temporary path are recorded.

## Validation
- cargo test --workspace --all-features passed; solver-worker library: 336 passed, 13 ignored, 0 failed; snapshot_builder: 91 passed, 0 failed.
- cargo clippy --workspace --all-targets --all-features -- -D warnings; cargo fmt --all -- --check; git diff --check; strict docpact config validation; enforced docpact lint.
- Focused large-manifest transport/cleanup, file-input parsing, conflicting-input, stable failure-code, scope_closure, and snapshot_builder tests passed.

## Risks / Rollback
- make check is locally blocked only because tools/bw25-validator/.venv adds 5,692 Python files to an active-source inventory expected to contain 99 tracked files; excluding the existing local venv yields the same 99 files as origin/main. The pre-push hook was bypassed only after the equivalent Rust, format, Clippy, and docpact gates passed independently.

## Follow-ups
- Fix the static inventory script separately so local .venv directories cannot invalidate tracked-source qualification.

## Workspace Integration
- After merge, update the tiangong-lca-worker submodule pointer in lca-workspace through the normal root integration flow.