### PR TITLE
fix: reuse existing commercial data during TIDAS import

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,6 +1,6 @@
 version: 1
 layout: repo
-lastReviewedCommit: "cfc356d96f7fe47e4f128ce1551c5ce3f3f47326"
+lastReviewedCommit: "23d514c88ad7c4e334e2afd0499881cff6ef72c6"
 lastReviewedAt: "2026-08-04"
 lastReviewedNote: "Reviewed for Worker Issues #205 and #207: file-backed scope-closure input and the no-fallback document-validation family preserve routing, while the solver build binds its exact source commit into the secret-free acceptance marker."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: cfc356d96f7fe47e4f128ce1551c5ce3f3f47326
+lastReviewedCommit: 23d514c88ad7c4e334e2afd0499881cff6ef72c6
 lastReviewedAt: 2026-08-04
 lastReviewedNote: "Reviewed for Worker Issues #205 and #207: file-backed snapshot_builder input, temporary document-validation isolation, and exact source-commit attestation remain Worker-owned, while Database #409 remains the private routine and schema authority."
 related:

--- a/crates/solver-worker/src/package_execution.rs
+++ b/crates/solver-worker/src/package_execution.rs
@@ -935,6 +935,10 @@ fn is_open_data_state_code(state_code: i32) -> bool {
     (OPEN_DATA_STATE_CODE_START..=OPEN_DATA_STATE_CODE_END).contains(&state_code)
 }
 
+fn is_skippable_import_conflict_state_code(state_code: i32) -> bool {
+    (OPEN_DATA_STATE_CODE_START..=200).contains(&state_code)
+}
+
 async fn fetch_scope_root_refs_single(
     pool: &PgPool,
     requested_by: Uuid,
@@ -3707,7 +3711,10 @@ fn partition_conflicts_from_rows(
             state_code: row.state_code,
             user_id: row.user_id,
         };
-        if row.state_code.is_some_and(is_open_data_state_code) {
+        if row
+            .state_code
+            .is_some_and(is_skippable_import_conflict_state_code)
+        {
             sets.open_data_conflicts.push(record);
         } else {
             sets.user_conflicts.push(record);
@@ -4721,7 +4728,7 @@ mod tests {
     }
 
     #[test]
-    fn partition_conflicts_filters_open_data_but_flags_user_conflicts() {
+    fn partition_conflicts_filters_existing_open_and_commercial_data() {
         let id = Uuid::nil();
         let entries = vec![PackageEntry {
             table: PackageRootTable::Processes,
@@ -4732,25 +4739,19 @@ mod tests {
             json_tg: None,
             model_id: None,
         }];
-        let rows = vec![
-            ConflictRow {
+        for state_code in [100, 199, 200] {
+            let rows = vec![ConflictRow {
                 id,
                 version: "01.00.000".to_owned(),
-                state_code: Some(100),
+                state_code: Some(state_code),
                 user_id: None,
-            },
-            ConflictRow {
-                id,
-                version: "02.00.000".to_owned(),
-                state_code: Some(150),
-                user_id: None,
-            },
-        ];
+            }];
 
-        let partitioned =
-            partition_conflicts_from_rows(PackageRootTable::Processes, &entries, &rows);
-        assert_eq!(partitioned.open_data_conflicts.len(), 1);
-        assert_eq!(partitioned.user_conflicts.len(), 0);
+            let partitioned =
+                partition_conflicts_from_rows(PackageRootTable::Processes, &entries, &rows);
+            assert_eq!(partitioned.open_data_conflicts.len(), 1);
+            assert_eq!(partitioned.user_conflicts.len(), 0);
+        }
     }
 
     #[test]
@@ -4802,6 +4803,31 @@ mod tests {
         assert_eq!(partitioned.open_data_conflicts.len(), 0);
         assert_eq!(partitioned.user_conflicts.len(), 1);
         assert_eq!(partitioned.user_conflicts[0].user_id, Some(user_id));
+    }
+
+    #[test]
+    fn partition_conflicts_rejects_states_above_commercial_data() {
+        let id = Uuid::nil();
+        let entries = vec![PackageEntry {
+            table: PackageRootTable::Processes,
+            id,
+            version: "01.00.000".to_owned(),
+            json_ordered: json!({"name": "Process"}),
+            rule_verification: true,
+            json_tg: None,
+            model_id: None,
+        }];
+        let rows = vec![ConflictRow {
+            id,
+            version: "01.00.000".to_owned(),
+            state_code: Some(201),
+            user_id: None,
+        }];
+
+        let partitioned =
+            partition_conflicts_from_rows(PackageRootTable::Processes, &entries, &rows);
+        assert_eq!(partitioned.open_data_conflicts.len(), 0);
+        assert_eq!(partitioned.user_conflicts.len(), 1);
     }
 
     #[test]

--- a/crates/solver-worker/src/package_execution.rs
+++ b/crates/solver-worker/src/package_execution.rs
@@ -936,7 +936,7 @@ fn is_open_data_state_code(state_code: i32) -> bool {
 }
 
 fn is_skippable_import_conflict_state_code(state_code: i32) -> bool {
-    (OPEN_DATA_STATE_CODE_START..=200).contains(&state_code)
+    is_open_data_state_code(state_code) || state_code == 200
 }
 
 async fn fetch_scope_root_refs_single(

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: cfc356d96f7fe47e4f128ce1551c5ce3f3f47326
+lastReviewedCommit: 23d514c88ad7c4e334e2afd0499881cff6ef72c6
 lastReviewedAt: 2026-08-04
 lastReviewedNote: "Reviewed for Worker Issues #205 and #207: file-backed frozen-manifest handoff stays inside the Worker/snapshot_builder boundary, while the fail-closed document-validation pool uses exact Database #409 routines and exposes the exact Worker build commit in its acceptance marker."
 related:

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,7 +40,7 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedCommit: cfc356d96f7fe47e4f128ce1551c5ce3f3f47326
+lastReviewedCommit: 23d514c88ad7c4e334e2afd0499881cff6ef72c6
 lastReviewedAt: 2026-08-04
 lastReviewedNote: "Reviewed for Worker Issues #205 and #207: proof retains file-backed large-manifest permissions/cleanup and requires restricted-login, exact Database #409, concurrency/reconnect, no-fallback, secret-free evidence, and exact compile-time source-commit attestation."
 related:

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,7 +25,7 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-04
-lastReviewedCommit: cfc356d96f7fe47e4f128ce1551c5ce3f3f47326
+lastReviewedCommit: 23d514c88ad7c4e334e2afd0499881cff6ef72c6
 lastReviewedNote: "Reviewed for Worker Issues #205 and #207: file-backed snapshot_builder handoff, document-validation SQL isolation, and exact source-commit attestation are internal and change no Worker, Edge, Next, job-payload, or result DTO labels."
 related:
   - AGENTS.md

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: cfc356d96f7fe47e4f128ce1551c5ce3f3f47326
+lastReviewedCommit: 23d514c88ad7c4e334e2afd0499881cff6ef72c6
 lastReviewedAt: 2026-08-04
-lastReviewedNote: "Reviewed for Worker Issues #205 and #207: file-backed scope-closure input and the solver-only document-validation pool do not change TIDAS package import/export artifacts, retention, semantics, or package-worker state."
+lastReviewedNote: "Reviewed for Worker Issue #212: import conflict filtering now reuses existing state-code 100-200 datasets without changing the open-data export scope or report schema."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -148,6 +148,8 @@ payload 必须仍携带有效 `job_id` compatibility UUID，因为 `lca_package_
    - 不执行 conflict checks
    - 不执行任何 inserts
 6. 若无校验错误，再执行现有冲突检测和导入流程。
+
+冲突检测以 `table + UUID + 规范化 version` 为精确键。目标环境中已存在的 `state_code = 100..=200` 记录统一视为可复用记录：Worker 跳过 package 中的对应条目，并继续导入其余数据；为保持现有 consumer 兼容，这些记录仍投影到 `filtered_open_data_count` 与 `filtered_open_data`。`state_code` 为 `null` 或不在 `100..=200` 时仍属于 `user_conflicts`，任一此类冲突都会返回 `USER_DATA_CONFLICT` 并阻止整包写入。该导入规则不改变 `open_data` export scope；导出仍只选择 `state_code = 100..=199`。
 
 运行时不得探测 Python module、`tidas-validate` 或其他候选命令。统一 binary 无法启动、版本/协议不匹配、超时、report/spool 不完整或 hash/count 不一致时，任务必须 fail closed，并映射为稳定的 `tidas_*` error code；这些 system failures 不能伪装为数据 validation issue。Worker 继续独立持有 job lease、heartbeat、取消检查、request-cache 状态和 terminal result projection，`tidas` 不接管这些行为。等待长时 validation 时，worker-jobs executor 每个 lease 的三分之一周期续租；heartbeat 被拒绝即丢弃当前 operation future，禁止继续接受或投影 validator evidence。
 


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#212

## Summary
- Treat an exact existing TIDAS dataset with state_code 200 as reusable during package import, alongside state codes 100–199.
- Keep conflict detection for state codes below 100, above 200, and NULL so user-owned or otherwise non-reusable data still blocks the import.

## Key Decisions
- Use an import-specific predicate for the inclusive 100–200 range; retain the existing 100–199 open-data predicate for export behavior.
- Preserve the current import report schema and compatibility fields filtered_open_data_count and filtered_open_data in this Worker-only delivery.

## Validation
- cargo test -p solver-worker partition_conflicts (4 passed)
- cargo test -p solver-worker package_execution::tests (23 passed)
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- Full repository pre-push make check, including cargo test --workspace --all-features (passed; ignored environment-dependent tests remained ignored).
- Docpact strict validation and governed-document lint passed against the origin/main merge base.

## Risks / Rollback
- The compatibility report fields still describe all skipped reusable records as filtered_open_data; changing API naming and frontend copy is intentionally deferred.
- Rollback is limited to reverting the import-specific state-code predicate and its tests/docs.

## Follow-ups
- Update frontend/API terminology in a separate change if the report should distinguish open and commercial reusable records.

## Workspace Integration
- After merge, update the lca-workspace Worker submodule pointer through the normal integration workflow; no root pointer change is included here.