### PR TITLE
fix: raise source closure document budget

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "e5a7f769f4716266271eea53cb5233781635174f"
+lastReviewedAt: "2026-08-05"
+lastReviewedCommit: "9a44912cf81641f4269221bf97d7d1f7a51f7cd8"
 lastReviewedNote: "Reviewed for Worker Issue #193: existing routing and ownership cover the exact tidas v0.1.3 runtime-default rollout."
 
 # Keep deterministic governance facts here.

--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,10 @@ SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS="900"
 # Default: 1800 seconds. Zero, negative/non-numeric, and unset values fail back
 # to the default rather than disabling the timeout.
 SNAPSHOT_BUILDER_WALL_TIMEOUT_SECONDS="1800"
+# Cumulative canonical JSON bytes admitted by one snapshot source-closure walk.
+# Default: 1073741824 (1 GiB). Zero, malformed, and overflow values fall back
+# to the default; this does not relax the separate 64 MiB support-batch limit.
+SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES="1073741824"
 # Versioned public_plus_owner_draft builds load the reviewed LCIA bundle from
 # exactly one trusted source. Production URLs must use HTTPS; LCIA_STATIC_CACHE_DIR
 # is intended for local/operator validation against the Next public asset root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Worker Issue #193: the exact tidas v0.1.3 runtime default changes without altering Worker orchestration or provider ownership."
 related:
   - .docpact/config.yaml

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/tidas-package-contract.md
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Issue #193: the active governed Rust tidas baseline is v0.1.3 while scope-closure v3 retains the 2048 MiB Linux RSS guard."
 related:
   - AGENTS.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -104,9 +104,25 @@ const SLOW_QUERY_LOG_THRESHOLD: Duration = Duration::from_secs(30);
 const SOURCE_CLOSURE_FLOW_QUERY_BATCH_SIZE: usize = 1_024;
 const SOURCE_CLOSURE_SUPPORT_QUERY_BATCH_SIZE: usize = 512;
 const SOURCE_CLOSURE_SUPPORT_BATCH_MAX_BYTES: usize = 64 * 1024 * 1024;
-const SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES: usize = 512 * 1024 * 1024;
+const DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES: usize = 1024 * 1024 * 1024;
+const SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES_ENV: &str = "SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES";
 const MAX_LCIA_GAP_EVIDENCE_RECORDS: u64 = 25_000_000;
 const MAX_LCIA_GAP_EVIDENCE_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
+fn source_closure_total_document_bytes_limit() -> usize {
+    source_closure_total_document_bytes_limit_from(
+        std::env::var(SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES_ENV)
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn source_closure_total_document_bytes_limit_from(value: Option<&str>) -> usize {
+    value
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES)
+}
 
 fn emit_snapshot_builder_succeeded(
     resolved_snapshot_id: Uuid,
@@ -7416,6 +7432,7 @@ async fn build_frozen_source_datasets(
     Vec<CompiledReleaseSourceDataset>,
     Option<CompiledSourceReferenceProvenance>,
 )> {
+    let source_closure_total_document_bytes = source_closure_total_document_bytes_limit();
     let mut datasets = BTreeMap::<
         (CompiledReleaseSourceDatasetType, Uuid, String),
         CompiledReleaseSourceDataset,
@@ -7520,10 +7537,10 @@ async fn build_frozen_source_datasets(
             .checked_add(serde_json::to_vec(&dataset.document)?.len())
             .ok_or_else(|| anyhow::anyhow!("source closure document bytes overflow"))
     })?;
-    if total_document_bytes > SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES {
+    if total_document_bytes > source_closure_total_document_bytes {
         return Err(SnapshotSourceClosureError::Operator {
             message: format!(
-                "source_closure_document_bytes_exceeded: actual={total_document_bytes} limit={SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES}"
+                "source_closure_document_bytes_exceeded: actual={total_document_bytes} limit={source_closure_total_document_bytes}"
             ),
         }
         .into());
@@ -7718,10 +7735,10 @@ async fn build_frozen_source_datasets(
                                 .ok_or_else(|| {
                                     anyhow::anyhow!("source closure document bytes overflow")
                                 })?;
-                            if total_document_bytes > SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES {
+                            if total_document_bytes > source_closure_total_document_bytes {
                                 return Err(SnapshotSourceClosureError::Operator {
                                     message: format!(
-                                        "source_closure_document_bytes_exceeded: actual={total_document_bytes} limit={SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES}"
+                                        "source_closure_document_bytes_exceeded: actual={total_document_bytes} limit={source_closure_total_document_bytes}"
                                     ),
                                 }
                                 .into());
@@ -9360,26 +9377,27 @@ fn write_provider_rule_replay_report_files(
 mod tests {
     use super::{
         AllocationFallbackState, AllocationFractionState, AllocationMode, Cli,
-        DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS, ExchangeDirection, FlowRow, ImpactFactorSet,
-        LciaExchangeObservation, MethodSelection, MultiProviderDecision, NormalizationMode,
-        ParsedExchange, ProcessMeta, ProcessRow, ProviderRule, ResolvedLciaMethodIdentity,
-        ResolvedLciaMethodRow, SnapshotBuildConfig, SnapshotSelectionMode, SourceDatasetReference,
-        SourceSnapshotSummary, accumulate_finite_factor, add_technosphere_edge,
-        assemble_sparse_payload, attach_artifact_lifecycle, biosphere_gross_value,
-        build_compiled_release_evidence, build_lcia_factor_coverage,
-        build_review_submit_overlay_graph, candidate_count_bucket_label,
-        collect_lcia_factor_flow_references, compute_review_submit_overlay_source_hash,
-        compute_scope_hash, compute_source_fingerprint_from_summary,
-        flow_reference_requests_from_source_references, geo_score, insert_compiled_source_dataset,
-        load_impact_factor_sets, location_granularity_label, no_balancing_reference_failure_reason,
-        normalize_request_roots, parse_number, parse_process_annual_supply_or_production_volume,
-        parse_process_states, parse_provider_rule_list, parse_scope_closure_snapshot_args,
-        resolve_allocation_fraction, resolve_database_lcia_method_row,
-        resolve_database_lcia_method_rows, resolve_lcia_method_source_row,
-        resolve_lcia_support_flows, resolve_multi_provider, resolve_process_selection,
-        resolve_reference_normalization, review_submit_root_dependency_fingerprint,
-        reviewed_lcia_artifact_locator, scope_closure_boundary_policy,
-        scope_closure_candidate_process_axis, snapshot_db_statement_timeout,
+        DEFAULT_SNAPSHOT_DB_STATEMENT_TIMEOUT_SECONDS, DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES,
+        ExchangeDirection, FlowRow, ImpactFactorSet, LciaExchangeObservation, MethodSelection,
+        MultiProviderDecision, NormalizationMode, ParsedExchange, ProcessMeta, ProcessRow,
+        ProviderRule, ResolvedLciaMethodIdentity, ResolvedLciaMethodRow, SnapshotBuildConfig,
+        SnapshotSelectionMode, SourceDatasetReference, SourceSnapshotSummary,
+        accumulate_finite_factor, add_technosphere_edge, assemble_sparse_payload,
+        attach_artifact_lifecycle, biosphere_gross_value, build_compiled_release_evidence,
+        build_lcia_factor_coverage, build_review_submit_overlay_graph,
+        candidate_count_bucket_label, collect_lcia_factor_flow_references,
+        compute_review_submit_overlay_source_hash, compute_scope_hash,
+        compute_source_fingerprint_from_summary, flow_reference_requests_from_source_references,
+        geo_score, insert_compiled_source_dataset, load_impact_factor_sets,
+        location_granularity_label, no_balancing_reference_failure_reason, normalize_request_roots,
+        parse_number, parse_process_annual_supply_or_production_volume, parse_process_states,
+        parse_provider_rule_list, parse_scope_closure_snapshot_args, resolve_allocation_fraction,
+        resolve_database_lcia_method_row, resolve_database_lcia_method_rows,
+        resolve_lcia_method_source_row, resolve_lcia_support_flows, resolve_multi_provider,
+        resolve_process_selection, resolve_reference_normalization,
+        review_submit_root_dependency_fingerprint, reviewed_lcia_artifact_locator,
+        scope_closure_boundary_policy, scope_closure_candidate_process_axis,
+        snapshot_db_statement_timeout, source_closure_total_document_bytes_limit_from,
         source_dataset_document_id, source_reference_is_satisfied_index,
         summarize_matching_diagnostics, time_score, unique_supported_direction_by_flow,
         validate_compiled_sources_against_frozen_manifest, validate_flow_row_visibility,
@@ -9392,6 +9410,33 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
     use std::io::Write;
     use uuid::Uuid;
+
+    #[test]
+    fn source_closure_total_document_bytes_limit_defaults_to_one_gib() {
+        assert_eq!(
+            source_closure_total_document_bytes_limit_from(None),
+            DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES
+        );
+        assert_eq!(
+            DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES,
+            1024 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn source_closure_total_document_bytes_limit_accepts_positive_override_only() {
+        assert_eq!(
+            source_closure_total_document_bytes_limit_from(Some("657356743")),
+            657_356_743
+        );
+        for value in ["0", "-1", "invalid", "999999999999999999999999999999999999"] {
+            assert_eq!(
+                source_closure_total_document_bytes_limit_from(Some(value)),
+                DEFAULT_SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES,
+                "expected default for {value:?}"
+            );
+        }
+    }
 
     use solver_worker::compiled_graph::{
         CompiledAllocationStats, CompiledBiosphereEdge, CompiledFlow, CompiledFlowKind,

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-external-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Worker Issue #193: tidas v0.1.3 evidence preserves the existing bounded memory, result, four-mode identity, and owner-evidence contracts."
 related:
   - ../../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Worker Issue #193: the tidas v0.1.3 default does not change Worker, provider, or root-integration ownership boundaries."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Worker Issue #193: existing runtime, release-binary, scope-closure, and docpact proof requirements apply to tidas v0.1.3."
 related:
   - ../../AGENTS.md

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -24,8 +24,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 833808c
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
 related:
   - AGENTS.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -24,8 +24,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 833808c
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
 related:
   - AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: e5a7f769f4716266271eea53cb5233781635174f
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Reviewed for Worker Issue #193: the exact tidas v0.1.3 default does not change public Worker, Edge, or Next DTOs."
 related:
   - AGENTS.md

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 833808c
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Issue #146 adds selected LCIA-factor Flow source-closure policy to build identity; readiness schema and blocker semantics are unchanged."
 related:
   - AGENTS.md

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -22,8 +22,8 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 833808c
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
 lastReviewedNote: "Issue #146 separates selected LCIA-factor Flow source evidence from the inventory-derived matrix and provider Flow universe."
 related:
   - AGENTS.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -172,7 +172,10 @@ The numerical snapshot source walk is `path-aware-bounded-frontier-v2`. It consu
 reference edges produced by `scope_closure.rs`, but applies a separate role × artifact-purpose
 policy. Each exact document identity/hash is processed once; exact and omitted-version indexes make
 satisfaction checks deterministic; support reads use fixed 512-identity batches with a 64 MiB
-returned-byte ceiling, and the build enforces cumulative document/reference/edge/depth limits.
+returned-byte ceiling. The cumulative canonical source-document ceiling is configured by
+`SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES` and defaults to 1 GiB; zero, malformed, and overflow
+values fail back to that bounded default. The build separately enforces cumulative
+document/reference/edge/depth limits.
 Identity/hash drift and limit overflow are operator errors. Metrics expose source document count,
 classified reference count, frontier rounds, support query count, and decoded document bytes.
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,8 +19,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 126d0be9140ea2218a0181210c55e4dead8471b5
-lastReviewedAt: 2026-08-04
+lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
+lastReviewedAt: 2026-08-05
 lastReviewedNote: "Reviewed for rollback Issue #211 after Issue #212: removing the incremental schema qualification route does not change reusable state-code 100-200 import behavior, open-data export scope, or the package report schema."
 related:
   - AGENTS.md


### PR DESCRIPTION
Closes #215

## Summary
- Raise the default cumulative source-closure document budget from 512 MiB to 1 GiB.
- Allow an explicit SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES override while falling back to the safe default for malformed, zero, or overflow input.

## Key Decisions
- Keep the independent 64 MiB support-batch ceiling and all reference, edge, and depth guards unchanged.

## Validation
- cargo test -p solver-worker --bin snapshot_builder source_closure_total_document_bytes_limit -- --nocapture
- make check and strict Docpact lint passed locally and in the pre-push gate.

## Risks / Rollback
- Higher admission permits up to 1 GiB of cumulative canonical source documents; it remains bounded below the production 4 GiB closure RSS budget.
- Rollback: redeploy the preceding Worker revision or set a lower positive SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES.

## Follow-ups
- The three production servers are already hot-patched at 1 GiB and their two solver instances are active; deploy this merged revision to make the change durable.

## Workspace Integration
- After merge, update the root workspace Worker submodule pointer through the normal integration workflow.