### PR TITLE
fix: ignore external digital file URI blockers

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-05"
-lastReviewedCommit: "9a44912cf81641f4269221bf97d7d1f7a51f7cd8"
-lastReviewedNote: "Reviewed for Worker Issue #193: existing routing and ownership cover the exact tidas v0.1.3 runtime-default rollout."
+lastReviewedCommit: "f32cc8463b3ed2ed15d3046400ad981d7673477e"
+lastReviewedNote: "Reviewed for Worker Issue #217: existing scope-closure routing and ownership cover the numerical source-reference policy correction."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Worker Issue #193: the exact tidas v0.1.3 runtime default changes without altering Worker orchestration or provider ownership."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling remains Worker-owned and does not alter orchestration or provider ownership."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -9657,11 +9657,14 @@ mod tests {
         config.source_reference_policy = "source-reference-policy.v2".to_owned();
         let v2_snapshot_hash = compute_source_fingerprint_from_summary(&summary, &config)
             .expect("v2 source-reference fingerprint");
-        assert_ne!(snapshot_hash, v2_snapshot_hash);
+        config.source_reference_policy = "source-reference-policy.v3".to_owned();
+        let v3_snapshot_hash = compute_source_fingerprint_from_summary(&summary, &config)
+            .expect("v3 source-reference fingerprint");
+        assert_ne!(v2_snapshot_hash, v3_snapshot_hash);
         assert_eq!(
-            v2_snapshot_hash,
+            v3_snapshot_hash,
             compute_source_fingerprint_from_summary(&summary, &config)
-                .expect("stable v2 source-reference fingerprint")
+                .expect("stable v3 source-reference fingerprint")
         );
     }
 

--- a/crates/solver-worker/src/snapshot_source_closure.rs
+++ b/crates/solver-worker/src/snapshot_source_closure.rs
@@ -103,6 +103,11 @@ pub fn classify_source_document(
         .issues
         .into_iter()
         .filter_map(|issue| {
+            if purpose != ArtifactPurpose::CertificateClosure
+                && is_external_digital_file_path(issue.json_path.as_str())
+            {
+                return None;
+            }
             let role = classify_malformed_reference_role(
                 issue.source_category.as_str(),
                 issue.json_path.as_str(),
@@ -155,6 +160,12 @@ pub fn classify_source_document(
         references,
         extraction_issues,
     })
+}
+
+fn is_external_digital_file_path(json_path: &str) -> bool {
+    json_path
+        .to_ascii_lowercase()
+        .ends_with("referencetodigitalfile")
 }
 
 pub fn validate_resource_limits(
@@ -427,5 +438,46 @@ mod tests {
             required.extraction_issues[0]["referenceRole"],
             "exchange_flow"
         );
+    }
+
+    #[test]
+    fn external_digital_file_uri_does_not_block_numeric_source_closure() {
+        let document = json!({
+            "sourceDataSet": {
+                "sourceInformation": {
+                    "dataSetInformation": {
+                        "referenceToDigitalFile": {
+                            "@uri": "http://lca.jrc.ec.europa.eu"
+                        }
+                    }
+                }
+            }
+        });
+
+        for purpose in [
+            ArtifactPurpose::ReviewSubmit,
+            ArtifactPurpose::CalculationBundle,
+        ] {
+            let classified = classify_source_document(
+                &source(CompiledReleaseSourceDatasetType::Source, document.clone()),
+                purpose,
+            )
+            .unwrap();
+            assert!(classified.references.is_empty());
+            assert!(classified.extraction_issues.is_empty());
+        }
+
+        let certificate = classify_source_document(
+            &source(CompiledReleaseSourceDatasetType::Source, document),
+            ArtifactPurpose::CertificateClosure,
+        )
+        .unwrap();
+        assert!(certificate.references.is_empty());
+        assert_eq!(certificate.extraction_issues.len(), 2);
+        assert!(certificate.extraction_issues.iter().all(|issue| {
+            issue["jsonPath"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("referenceToDigitalFile"))
+        }));
     }
 }

--- a/crates/solver-worker/src/source_reference_policy.rs
+++ b/crates/solver-worker/src/source_reference_policy.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::scope_closure::ReferenceEdge;
 
-pub const SOURCE_REFERENCE_POLICY_VERSION: &str = "source-reference-policy.v2";
+pub const SOURCE_REFERENCE_POLICY_VERSION: &str = "source-reference-policy.v3";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,8 +28,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Worker Issue #193: tidas v0.1.3 evidence preserves the existing bounded memory, result, four-mode identity, and owner-evidence contracts."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: the numerical source-reference policy correction does not change bounded memory, result, or owner-evidence contracts."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Worker Issue #193: the tidas v0.1.3 default does not change Worker, provider, or root-integration ownership boundaries."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: the source-reference classifier correction stays within existing Worker and root-integration boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Worker Issue #193: existing runtime, release-binary, scope-closure, and docpact proof requirements apply to tidas v0.1.3."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: existing runtime, focused source-closure, and docpact proof requirements cover the policy correction."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -25,8 +25,8 @@ checkPaths:
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change signed-flow routing or provider selection."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -25,8 +25,8 @@ checkPaths:
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Issue #146: LCIA-factor source support is separate from implicit signed-flow routing and provider selection."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change signed-flow routing or provider selection."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Reviewed for Worker Issue #193: the exact tidas v0.1.3 default does not change public Worker, Edge, or Next DTOs."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Updated for Worker Issue #217: source-reference policy v3 excludes external digital-file URI findings from numerical blockers without changing public DTOs."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -287,7 +287,7 @@ evidence/coverage.json
 - process axis 固化 Process UUID/version 和唯一 quantitative reference 的 exchange internal ID、Flow UUID/version、reference unit、raw direction/amount/coefficient 与 signed normalized pivot；inventory axis逐 exchange 保存 raw/signed/normalized coefficient、allocation target 与 selected fraction。Snapshot flow axis 使用 `(Flow UUID, resolved version)`；同一 UUID 的多个实际引用 revision 可共存并获得独立连续 `flow_idx`，未被最终 process closure exchange 引用的 revision 不进入矩阵。Selected LCIA-factor-only Elementary Flow 不获得 `flow_idx`，但会作为 source-closure `support` 文档进入 bundle。
 - 普通 fresh snapshot 与 review-submit overlay snapshot 都必须把 `compiled_graph.release_evidence` 及 `source_datasets` 写入 snapshot artifact。source closure 从本次 snapshot 精确选择的 Process/inventory Flow revision 和已审 LCIA Method identity 出发；另外一次扫描 selected Method 的全部 factor Flow reference（包括 zero factor），按 UUID/version 去重后 bounded-batch 解析为 Elementary Flow support root，再递归解析 Contact、Flow Property、Source、Unit Group 与 LCIA Method reference。显式版本只允许 exact match，省略的 support version 只确定一次并冻结，缺失、歧义、无效 UUID/version、非 Elementary factor target 或同 identity/version 内容漂移均 fail closed。这个 source-evidence 扩展不改变 B/C axis、compiled graph 或 provider lookup；support documents 不在 solve 时重新查询。
 - numerical source closure 复用 `scope_closure.rs` raw extractor，并通过
-  `source-reference-policy.v2` 决定 artifact-purpose action。lineage / model-composition 只进入
+  `source-reference-policy.v3` 决定 artifact-purpose action。lineage / model-composition 只进入
   additive `release_evidence.source_reference_provenance` 的 count/hash/bounded sample，不 probe
   target，也不改变 Process/Flow axis、A/B/C、sparse payload 或 Calculation Bundle 的 unit-process
   source validator。unknown Flow/Process path 是 operator error。
@@ -313,7 +313,7 @@ Snapshot 的 Process 身份契约是：一个完整 TIDAS Process revision 只�
 
 Snapshot build 对 exchange allocation 使用 target-aware 语义：object/array 都按 `@internalReferenceToCoProduct` 匹配当前 quantitative reference，TIDAS `Perc` 统一除以 `100`；闭合 allocation vector 中缺少当前 target 表示稀疏零，完全未声明 allocation 表示 fraction `1`。Legacy compatibility 只允许两个有界 fallback：scalar `{}` 按 undeclared 处理；单个 targetless full allocation 仅在 reference exchange 和 internal ID 唯一时推断。方向不参与 target validity；multiple-entry targetless、多个 quantitative reference、坏 ID 或其他无效声明均 fail closed。Reference pivot 本身不乘 allocation fraction。
 
-Build config 记录 `allocation_semantics_version = tidas-reference-allocation-v3`、`link_semantics_version = signed-flow-balance-v1`、`technosphere_boundary_policy`、`flow_identity_policy = exact-flow-version-reference-unit-v2`、`source_closure_policy = path-aware-bounded-frontier-v2` 与 `source_reference_policy = source-reference-policy.v2`；所有字段进入 source/review fingerprint，solver contract 也显式记录两项 source policy。Flow identity v2 只查询和编译最终 process closure exchange 实际引用的 exact Flow identities；source-closure v2 只为 selected LCIA-factor-only Elementary Flow 增加 support evidence，不扩大稀疏矩阵轴。legacy artifact 仍可反序列化，但 `legacy-unclassified-v1` 不可作为 v2 reuse candidate；相同 v2 输入的 hash/reuse 必须稳定。
+Build config 记录 `allocation_semantics_version = tidas-reference-allocation-v3`、`link_semantics_version = signed-flow-balance-v1`、`technosphere_boundary_policy`、`flow_identity_policy = exact-flow-version-reference-unit-v2`、`source_closure_policy = path-aware-bounded-frontier-v2` 与 `source_reference_policy = source-reference-policy.v3`；所有字段进入 source/review fingerprint，solver contract 也显式记录两项 source policy。Flow identity v2 只查询和编译最终 process closure exchange 实际引用的 exact Flow identities；source-closure v2 只为 selected LCIA-factor-only Elementary Flow 增加 support evidence，不扩大稀疏矩阵轴。`referenceToDigitalFile` 只是外部附件 URI，在 review-submit 和普通 Calculation Bundle 中不作为数据集引用校验。legacy artifact 仍可反序列化，但非 v3 policy artifact 不可作为 v3 reuse candidate；相同 v3 输入的 hash/reuse 必须稳定。
 
 显式零或稀疏零 allocation 得到的 Input 不展开 provider closure、不产生 provider-gap diagnostics，也不写入 `A`；零 attributed elementary exchange 也不写入 `B`，不参与 LCIA direction 与 factor-coverage evidence。它只表示该 exchange 对当前 quantitative reference 没有 attributed burden。
 

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Issue #146 adds selected LCIA-factor Flow source-closure policy to build identity; readiness schema and blocker semantics are unchanged."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: source-reference policy v3 changes build identity without changing readiness schema or blocker semantics."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -23,8 +23,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
-lastReviewedNote: "Issue #146 separates selected LCIA-factor Flow source evidence from the inventory-derived matrix and provider Flow universe."
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change the provider Flow universe or linking decisions."
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md

--- a/docs/review-submit-fast-gate-contract.md
+++ b/docs/review-submit-fast-gate-contract.md
@@ -29,9 +29,9 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 7dbb9ced5ce00cec24c62334ca75cb12dbf18df8
-lastReviewedNote: "Removed lifecycle state blocking from the worker-owned numerical gate for Issue #133; lifecycle eligibility remains a consumer/coordinator responsibility."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Updated for Worker Issue #217: source-reference policy v3 treats referenceToDigitalFile as a non-dataset URI for review-submit."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -148,7 +148,7 @@ DB runner 默认通过 snapshot_builder 的 no-LCIA baseline + draft overlay fas
 no-LCIA fast path 的 source fingerprint 不包含 `lciamethods` count / max_modified_at，因此 LCIA method 或 factor 变化不会打断 review-submit submit-readiness snapshot 复用。baseline source hash 只绑定依赖数据与 root dependency surface；draft root 的完整内容通过权威 `json_ordered` checksum 进入 overlay source hash，所以金额等 draft 内容变化会重建 overlay，但不必重建依赖 baseline。
 
 Source reference preflight 使用 `scope_closure.rs` 的公共 raw extractor，再由
-`source-reference-policy.v2` 做 role classification 和 artifact-purpose action。Process 数值轴只来自
+`source-reference-policy.v3` 做 role classification 和 artifact-purpose action。Process 数值轴只来自
 request root 与 provider graph invariant，不从任意 document Process reference 推断。
 `referenceToPrecedingDataSetVersion` 等 lineage reference 与
 `referenceToIncludedProcesses` 等 model-composition reference 在 review-submit / 普通 bundle 中只形成
@@ -156,7 +156,8 @@ count、SHA-256 和 bounded sample evidence；它们不 fetch/probe target、不
 exchange Flow 与 provider Process 的 exact identity 仍 fail closed；未知 Flow/Process path 是 operator
 error。role/provenance 字符串固定为 snake_case（例如 `model_composition`、`required_support`）。
 确定性的必需 source 缺失使用稳定 `source_dependency_unavailable` blocker；必需 numerical/support
-reference 的 malformed UUID/version 使用稳定 `source_reference_invalid`。Lineage/ModelComposition
+reference 的 malformed UUID/version 使用稳定 `source_reference_invalid`。`referenceToDigitalFile`
+是外部附件 URI，不作为数据集 reference 阻断 review-submit。Lineage/ModelComposition
 的 malformed target 在数值 artifact 中仍只记录 evidence，不触发 target lookup。
 
 Snapshot builder 子进程输出 exactly-one `snapshot_builder_terminal.v1` terminal frame，状态只为

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -31,9 +31,9 @@ checkPaths:
   - scripts/scope_closure_qualification.py
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: e67971ff8624fe543f10d93abe88c11bf5e1a396
-lastReviewedNote: "Updated for Worker Issue #186: git-tracked external and isolated-provider executables emit the exact root qualification child contracts and fail closed on identity, payload, target, or cleanup drift."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedNote: "Updated for Worker Issue #217: numerical source-reference policy v3 ignores external digital-file URI findings while certificate traversal stays strict."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -183,6 +183,10 @@ This numerical frontier does not replace certificate-grade administrative traver
 review-submit and ordinary Calculation Bundles, lineage and model-composition edges are evidence
 only and never probe their target. Certificate closure continues its full, non-fail-fast union
 traversal and issue aggregation under this document's frozen-release rules.
+Schema-defined `referenceToDigitalFile` URI values are external attachment locators rather than
+dataset references. The numerical source walk ignores their raw extraction findings for
+review-submit and ordinary Calculation Bundles; certificate-grade administrative traversal keeps
+its existing strict extraction and issue-aggregation behavior.
 
 Each fresh scan produces deterministic administrative artifacts:
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 9a44912cf81641f4269221bf97d7d1f7a51f7cd8
+lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
 lastReviewedAt: 2026-08-05
-lastReviewedNote: "Reviewed for rollback Issue #211 after Issue #212: removing the incremental schema qualification route does not change reusable state-code 100-200 import behavior, open-data export scope, or the package report schema."
+lastReviewedNote: "Reviewed for Worker Issue #217: the numerical source-reference policy correction does not change package import, export, or certificate binding."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#217

## Summary
- Prevent schema-defined referenceToDigitalFile URI fields from becoming source_reference_invalid blockers in review-submit and ordinary Calculation Bundle snapshot builds.
- Bump source-reference policy identity to v3 so older artifacts are not reused under the corrected semantics.

## Key Decisions
- Keep the shared raw/certificate-grade extractor strict; suppress only referenceToDigitalFile extraction findings in numerical source closure.
- Preserve fail-closed UUID, version, exchange-axis, provider, and required-support validation for actual dataset references.

## Validation
- cargo test -p solver-worker snapshot_source_closure --lib
- cargo test -p solver-worker --bin snapshot_builder
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- make check
- docpact validate-config --strict and enforced worktree/commit lint

## Risks / Rollback
- Low and path-scoped: only referenceToDigitalFile findings are downgraded for numerical artifacts; certificate-grade traversal remains strict.

## Follow-ups
- After merge, deploy the merged Worker main commit and update the workspace submodule pointer when the release is integrated.

## Workspace Integration
- Workspace Integration Pending after merge.