### PR TITLE
fix: bound source support reads by bytes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-05"
-lastReviewedCommit: "f32cc8463b3ed2ed15d3046400ad981d7673477e"
-lastReviewedNote: "Reviewed for Worker Issue #217: existing scope-closure routing and ownership cover the numerical source-reference policy correction."
+lastReviewedCommit: "c9a16ab2b166b01e4d407b3b16f88dbde357d000"
+lastReviewedNote: "Reviewed for Worker Issue #219: existing routing and ownership cover bounded numerical source-support read planning."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling remains Worker-owned and does not alter orchestration or provider ownership."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: bounded numerical source-support reads remain Worker-owned and do not alter orchestration or provider ownership."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -317,6 +317,13 @@ struct MethodRow {
     json: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SourceDatasetReadIdentity {
+    id: Uuid,
+    version: String,
+    estimated_bytes: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolvedLciaMethodIdentity {
     method_id: Uuid,
@@ -7319,6 +7326,186 @@ fn source_dataset_query(
     }
 }
 
+fn source_dataset_metadata_query(
+    dataset_type: CompiledReleaseSourceDatasetType,
+) -> anyhow::Result<&'static str> {
+    match dataset_type {
+        CompiledReleaseSourceDatasetType::Contact => Ok(
+            "SELECT id, btrim(version::text) AS version, octet_length(COALESCE(json, json_ordered::jsonb)::text)::bigint AS document_bytes FROM public.contacts WHERE id = ANY($1) ORDER BY id, version",
+        ),
+        CompiledReleaseSourceDatasetType::FlowProperty => Ok(
+            "SELECT id, btrim(version::text) AS version, octet_length(COALESCE(json, json_ordered::jsonb)::text)::bigint AS document_bytes FROM public.flowproperties WHERE id = ANY($1) ORDER BY id, version",
+        ),
+        CompiledReleaseSourceDatasetType::LciaMethod => Ok(
+            "SELECT id, btrim(version::text) AS version, octet_length(COALESCE(json, json_ordered::jsonb)::text)::bigint AS document_bytes FROM public.lciamethods WHERE id = ANY($1) ORDER BY id, version",
+        ),
+        CompiledReleaseSourceDatasetType::Source => Ok(
+            "SELECT id, btrim(version::text) AS version, octet_length(COALESCE(json, json_ordered::jsonb)::text)::bigint AS document_bytes FROM public.sources WHERE id = ANY($1) ORDER BY id, version",
+        ),
+        CompiledReleaseSourceDatasetType::UnitGroup => Ok(
+            "SELECT id, btrim(version::text) AS version, octet_length(COALESCE(json, json_ordered::jsonb)::text)::bigint AS document_bytes FROM public.unitgroups WHERE id = ANY($1) ORDER BY id, version",
+        ),
+        CompiledReleaseSourceDatasetType::Flow | CompiledReleaseSourceDatasetType::Process => {
+            Err(anyhow::anyhow!(
+                "{} closure rows must come from the exact snapshot selection",
+                dataset_type.as_str()
+            ))
+        }
+    }
+}
+
+fn source_dataset_exact_query(
+    dataset_type: CompiledReleaseSourceDatasetType,
+) -> anyhow::Result<&'static str> {
+    match dataset_type {
+        CompiledReleaseSourceDatasetType::Contact => Ok(
+            "WITH requested(id, version) AS (SELECT * FROM unnest($1::uuid[], $2::text[])) SELECT dataset.id, btrim(dataset.version::text) AS version, COALESCE(dataset.json, dataset.json_ordered::jsonb) AS json FROM public.contacts AS dataset JOIN requested ON requested.id = dataset.id AND requested.version = btrim(dataset.version::text) ORDER BY dataset.id, btrim(dataset.version::text)",
+        ),
+        CompiledReleaseSourceDatasetType::FlowProperty => Ok(
+            "WITH requested(id, version) AS (SELECT * FROM unnest($1::uuid[], $2::text[])) SELECT dataset.id, btrim(dataset.version::text) AS version, COALESCE(dataset.json, dataset.json_ordered::jsonb) AS json FROM public.flowproperties AS dataset JOIN requested ON requested.id = dataset.id AND requested.version = btrim(dataset.version::text) ORDER BY dataset.id, btrim(dataset.version::text)",
+        ),
+        CompiledReleaseSourceDatasetType::LciaMethod => Ok(
+            "WITH requested(id, version) AS (SELECT * FROM unnest($1::uuid[], $2::text[])) SELECT dataset.id, btrim(dataset.version::text) AS version, COALESCE(dataset.json, dataset.json_ordered::jsonb) AS json FROM public.lciamethods AS dataset JOIN requested ON requested.id = dataset.id AND requested.version = btrim(dataset.version::text) ORDER BY dataset.id, btrim(dataset.version::text)",
+        ),
+        CompiledReleaseSourceDatasetType::Source => Ok(
+            "WITH requested(id, version) AS (SELECT * FROM unnest($1::uuid[], $2::text[])) SELECT dataset.id, btrim(dataset.version::text) AS version, COALESCE(dataset.json, dataset.json_ordered::jsonb) AS json FROM public.sources AS dataset JOIN requested ON requested.id = dataset.id AND requested.version = btrim(dataset.version::text) ORDER BY dataset.id, btrim(dataset.version::text)",
+        ),
+        CompiledReleaseSourceDatasetType::UnitGroup => Ok(
+            "WITH requested(id, version) AS (SELECT * FROM unnest($1::uuid[], $2::text[])) SELECT dataset.id, btrim(dataset.version::text) AS version, COALESCE(dataset.json, dataset.json_ordered::jsonb) AS json FROM public.unitgroups AS dataset JOIN requested ON requested.id = dataset.id AND requested.version = btrim(dataset.version::text) ORDER BY dataset.id, btrim(dataset.version::text)",
+        ),
+        CompiledReleaseSourceDatasetType::Flow | CompiledReleaseSourceDatasetType::Process => {
+            Err(anyhow::anyhow!(
+                "{} closure rows must come from the exact snapshot selection",
+                dataset_type.as_str()
+            ))
+        }
+    }
+}
+
+async fn fetch_source_dataset_metadata(
+    pool: &PgPool,
+    dataset_type: CompiledReleaseSourceDatasetType,
+    ids: &[Uuid],
+) -> anyhow::Result<Vec<SourceDatasetReadIdentity>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = sqlx::query(source_dataset_metadata_query(dataset_type)?)
+        .bind(ids)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter()
+        .map(|row| {
+            let document_bytes = row.try_get::<i64, _>("document_bytes")?;
+            Ok(SourceDatasetReadIdentity {
+                id: row.try_get("id")?,
+                version: row.try_get::<String, _>("version")?.trim().to_owned(),
+                estimated_bytes: usize::try_from(document_bytes).map_err(|_| {
+                    anyhow::anyhow!("source support document bytes are invalid: {document_bytes}")
+                })?,
+            })
+        })
+        .collect()
+}
+
+async fn fetch_exact_source_dataset_rows(
+    pool: &PgPool,
+    dataset_type: CompiledReleaseSourceDatasetType,
+    identities: &[SourceDatasetReadIdentity],
+) -> anyhow::Result<Vec<MethodRow>> {
+    if identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids = identities
+        .iter()
+        .map(|identity| identity.id)
+        .collect::<Vec<_>>();
+    let versions = identities
+        .iter()
+        .map(|identity| identity.version.clone())
+        .collect::<Vec<_>>();
+    let rows = sqlx::query(source_dataset_exact_query(dataset_type)?)
+        .bind(ids)
+        .bind(versions)
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(MethodRow {
+                id: row.try_get("id")?,
+                version: row.try_get::<String, _>("version")?.trim().to_owned(),
+                json: row.try_get("json")?,
+            })
+        })
+        .collect()
+}
+
+fn select_source_dataset_read_identities(
+    references: &[&ClassifiedSourceReference],
+    metadata: &[SourceDatasetReadIdentity],
+) -> Vec<SourceDatasetReadIdentity> {
+    let mut selected = BTreeSet::new();
+    for reference in references {
+        let Ok(target_id) = Uuid::parse_str(reference.target_uuid.as_str()) else {
+            continue;
+        };
+        let mut candidates = metadata
+            .iter()
+            .filter(|candidate| {
+                candidate.id == target_id
+                    && reference
+                        .requested_version
+                        .as_ref()
+                        .is_none_or(|version| candidate.version == *version)
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| right.version.cmp(&left.version));
+        if let Some(candidate) = candidates.first() {
+            selected.insert((*candidate).clone());
+        }
+    }
+    selected.into_iter().collect()
+}
+
+fn plan_source_support_read_batches(
+    identities: &[SourceDatasetReadIdentity],
+    max_count: usize,
+    max_bytes: usize,
+) -> Result<Vec<Vec<SourceDatasetReadIdentity>>, SnapshotSourceClosureError> {
+    let mut batches = Vec::new();
+    let mut batch = Vec::new();
+    let mut batch_bytes = 0_usize;
+    for identity in identities {
+        if identity.estimated_bytes > max_bytes {
+            return Err(SnapshotSourceClosureError::Operator {
+                message: format!(
+                    "source_support_document_bytes_exceeded: id={} version={} actual={} limit={max_bytes}",
+                    identity.id, identity.version, identity.estimated_bytes
+                ),
+            });
+        }
+        let next_bytes = batch_bytes
+            .checked_add(identity.estimated_bytes)
+            .ok_or_else(|| SnapshotSourceClosureError::Operator {
+                message: "source support batch bytes overflow".to_owned(),
+            })?;
+        if !batch.is_empty() && (batch.len() >= max_count || next_bytes > max_bytes) {
+            batches.push(std::mem::take(&mut batch));
+            batch_bytes = 0;
+        }
+        batch_bytes = batch_bytes
+            .checked_add(identity.estimated_bytes)
+            .ok_or_else(|| SnapshotSourceClosureError::Operator {
+                message: "source support batch bytes overflow".to_owned(),
+            })?;
+        batch.push(identity.clone());
+    }
+    if !batch.is_empty() {
+        batches.push(batch);
+    }
+    Ok(batches)
+}
+
 async fn fetch_source_dataset_rows(
     pool: &PgPool,
     dataset_type: CompiledReleaseSourceDatasetType,
@@ -7688,10 +7875,23 @@ async fn build_frozen_source_datasets(
             if ids.is_empty() {
                 continue;
             }
-            let mut rows = Vec::new();
+            let mut metadata = Vec::new();
             for chunk in ids.chunks(SOURCE_CLOSURE_SUPPORT_QUERY_BATCH_SIZE) {
                 support_query_count += 1;
-                let batch_rows = fetch_source_dataset_rows(pool, dataset_type, chunk).await?;
+                metadata.extend(fetch_source_dataset_metadata(pool, dataset_type, chunk).await?);
+            }
+            let selected_identities =
+                select_source_dataset_read_identities(&type_references, &metadata);
+            let read_batches = plan_source_support_read_batches(
+                &selected_identities,
+                SOURCE_CLOSURE_SUPPORT_QUERY_BATCH_SIZE,
+                SOURCE_CLOSURE_SUPPORT_BATCH_MAX_BYTES,
+            )?;
+            let mut rows = Vec::new();
+            for batch in read_batches {
+                support_query_count += 1;
+                let batch_rows =
+                    fetch_exact_source_dataset_rows(pool, dataset_type, &batch).await?;
                 let batch_bytes = batch_rows.iter().try_fold(0_usize, |total, row| {
                     total
                         .checked_add(serde_json::to_vec(&row.json)?.len())
@@ -7700,7 +7900,7 @@ async fn build_frozen_source_datasets(
                 if batch_bytes > SOURCE_CLOSURE_SUPPORT_BATCH_MAX_BYTES {
                     return Err(SnapshotSourceClosureError::Operator {
                         message: format!(
-                            "source_support_batch_bytes_exceeded: actual={batch_bytes} limit={SOURCE_CLOSURE_SUPPORT_BATCH_MAX_BYTES}"
+                            "source_support_batch_estimate_drift: actual={batch_bytes} limit={SOURCE_CLOSURE_SUPPORT_BATCH_MAX_BYTES}"
                         ),
                     }
                     .into());
@@ -9381,28 +9581,29 @@ mod tests {
         ExchangeDirection, FlowRow, ImpactFactorSet, LciaExchangeObservation, MethodSelection,
         MultiProviderDecision, NormalizationMode, ParsedExchange, ProcessMeta, ProcessRow,
         ProviderRule, ResolvedLciaMethodIdentity, ResolvedLciaMethodRow, SnapshotBuildConfig,
-        SnapshotSelectionMode, SourceDatasetReference, SourceSnapshotSummary,
-        accumulate_finite_factor, add_technosphere_edge, assemble_sparse_payload,
-        attach_artifact_lifecycle, biosphere_gross_value, build_compiled_release_evidence,
-        build_lcia_factor_coverage, build_review_submit_overlay_graph,
-        candidate_count_bucket_label, collect_lcia_factor_flow_references,
-        compute_review_submit_overlay_source_hash, compute_scope_hash,
-        compute_source_fingerprint_from_summary, flow_reference_requests_from_source_references,
-        geo_score, insert_compiled_source_dataset, load_impact_factor_sets,
-        location_granularity_label, no_balancing_reference_failure_reason, normalize_request_roots,
-        parse_number, parse_process_annual_supply_or_production_volume, parse_process_states,
-        parse_provider_rule_list, parse_scope_closure_snapshot_args, resolve_allocation_fraction,
+        SnapshotSelectionMode, SourceDatasetReadIdentity, SourceDatasetReference,
+        SourceSnapshotSummary, accumulate_finite_factor, add_technosphere_edge,
+        assemble_sparse_payload, attach_artifact_lifecycle, biosphere_gross_value,
+        build_compiled_release_evidence, build_lcia_factor_coverage,
+        build_review_submit_overlay_graph, candidate_count_bucket_label,
+        collect_lcia_factor_flow_references, compute_review_submit_overlay_source_hash,
+        compute_scope_hash, compute_source_fingerprint_from_summary,
+        flow_reference_requests_from_source_references, geo_score, insert_compiled_source_dataset,
+        load_impact_factor_sets, location_granularity_label, no_balancing_reference_failure_reason,
+        normalize_request_roots, parse_number, parse_process_annual_supply_or_production_volume,
+        parse_process_states, parse_provider_rule_list, parse_scope_closure_snapshot_args,
+        plan_source_support_read_batches, resolve_allocation_fraction,
         resolve_database_lcia_method_row, resolve_database_lcia_method_rows,
         resolve_lcia_method_source_row, resolve_lcia_support_flows, resolve_multi_provider,
         resolve_process_selection, resolve_reference_normalization,
         review_submit_root_dependency_fingerprint, reviewed_lcia_artifact_locator,
         scope_closure_boundary_policy, scope_closure_candidate_process_axis,
-        snapshot_db_statement_timeout, source_closure_total_document_bytes_limit_from,
-        source_dataset_document_id, source_reference_is_satisfied_index,
-        summarize_matching_diagnostics, time_score, unique_supported_direction_by_flow,
-        validate_compiled_sources_against_frozen_manifest, validate_flow_row_visibility,
-        validate_process_row_visibility, validate_quantitative_references,
-        validate_unique_database_lcia_method_identities,
+        select_source_dataset_read_identities, snapshot_db_statement_timeout,
+        source_closure_total_document_bytes_limit_from, source_dataset_document_id,
+        source_reference_is_satisfied_index, summarize_matching_diagnostics, time_score,
+        unique_supported_direction_by_flow, validate_compiled_sources_against_frozen_manifest,
+        validate_flow_row_visibility, validate_process_row_visibility,
+        validate_quantitative_references, validate_unique_database_lcia_method_identities,
     };
     use chrono::Utc;
     use clap::Parser;
@@ -9436,6 +9637,90 @@ mod tests {
                 "expected default for {value:?}"
             );
         }
+    }
+
+    #[test]
+    fn source_support_reads_are_packed_by_count_and_estimated_bytes() {
+        let identities = [40_usize, 30, 20, 10]
+            .into_iter()
+            .enumerate()
+            .map(|(index, estimated_bytes)| SourceDatasetReadIdentity {
+                id: Uuid::from_u128(u128::try_from(index + 1).expect("small fixture ordinal")),
+                version: "01.00.000".to_owned(),
+                estimated_bytes,
+            })
+            .collect::<Vec<_>>();
+
+        let batches = plan_source_support_read_batches(&identities, 2, 64)
+            .expect("valid support documents should be packed into bounded exact reads");
+        assert_eq!(
+            batches
+                .iter()
+                .map(|batch| {
+                    (
+                        batch.len(),
+                        batch.iter().map(|item| item.estimated_bytes).sum::<usize>(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(1, 40), (2, 50), (1, 10)]
+        );
+        assert_eq!(
+            batches.into_iter().flatten().collect::<Vec<_>>(),
+            identities,
+            "packing must preserve deterministic identity order"
+        );
+    }
+
+    #[test]
+    fn source_support_read_rejects_one_irreducibly_large_document() {
+        let identity = SourceDatasetReadIdentity {
+            id: Uuid::new_v4(),
+            version: "01.00.000".to_owned(),
+            estimated_bytes: 65,
+        };
+
+        let error = plan_source_support_read_batches(&[identity], 512, 64)
+            .expect_err("one document above the read ceiling must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("source_support_document_bytes_exceeded")
+        );
+    }
+
+    #[test]
+    fn source_support_read_selection_freezes_omitted_and_exact_versions() {
+        use solver_worker::snapshot_source_closure::ClassifiedSourceReference;
+        use solver_worker::source_reference_policy::{SourceReferenceAction, SourceReferenceRole};
+
+        let source_id = Uuid::new_v4();
+        let metadata = vec![
+            SourceDatasetReadIdentity {
+                id: source_id,
+                version: "01.00.000".to_owned(),
+                estimated_bytes: 10,
+            },
+            SourceDatasetReadIdentity {
+                id: source_id,
+                version: "02.00.000".to_owned(),
+                estimated_bytes: 20,
+            },
+        ];
+        let reference = |version: Option<&str>| ClassifiedSourceReference {
+            source_identity: "process:test@01.00.000".to_owned(),
+            target_type: CompiledReleaseSourceDatasetType::Source,
+            target_uuid: source_id.to_string(),
+            requested_version: version.map(ToOwned::to_owned),
+            json_path: "$.referenceToDataSource".to_owned(),
+            role: SourceReferenceRole::RequiredSupport,
+            action: SourceReferenceAction::FetchRequiredSupport,
+        };
+        let references = [reference(None), reference(Some("01.00.000"))];
+        let reference_views = references.iter().collect::<Vec<_>>();
+
+        let selected = select_source_dataset_read_identities(&reference_views, &metadata);
+        assert_eq!(selected, metadata);
     }
 
     use solver_worker::compiled_graph::{

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,8 +28,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: the numerical source-reference policy correction does not change bounded memory, result, or owner-evidence contracts."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: byte-planned numerical source-support reads preserve the bounded memory, result, and owner-evidence contracts."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: the source-reference classifier correction stays within existing Worker and root-integration boundaries."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: source-support read planning stays within existing Worker and root-integration boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: existing runtime, focused source-closure, and docpact proof requirements cover the policy correction."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: existing runtime, focused source-closure, and docpact proof requirements cover bounded source-support reads."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -25,8 +25,8 @@ checkPaths:
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change signed-flow routing or provider selection."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: source-support read batching does not change signed-flow routing or provider selection."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -25,8 +25,8 @@ checkPaths:
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change signed-flow routing or provider selection."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: source-support read batching does not change signed-flow routing or provider selection."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Updated for Worker Issue #217: source-reference policy v3 excludes external digital-file URI findings from numerical blockers without changing public DTOs."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: byte-planned source-support reads preserve public jobs, results, and payload contracts."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: source-reference policy v3 changes build identity without changing readiness schema or blocker semantics."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: source-support read batching does not change readiness schema or blocker semantics."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -23,8 +23,8 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Reviewed for Worker Issue #217: external digital-file URI handling does not change the provider Flow universe or linking decisions."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Reviewed for Worker Issue #219: source-support read batching does not change the provider Flow universe or linking decisions."
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-05
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
-lastReviewedNote: "Updated for Worker Issue #217: numerical source-reference policy v3 ignores external digital-file URI findings while certificate traversal stays strict."
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
+lastReviewedNote: "Updated for Worker Issue #219: numerical source support reads are byte-planned before exact document fetches while preserving the 64 MiB per-read and 1 GiB cumulative ceilings."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -171,8 +171,11 @@ Administrative closure and numerical Flow selection remain distinct. During the 
 The numerical snapshot source walk is `path-aware-bounded-frontier-v2`. It consumes the same raw
 reference edges produced by `scope_closure.rs`, but applies a separate role × artifact-purpose
 policy. Each exact document identity/hash is processed once; exact and omitted-version indexes make
-satisfaction checks deterministic; support reads use fixed 512-identity batches with a 64 MiB
-returned-byte ceiling. The cumulative canonical source-document ceiling is configured by
+satisfaction checks deterministic. Support reads first obtain bounded identity/version/byte-size
+metadata, resolve the exact versions needed by the frontier, and deterministically pack exact-row
+queries to both a 512-identity and 64 MiB returned-byte ceiling. A single support document above
+64 MiB fails closed instead of weakening the query admission limit. The cumulative canonical
+source-document ceiling is configured by
 `SOURCE_CLOSURE_TOTAL_DOCUMENT_BYTES` and defaults to 1 GiB; zero, malformed, and overflow
 values fail back to that bounded default. The build separately enforces cumulative
 document/reference/edge/depth limits.

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: f32cc8463b3ed2ed15d3046400ad981d7673477e
+lastReviewedCommit: c9a16ab2b166b01e4d407b3b16f88dbde357d000
 lastReviewedAt: 2026-08-05
-lastReviewedNote: "Reviewed for Worker Issue #217: the numerical source-reference policy correction does not change package import, export, or certificate binding."
+lastReviewedNote: "Reviewed for Worker Issue #219: numerical source-support read planning does not change package import, export, or certificate binding."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#219

## Summary
- Prevent reducible source-support reads from failing when a 512-document query exceeds the 64 MiB response ceiling.
- Fetch bounded identity/version/byte metadata first, freeze omitted and explicit versions deterministically, then issue exact document queries packed by both count and estimated bytes.

## Key Decisions
- Preserve the 512-identity, 64 MiB per-read, and 1 GiB cumulative source-document limits instead of raising production memory budgets.
- A single support document above 64 MiB remains a stable fail-closed blocker; post-fetch byte verification catches metadata/content drift.

## Validation
- make check (workspace fmt, all-feature clippy with -D warnings, and full workspace tests) passed locally and again in the pre-push gate.
- snapshot_builder binary tests: 96 passed, including count/byte packing, irreducibly large document rejection, and exact/omitted version freezing.
- Strict docpact config validation and enforced worktree/base lint passed.

## Risks / Rollback
- Adds lightweight metadata queries before support-document fetches. Rollback is a single commit revert; no schema, DTO, provider-linking, matrix-axis, or external-URI behavior changes.

## Follow-ups
- After merge, update the tiangong-lca-worker submodule pointer through the root workspace integration flow before marking delivery complete.

## Workspace Integration
- Worker is an M1 repository; this PR targets worker main, and root main should integrate the exact merged worker main commit.