### PR TITLE
chore: upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install SuiteSparse dependencies
         run: sudo apt-get update && sudo apt-get install -y libsuitesparse-dev libopenblas-dev liblapack-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#226

## Summary
- Upgrade every active workflow checkout reference to actions/checkout@v7.

## Validation
- Parsed all changed workflow YAML files; docpact lint and git diff --check passed.

## Risks / Rollback
- Low-risk CI dependency major-version update; rollback is a one-line version reversion.

## Workspace Integration
- Submodule repositories require a later exact-SHA workspace pointer update after merge.