### PR TITLE
fix: exclude historical LCIA results from scope closure

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd"
+lastReviewedCommit: "05bcf3443490c37629689796695fbbf9cf16f38a"
 lastReviewedNote: "Reviewed for Worker Issue #233: bounded snapshot discovery transport remains within Worker runtime ownership and existing public contracts."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Reviewed for Worker Issue #233: the discovery transport fix stays within Worker runtime and contract ownership boundaries."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -1901,7 +1901,7 @@ async fn collect_scope_closure<P: ScopeClosureProvider>(
                 }
                 continue;
             };
-            let extraction = extract_references(
+            let extraction = extract_scope_closure_references(
                 document.identity.document_key().as_str(),
                 document.identity.category,
                 &document.payload,
@@ -2288,6 +2288,24 @@ pub fn extract_references(
     category: DatasetCategory,
     payload: &Value,
 ) -> ReferenceExtractionResult {
+    extract_references_with_profile(document_key, category, payload, true)
+}
+
+#[must_use]
+pub fn extract_scope_closure_references(
+    document_key: &str,
+    category: DatasetCategory,
+    payload: &Value,
+) -> ReferenceExtractionResult {
+    extract_references_with_profile(document_key, category, payload, false)
+}
+
+fn extract_references_with_profile(
+    document_key: &str,
+    category: DatasetCategory,
+    payload: &Value,
+    include_process_lcia_results: bool,
+) -> ReferenceExtractionResult {
     let mut result = ReferenceExtractionResult {
         schema_version: "tidas.reference-extraction-result.v1".to_owned(),
         document_key: document_key.to_owned(),
@@ -2295,7 +2313,14 @@ pub fn extract_references(
         edges: Vec::new(),
         issues: Vec::new(),
     };
-    walk_references(payload, "$", None, category, &mut result);
+    walk_references(
+        payload,
+        "$",
+        None,
+        category,
+        include_process_lcia_results,
+        &mut result,
+    );
     result
 }
 
@@ -2304,8 +2329,15 @@ fn walk_references(
     path: &str,
     parent_key: Option<&str>,
     source_category: DatasetCategory,
+    include_process_lcia_results: bool,
     result: &mut ReferenceExtractionResult,
 ) {
+    if !include_process_lcia_results
+        && source_category == DatasetCategory::Processes
+        && path.eq_ignore_ascii_case("$.processDataSet.LCIAResults")
+    {
+        return;
+    }
     match node {
         Value::Object(object) => {
             if looks_like_reference(object, parent_key) {
@@ -2317,6 +2349,7 @@ fn walk_references(
                     format!("{path}.{key}").as_str(),
                     Some(key),
                     source_category,
+                    include_process_lcia_results,
                     result,
                 );
             }
@@ -2328,6 +2361,7 @@ fn walk_references(
                     format!("{path}[{index}]").as_str(),
                     parent_key,
                     source_category,
+                    include_process_lcia_results,
                     result,
                 );
             }
@@ -9956,6 +9990,188 @@ mod tests {
                 assert_eq!(targets, expected);
             }
         }
+    }
+
+    #[test]
+    fn scope_closure_reference_extraction_excludes_process_lcia_results() {
+        let exchange_flow = id("10101010-1010-4010-8010-101010101010");
+        let historical_method = id("20202020-2020-4020-8020-202020202020");
+        let payload = json!({
+            "processDataSet": {
+                "exchanges": {
+                    "exchange": {
+                        "referenceToFlowDataSet": reference(
+                            "flow",
+                            exchange_flow,
+                            Some("01.00.000")
+                        )
+                    }
+                },
+                "LCIAResults": {
+                    "LCIAResult": [
+                        {
+                            "referenceToLCIAMethodDataSet": {
+                                "@type": "LCIA method data set",
+                                "@refObjectId": historical_method,
+                                "@version": "01.00.000",
+                                "@uri": format!("../lciamethods/{historical_method}.json")
+                            },
+                            "meanAmount": 1.0
+                        },
+                        {
+                            "referenceToLCIAMethodDataSet": {
+                                "@type": "LCIA method data set",
+                                "@version": "invalid"
+                            },
+                            "meanAmount": 2.0
+                        }
+                    ]
+                }
+            }
+        });
+
+        let generic = extract_references("process-fixture", DatasetCategory::Processes, &payload);
+        assert_eq!(generic.edges.len(), 2);
+        assert!(!generic.issues.is_empty());
+
+        let closure = extract_scope_closure_references(
+            "process-fixture",
+            DatasetCategory::Processes,
+            &payload,
+        );
+        assert!(closure.issues.is_empty());
+        assert_eq!(closure.edges.len(), 1);
+        assert_eq!(closure.edges[0].target_uuid, exchange_flow.to_string());
+        assert_eq!(closure.edges[0].reference_role, "process_exchange_flow");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn scope_closure_does_not_fetch_historical_lcia_result_dependencies() {
+        let process = identity(
+            DatasetCategory::Processes,
+            "30303030-3030-4030-8030-303030303030",
+        );
+        let selected_method = identity(
+            DatasetCategory::Lciamethods,
+            "40404040-4040-4040-8040-404040404040",
+        );
+        let historical_method = identity(
+            DatasetCategory::Lciamethods,
+            "50505050-5050-4050-8050-505050505050",
+        );
+        let exchange_flow = identity(
+            DatasetCategory::Flows,
+            "60606060-6060-4060-8060-606060606060",
+        );
+        let selected_factor_flow = identity(
+            DatasetCategory::Flows,
+            "70707070-7070-4070-8070-707070707070",
+        );
+        let historical_factor_flow = identity(
+            DatasetCategory::Flows,
+            "80808080-8080-4080-8080-808080808080",
+        );
+        let lcia_reference = |target: &ExactDatasetIdentity| {
+            json!({
+                "@type": "LCIA method data set",
+                "@refObjectId": target.id,
+                "@version": target.version,
+                "@uri": format!("../lciamethods/{}.json", target.id)
+            })
+        };
+        let method_payload = |factor: &ExactDatasetIdentity| {
+            json!({
+                "LCIAMethodDataSet": {
+                    "characterisationFactors": {
+                        "factor": {
+                            "referenceToFlowDataSet": reference(
+                                "flow",
+                                factor.id,
+                                Some(factor.version.as_str())
+                            )
+                        }
+                    }
+                }
+            })
+        };
+        let documents = [
+            ClosureDocument {
+                identity: process.clone(),
+                payload: json!({
+                    "processDataSet": {
+                        "exchanges": {
+                            "exchange": {
+                                "referenceToFlowDataSet": reference(
+                                    "flow",
+                                    exchange_flow.id,
+                                    Some(exchange_flow.version.as_str())
+                                )
+                            }
+                        },
+                        "LCIAResults": {
+                            "LCIAResult": {
+                                "referenceToLCIAMethodDataSet": lcia_reference(&historical_method),
+                                "meanAmount": 1.0
+                            }
+                        }
+                    }
+                }),
+            },
+            ClosureDocument {
+                identity: selected_method.clone(),
+                payload: method_payload(&selected_factor_flow),
+            },
+            ClosureDocument {
+                identity: historical_method.clone(),
+                payload: method_payload(&historical_factor_flow),
+            },
+            ClosureDocument {
+                identity: exchange_flow.clone(),
+                payload: json!({}),
+            },
+            ClosureDocument {
+                identity: selected_factor_flow.clone(),
+                payload: json!({}),
+            },
+            ClosureDocument {
+                identity: historical_factor_flow.clone(),
+                payload: json!({}),
+            },
+        ]
+        .into_iter()
+        .map(|document| (document.identity.clone(), document))
+        .collect();
+        let provider = FakeProvider {
+            documents,
+            ..FakeProvider::default()
+        };
+        let mut requested_scope = manifest(vec![process]);
+        requested_scope.lcia_methods.push(RequestedIdentity {
+            id: selected_method.id,
+            version: selected_method.version.clone(),
+        });
+
+        let scan = collect_scope_closure(&provider, &requested_scope)
+            .await
+            .unwrap();
+
+        assert!(scan.complete);
+        assert!(scan.issues.is_empty());
+        assert_eq!(scan.documents.len(), 4);
+        assert_eq!(scan.edges.len(), 2);
+        let fetched = provider
+            .fetches
+            .lock()
+            .unwrap()
+            .iter()
+            .flatten()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        assert!(fetched.contains(&selected_method));
+        assert!(fetched.contains(&selected_factor_flow));
+        assert!(!fetched.contains(&historical_method));
+        assert!(!fetched.contains(&historical_factor_flow));
     }
 
     #[tokio::test]

--- a/crates/solver-worker/src/snapshot_source_closure.rs
+++ b/crates/solver-worker/src/snapshot_source_closure.rs
@@ -9,7 +9,7 @@ use crate::{
         CompiledReleaseSourceDataset, CompiledReleaseSourceDatasetType,
         CompiledSourceReferenceProvenance, CompiledSourceReferenceSample,
     },
-    scope_closure::{DatasetCategory, extract_references},
+    scope_closure::{DatasetCategory, extract_scope_closure_references},
     source_reference_policy::{
         ArtifactPurpose, SOURCE_REFERENCE_POLICY_VERSION, SourceReferenceAction,
         SourceReferenceRole, classify_malformed_reference_role, classify_reference,
@@ -82,7 +82,8 @@ pub fn classify_source_document_with_lcia_flow_axis(
         source.dataset_id,
         source.dataset_version
     );
-    let extraction = extract_references(&source_identity, source_category, &source.document);
+    let extraction =
+        extract_scope_closure_references(&source_identity, source_category, &source.document);
     let mut references = Vec::with_capacity(extraction.edges.len());
     for edge in extraction.edges {
         if !lcia_factor_reference_is_active(
@@ -498,6 +499,51 @@ mod tests {
         assert_eq!(
             classified.references[0].target_uuid,
             active_flow.to_string()
+        );
+    }
+
+    #[test]
+    fn certificate_closure_ignores_historical_process_lcia_results() {
+        let exchange_flow = Uuid::new_v4();
+        let classified = classify_source_document(
+            &source(
+                CompiledReleaseSourceDatasetType::Process,
+                json!({
+                    "processDataSet": {
+                        "exchanges": {
+                            "exchange": {
+                                "referenceToFlowDataSet": {
+                                    "@type": "flow data set",
+                                    "@refObjectId": exchange_flow,
+                                    "@version": "01.00.000"
+                                }
+                            }
+                        },
+                        "LCIAResults": {
+                            "LCIAResult": {
+                                "referenceToLCIAMethodDataSet": {
+                                    "@type": "LCIA method data set",
+                                    "@version": "invalid"
+                                },
+                                "meanAmount": 1.0
+                            }
+                        }
+                    }
+                }),
+            ),
+            ArtifactPurpose::CertificateClosure,
+        )
+        .unwrap();
+
+        assert!(classified.extraction_issues.is_empty());
+        assert_eq!(classified.references.len(), 1);
+        assert_eq!(
+            classified.references[0].target_uuid,
+            exchange_flow.to_string()
+        );
+        assert_eq!(
+            classified.references[0].role,
+            SourceReferenceRole::ExchangeFlow
         );
     }
 

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,7 +28,7 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Updated for Worker Issue #233: successful discovery uses a bounded verified temporary JSON result instead of captured stdout."
 related:
   - ../../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Updated for Worker Issue #233: snapshot discovery crosses the child boundary through verified compact temporary JSON."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Updated for Worker Issue #233: validates large discovery transport, integrity failures, bounded terminal output, and cleanup."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,7 +25,7 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Reviewed for Worker Issue #233: internal discovery transport does not change public job, result, artifact, or download contracts."
 related:
   - AGENTS.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedNote: "Updated for Worker Issue #233: successful snapshot discovery uses a verified parent-owned temporary JSON file and bounded terminal descriptor."
 related:
   - AGENTS.md
@@ -81,6 +81,13 @@ Traversal is a union traversal over all exact process and LCIA-method roots. It 
 - non-fail-fast for domain findings;
 - checkpointed through the active Worker lease between batches.
 
+Process `LCIAResults` is a historical output subtree, not a current calculation input. Worker
+preserves it unchanged inside the canonical Process document used for hashing, storage, and TIDAS
+document validation, but the Scope Closure reference-extraction profile does not descend into that
+subtree. References below `$.processDataSet.LCIAResults` therefore produce no closure edge,
+reference issue, omitted-version resolution, or traversal target. Process exchanges and the exact
+LCIA methods requested by the frozen manifest remain ordinary closure inputs.
+
 CPU-heavy graph finalization runs through Tokio's blocking pool so sorting, coalescing, and affected-root analysis cannot occupy a lease-heartbeat runtime thread. Canonical ordering materializes each serialized sort key once per collection, and the Worker emits phase durations and collection counts for capacity diagnosis without changing the evidence payload.
 
 Fetched document payloads are canonicalized and appended to a temporary random-access spool during traversal, then released after reference extraction. The retained document index contains only exact identity, canonical content hash, file offset, and byte size. Reference-edge and resolved-reference evidence is likewise file-backed; affected-root analysis uses numeric identity IDs and compact adjacency lists rather than repeated full identity objects per graph edge. Cache hits never reload document payloads, while each uncached TIDAS execution reloads at most its fixed 64-document window.
@@ -97,7 +104,11 @@ An exact reference never falls back to another version. A missing exact identity
 
 ## TIDAS validation
 
-Reference extraction in `scope_closure.rs` mirrors the public `tidas.reference-extraction-result.v1` contract and is locked by the shared golden fixture under `crates/solver-worker/tests/fixtures/reference_extraction_v1/`.
+Generic reference extraction in `scope_closure.rs` mirrors the public
+`tidas.reference-extraction-result.v1` contract and is locked by the shared golden fixture under
+`crates/solver-worker/tests/fixtures/reference_extraction_v1/`. Scope Closure applies the explicit
+historical-`LCIAResults` subtree exclusion above before constructing its dependency graph; this
+does not change generic TIDAS reference extraction or document validation.
 
 Document validation uses only the published unified Rust `tidas` CLI selected by `TIDAS_BIN` (default `tidas`). No Python entrypoint, legacy binary name, or ordered command-candidate fallback is permitted:
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,7 +19,7 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
+lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
 lastReviewedAt: 2026-08-09
 lastReviewedNote: "Reviewed for Worker Issue #233: discovery transport does not change package tasks or certificate-binding contracts."
 related:


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#235

## Summary
- Exclude the exact Process LCIAResults subtree from both administrative and certificate-grade Scope Closure dependency extraction while preserving the canonical Process document and TIDAS validation input.

## Key Decisions
- Keep generic tidas.reference-extraction-result.v1 behavior unchanged and add a Scope Closure-specific extraction profile.
- Stop recursion at $.processDataSet.LCIAResults so historical method references create no edge, extraction issue, omitted-version resolution, or traversal target.
- Leave Process exchanges, frozen requested LCIA methods, and active C-factor traversal unchanged.

## Validation
- make check
- cargo test -p solver-worker scope_closure (64 passed, 8 qualification tests ignored)
- cargo test -p solver-worker snapshot_source_closure (7 passed)
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- docpact lint --worktree: ok, 0 findings

## Risks / Rollback
- Low and narrowly scoped: only references below the schema-defined Process LCIAResults path are excluded; rollback is the single Worker commit.

## Follow-ups
- After merge, update the lca-workspace Worker submodule pointer and deploy through the separately authorized production rollout.

## Workspace Integration
- Workspace integration remains Pending until the root Worker submodule pointer is updated after merge.