### PR TITLE
fix: propagate snapshot config into readiness

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "63dac07d858a14427f663a03c69f17db9ed26419"
-lastReviewedNote: "Reviewed for Worker Issue #237: cutoff-only certificate-grade Scope Closure remains within Worker runtime ownership and existing public contracts; no routing rule change is required."
+lastReviewedCommit: "d9feea1edde75874aebb25e91a774cd147ac61c5"
+lastReviewedNote: "Reviewed for Worker Issue #239: propagating the effective snapshot config into matrix readiness stays within existing Worker ownership and routing rules."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Reviewed for Worker Issue #233: the discovery transport fix stays within Worker runtime and contract ownership boundaries."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: effective snapshot-config propagation remains Worker runtime behavior and preserves public ownership boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/bin/snapshot_builder.rs
+++ b/crates/solver-worker/src/bin/snapshot_builder.rs
@@ -1354,6 +1354,7 @@ async fn run_snapshot_builder(cli: Cli) -> anyhow::Result<()> {
         &pool,
         snapshot_id,
         &method,
+        &build_config,
         resolved_scope.processes.clone(),
         cli.include_user_id,
         versioned_scope.as_ref(),
@@ -2057,6 +2058,7 @@ async fn run_review_submit_overlay_build(
     let built = assemble_sparse_payload(
         requested_snapshot_id,
         &method,
+        &overlay_config,
         &overlay_graph,
         cli.self_loop_cutoff,
         cli.singular_eps,
@@ -2224,6 +2226,7 @@ async fn load_or_build_review_submit_baseline(
         pool,
         baseline_snapshot_id,
         method,
+        baseline_config,
         baseline_processes.to_vec(),
         include_user_id,
         None,
@@ -3683,6 +3686,7 @@ async fn build_sparse_payload(
     pool: &PgPool,
     snapshot_id: Uuid,
     method: &MethodSelection,
+    build_config: &SnapshotBuildConfig,
     processes: Vec<ProcessRow>,
     include_user_id: Option<Uuid>,
     versioned_scope: Option<&ValidatedPublicOwnerDraftScope>,
@@ -3720,6 +3724,7 @@ async fn build_sparse_payload(
     assemble_sparse_payload_with_selection(
         snapshot_id,
         method,
+        build_config,
         &compiled_graph.graph,
         self_loop_cutoff,
         singular_eps,
@@ -4756,6 +4761,7 @@ fn select_active_lcia_factors(
 fn assemble_sparse_payload(
     snapshot_id: Uuid,
     method: &MethodSelection,
+    build_config: &SnapshotBuildConfig,
     compiled_graph: &CompiledGraph,
     self_loop_cutoff: f64,
     singular_eps: f64,
@@ -4778,6 +4784,7 @@ fn assemble_sparse_payload(
     assemble_sparse_payload_with_selection(
         snapshot_id,
         method,
+        build_config,
         compiled_graph,
         self_loop_cutoff,
         singular_eps,
@@ -4793,6 +4800,7 @@ fn assemble_sparse_payload(
 fn assemble_sparse_payload_with_selection(
     snapshot_id: Uuid,
     method: &MethodSelection,
+    build_config: &SnapshotBuildConfig,
     compiled_graph: &CompiledGraph,
     self_loop_cutoff: f64,
     singular_eps: f64,
@@ -5088,7 +5096,7 @@ fn assemble_sparse_payload_with_selection(
     let readiness = verify_matrix_readiness(&MatrixReadinessInput {
         schema_version: "matrix_readiness_input.v2".to_owned(),
         snapshot_id: Some(snapshot_id),
-        config: None,
+        config: Some(build_config.clone()),
         coverage: coverage.clone(),
         payload: data.clone(),
         compiled_graph: Some(compiled_graph.clone()),
@@ -10947,6 +10955,7 @@ mod tests {
         let built = assemble_sparse_payload(
             Uuid::new_v4(),
             &method,
+            &test_snapshot_build_config("tidas-reference-allocation-v3"),
             &overlay_graph,
             0.999_999,
             1e-12,
@@ -11066,6 +11075,7 @@ mod tests {
         let built = assemble_sparse_payload(
             Uuid::new_v4(),
             &method,
+            &test_snapshot_build_config("tidas-reference-allocation-v3"),
             &graph,
             0.999_999,
             1e-12,
@@ -11185,6 +11195,7 @@ mod tests {
         let built = assemble_sparse_payload(
             Uuid::new_v4(),
             &method,
+            &test_snapshot_build_config("tidas-reference-allocation-v3"),
             &graph,
             0.999_999,
             1e-12,
@@ -11227,6 +11238,7 @@ mod tests {
         let built = assemble_sparse_payload(
             snapshot_id,
             &method,
+            &test_snapshot_build_config("tidas-reference-allocation-v3"),
             &graph,
             0.999_999,
             1e-12,
@@ -11263,6 +11275,79 @@ mod tests {
                 .expect("release evidence link")
                 .byte_size,
             123
+        );
+    }
+
+    #[test]
+    fn assembled_readiness_uses_effective_snapshot_boundary_policy() {
+        let mut graph = super::empty_compiled_graph();
+        graph.matching_stats.input_edges_total = 1;
+        graph.matching_stats.unmatched_no_provider = 1;
+        graph.matching_stats.residual_edges_total = 1;
+        let method = MethodSelection {
+            has_lcia: false,
+            method_id: None,
+            method_version: None,
+            method_count: 0,
+            factor_count: 0,
+            source_evidence: None,
+            rows: Vec::new(),
+            static_bundle: None,
+        };
+        let mut build_config = test_snapshot_build_config("tidas-reference-allocation-v3");
+        build_config.technosphere_boundary_policy = "cutoff".to_owned();
+
+        let cutoff = assemble_sparse_payload(
+            Uuid::new_v4(),
+            &method,
+            &build_config,
+            &graph,
+            build_config.self_loop_cutoff,
+            build_config.singular_eps,
+            false,
+            &[],
+            &[],
+            false,
+        )
+        .expect("assemble cutoff readiness input");
+
+        assert!(cutoff.readiness.blockers.iter().all(|blocker| {
+            blocker.code != "provider_closure_unmatched"
+                && blocker.code != "provider_closure_write_pct_below_policy"
+        }));
+        assert!(cutoff.readiness.findings.iter().any(|finding| {
+            finding.code == "technosphere_boundary_unresolved_permitted"
+                && finding.details["technosphere_boundary_policy"] == "cutoff"
+        }));
+
+        build_config.technosphere_boundary_policy = "closed".to_owned();
+        let closed = assemble_sparse_payload(
+            Uuid::new_v4(),
+            &method,
+            &build_config,
+            &graph,
+            build_config.self_loop_cutoff,
+            build_config.singular_eps,
+            false,
+            &[],
+            &[],
+            false,
+        )
+        .expect("assemble closed readiness input");
+
+        assert!(
+            closed
+                .readiness
+                .blockers
+                .iter()
+                .any(|blocker| { blocker.code == "provider_closure_unmatched" })
+        );
+        assert!(
+            closed
+                .readiness
+                .blockers
+                .iter()
+                .any(|blocker| { blocker.code == "provider_closure_write_pct_below_policy" })
         );
     }
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,9 +35,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Updated for Worker Issue #233: snapshot discovery crosses the child boundary through verified compact temporary JSON."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: readiness now consumes the same effective snapshot config without changing repository topology."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,9 +40,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Updated for Worker Issue #233: validates large discovery transport, integrity failures, bounded terminal output, and cleanup."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: focused snapshot-builder coverage proves cutoff warning behavior and closed-policy blockers."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/implicit-regional-supply-mix-modeling.en.md
+++ b/docs/implicit-regional-supply-mix-modeling.en.md
@@ -24,9 +24,9 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
-lastReviewedNote: "Reviewed for Worker Issue #233: discovery transport does not change signed-flow routing or provider selection."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: config propagation restores the documented cutoff boundary without changing routing theory."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/implicit-regional-supply-mix-modeling.md
+++ b/docs/implicit-regional-supply-mix-modeling.md
@@ -24,9 +24,9 @@ checkPaths:
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/signed_flow.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
-lastReviewedNote: "Reviewed for Worker Issue #233: discovery transport does not change signed-flow routing or provider selection."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: config propagation restores the documented cutoff boundary without changing routing theory."
 related:
   - AGENTS.md
   - docs/agents/repo-architecture.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -24,9 +24,9 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Reviewed for Worker Issue #233: internal discovery transport does not change public job, result, artifact, or download contracts."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: the internal readiness-policy fix does not change public job, result, artifact, or download contracts."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/matrix-readiness-report-contract.md
+++ b/docs/matrix-readiness-report-contract.md
@@ -24,9 +24,9 @@ checkPaths:
   - docs/lca-api-contract.md
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
-lastReviewedNote: "Reviewed for Worker Issue #233: compact discovery projection does not change matrix-readiness report v2 semantics."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: snapshot assembly now supplies the effective config while report v2 semantics and defaults remain unchanged."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/provider-linking.md
+++ b/docs/provider-linking.md
@@ -22,9 +22,9 @@ checkPaths:
   - crates/solver-worker/src/bin/snapshot_builder.rs
   - crates/solver-worker/src/compiled_graph.rs
   - crates/solver-worker/src/snapshot_artifacts.rs
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cc603507f46e7fa1e611cf2dc2cf7e90a71d78dd
-lastReviewedNote: "Reviewed for Worker Issue #233: discovery transport does not change provider eligibility, routing, or evidence semantics."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
+lastReviewedNote: "Reviewed for Worker Issue #239: readiness config propagation restores the documented cutoff behavior without changing provider linking."
 related:
   - AGENTS.md
   - docs/implicit-regional-supply-mix-modeling.md


### PR DESCRIPTION
Closes linancn/tiangong-lca-worker#239

## Summary
- Thread the effective SnapshotBuildConfig through sparse payload assembly so matrix readiness evaluates the same frozen cutoff policy used by Scope Closure.

## Key Decisions
- Use the already resolved snapshot config as the single policy source instead of changing thresholds or filtering blocker codes.
- Preserve generic closed/open/cutoff behavior and all public job, result, and artifact contracts.

## Validation
- cargo test -p solver-worker --bin snapshot_builder (101 passed).
- cargo test -p solver-worker readiness (readiness coverage passed).
- cargo check -p solver-worker --all-targets; make check.
- docpact validate-config --strict and enforced worktree lint (0 findings).

## Risks / Rollback
- Low: only fixes readiness policy propagation; rollback by reverting the commit.

## Workspace Integration
- Requires an exact Worker submodule pointer update in tiangong-lca/workspace after merge.