### PR TITLE
fix: accept cutoff readiness scanner cache revision

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "d9feea1edde75874aebb25e91a774cd147ac61c5"
-lastReviewedNote: "Reviewed for Worker Issue #239: propagating the effective snapshot config into matrix readiness stays within existing Worker ownership and routing rules."
+lastReviewedCommit: "452e2736efb14a8df2b833bb2fd21f279d324aab"
+lastReviewedNote: "Reviewed for Worker Issue #241: the internal scanner-revision compatibility hotfix remains within Worker runtime ownership and existing routing rules."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
-lastReviewedNote: "Reviewed for Worker Issue #239: effective snapshot-config propagation remains Worker runtime behavior and preserves public ownership boundaries."
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Reviewed for Worker Issue #241: accepting the exact current and historical scanner revisions remains internal Worker runtime behavior and preserves public ownership boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -49,6 +49,9 @@ pub const SCOPE_CLOSURE_JOB_KIND: &str = "lcia.scope_closure_check";
 pub const SCOPE_CLOSURE_REQUEST_SCHEMA_VERSION: &str = "lcia.scope_closure_check.request.v1";
 pub const SCOPE_CLOSURE_RESULT_SCHEMA_VERSION: &str = "lcia.scope_closure_check.result.v1";
 pub const SCOPE_CLOSURE_SCANNER_VERSION: &str = "scope-closure-scanner.v1";
+const VALIDATOR_SCANNER_FINGERPRINT_V1: &str = "scope-closure-validator-scanner.v1";
+const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1: &str =
+    "scope-closure-validator-scanner.v1+cutoff-readiness-r1";
 pub const TIDAS_BATCH_PROTOCOL: &str = tidas_cli::TIDAS_BATCH_PROTOCOL;
 pub const TIDAS_BATCH_PROFILE: &str = tidas_cli::TIDAS_BATCH_PROFILE;
 pub const REFERENCE_EDGE_SCHEMA_VERSION: &str = "tidas.reference-edge.v1";
@@ -82,6 +85,17 @@ const XLSX_MAX_WORKSHEET_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 const XLSX_MAX_ARCHIVE_BYTES: u64 = 64 * 1024 * 1024;
 const SCOPE_CLOSURE_ARTIFACT_RETENTION_SECONDS: i64 = 7 * 24 * 60 * 60;
 const SCOPE_CLOSURE_ARTIFACT_STAGING_SECONDS: i32 = 3_600;
+
+fn validate_validator_scanner_fingerprint(fingerprint: &str) -> anyhow::Result<()> {
+    if fingerprint == VALIDATOR_SCANNER_FINGERPRINT_V1
+        || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1
+    {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "unsupported validator/scanner fingerprint: {fingerprint}"
+    ))
+}
 
 fn artifact_registration_batches(items: &[Value]) -> std::slice::Chunks<'_, Value> {
     items.chunks(ARTIFACT_REGISTRATION_BATCH_SIZE)
@@ -4561,12 +4575,7 @@ pub async fn execute_scope_closure_job(
     {
         return Err(anyhow::anyhow!("closure scan/snapshot envelope mismatch"));
     }
-    if input.expected_validator_scanner_fingerprint != "scope-closure-validator-scanner.v1" {
-        return Err(anyhow::anyhow!(
-            "unsupported validator/scanner fingerprint: {}",
-            input.expected_validator_scanner_fingerprint
-        ));
-    }
+    validate_validator_scanner_fingerprint(&input.expected_validator_scanner_fingerprint)?;
     let wait_started = std::time::Instant::now();
     let mut wait_backoff = std::time::Duration::from_secs(1);
     loop {
@@ -9919,6 +9928,23 @@ mod tests {
             "expectedValidatorScannerFingerprint": "scope-closure-validator-scanner.v1",
             "requestFingerprint": "5".repeat(64)
         })
+    }
+
+    #[test]
+    fn validator_scanner_fingerprint_compatibility_is_explicit() {
+        for fingerprint in [
+            VALIDATOR_SCANNER_FINGERPRINT_V1,
+            VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1,
+        ] {
+            assert!(validate_validator_scanner_fingerprint(fingerprint).is_ok());
+        }
+
+        let unsupported = "scope-closure-validator-scanner.v1+unknown-r2";
+        let error = validate_validator_scanner_fingerprint(unsupported).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("unsupported validator/scanner fingerprint: {unsupported}")
+        );
     }
 
     fn identity(category: DatasetCategory, value: &str) -> ExactDatasetIdentity {

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -27,9 +27,9 @@ checkPaths:
   - docs/agents/contracts/scope-closure-external-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Updated for Worker Issue #233: successful discovery uses a bounded verified temporary JSON result instead of captured stdout."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Reviewed for Worker Issue #241: scanner-revision compatibility does not change memory bounds, result publication, or artifact contracts."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
-lastReviewedNote: "Reviewed for Worker Issue #239: readiness now consumes the same effective snapshot config without changing repository topology."
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Reviewed for Worker Issue #241: the closed scanner-revision compatibility set changes no repository topology or public interface."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
-lastReviewedNote: "Reviewed for Worker Issue #239: focused snapshot-builder coverage proves cutoff warning behavior and closed-policy blockers."
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Reviewed for Worker Issue #241: focused coverage proves exact current and historical scanner revisions are accepted while unknown revisions fail closed."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: d9feea1edde75874aebb25e91a774cd147ac61c5
-lastReviewedNote: "Reviewed for Worker Issue #239: the internal readiness-policy fix does not change public job, result, artifact, or download contracts."
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Reviewed for Worker Issue #241: the internal cache-identity compatibility fix does not change public job, result, artifact, or download contracts."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -31,9 +31,9 @@ checkPaths:
   - scripts/scope_closure_qualification.py
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedNote: "Updated for Worker Issue #233: successful snapshot discovery uses a verified parent-owned temporary JSON file and bounded terminal descriptor."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedNote: "Updated for Worker Issue #241: new requests use the cutoff-readiness scanner revision while historical V1 requests remain executable."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -61,6 +61,8 @@ The canonical job kind is `lcia.scope_closure_check` with payload schema `lcia.s
 - `request_fingerprint`
 
 The Worker loads the full service input through `svc_lcia_scope_closure_check_get_worker_input`. It requires the normalized requested scope, scope/policy/request hashes, expected validator-scanner fingerprint, publication epoch, and `lcia.scope-closure-data-snapshot.v2`.
+
+The current internal request identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r1`. Worker also accepts the historical exact value `scope-closure-validator-scanner.v1` so already-enqueued and in-flight requests remain executable during rollout. This is a closed compatibility set: any other fingerprint fails before scan claim. The revision changes cache identity only; it does not version or alter the public V1 job, result, certificate, or artifact contracts.
 
 Every newly normalized certificate-grade request freezes `linkPolicy.technosphereBoundaryPolicy=cutoff`. Database accepts the legacy supported input spellings `closed`, `open`, and `cutoff` during normalization, but all of them produce the same canonical cutoff scope before hashes and snapshot identity are computed. Worker requires the frozen value to be exactly `cutoff` at both the service-input and snapshot-builder child-protocol boundaries. It never silently overrides a noncanonical frozen manifest; such input fails before scan claim/publication with `scope_closure_boundary_policy_must_be_cutoff`. Historical artifacts remain readable and generic snapshot/readiness diagnostics retain their explicit three-policy surface.
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 05bcf3443490c37629689796695fbbf9cf16f38a
-lastReviewedAt: 2026-08-09
-lastReviewedNote: "Reviewed for Worker Issue #233: discovery transport does not change package tasks or certificate-binding contracts."
+lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
+lastReviewedAt: 2026-08-10
+lastReviewedNote: "Reviewed for Worker Issue #241: scanner-revision compatibility does not change package tasks or certificate-binding contracts."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #241

## Summary
- Accept the exact historical and cutoff-readiness validator/scanner fingerprints during the coordinated cache rollout.
- Keep unknown scanner revisions fail-closed and leave every public V1 job, result, certificate, and artifact contract unchanged.

## Key Decisions
- Use a closed two-value compatibility set instead of accepting arbitrary revision suffixes.

## Validation
- make check (format, qualification tests, workspace Clippy with warnings denied, and all workspace tests): passed with zero failures.
- docpact enforce lint over origin/main...HEAD: passed with full coverage and no findings.

## Risks / Rollback
- Deploy this Worker commit to both production Workers before Database #450 changes the configured fingerprint; rollback the database fingerprint before reverting Worker compatibility.

## Follow-ups
- After Database #450 is deployed, submit a fresh Scope Closure check for the incident case and verify it no longer selects stale scan evidence.

## Workspace Integration
- Tracked by tiangong-lca/workspace#569; update the root Worker pointer after production qualification.