### PR TITLE
Fix Calculation Bundle certified LCIA method subsets

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "818c95b0cb188471327832bdd3e01c449e1e3c3d"
-lastReviewedNote: "Reviewed for Worker Issue #243: Database-authoritative fresh/direct-reuse Closure Bundle binding remains within Worker runtime ownership and existing routing rules."
+lastReviewedCommit: "1de9c777b57b034c2b703ceedabd692526bb4fd0"
+lastReviewedNote: "Reviewed for Worker Issue #245: certified LCIA method subsets remain within the existing Calculation Bundle runtime and documentation routes."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 818c95b0cb188471327832bdd3e01c449e1e3c3d
-lastReviewedNote: "Reviewed for Worker Issue #243: consuming the Database-owned fresh/direct-reuse Bundle predicate preserves repository and public-interface ownership boundaries."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Reviewed for Worker Issue #245: accepting the certified LCIA method subset preserves Worker ownership and existing public-interface boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/calculation_bundle.rs
+++ b/crates/solver-worker/src/calculation_bundle.rs
@@ -1027,10 +1027,9 @@ impl CalculationBundleWriter {
 }
 
 fn validate_impacts(items: &[SnapshotImpactMapEntry]) -> anyhow::Result<Vec<ReleaseImpact>> {
-    if items.len() != usize::try_from(RELEASE_METHOD_COUNT)? {
+    if items.is_empty() {
         return Err(anyhow::anyhow!(
-            "Calculation Bundle requires the reviewed {RELEASE_METHOD_COUNT}-method set; got {}",
-            items.len()
+            "Calculation Bundle requires a non-empty certified impact axis"
         ));
     }
     let mut impacts = items
@@ -1059,18 +1058,27 @@ fn validate_impacts(items: &[SnapshotImpactMapEntry]) -> anyhow::Result<Vec<Rele
             ));
         }
     }
-    let actual = impacts
-        .iter()
-        .map(|impact| (impact.id.to_string(), impact.version.clone()))
-        .collect::<BTreeSet<_>>();
-    let expected = RELEASE_METHOD_IDENTITIES
+    let reviewed = RELEASE_METHOD_IDENTITIES
         .iter()
         .map(|(method_id, version, _)| ((*method_id).to_owned(), (*version).to_owned()))
         .collect::<BTreeSet<_>>();
-    if actual != expected {
-        return Err(anyhow::anyhow!(
-            "Calculation Bundle impact identities do not match the reviewed method set"
-        ));
+    let mut selected = BTreeSet::new();
+    for impact in &impacts {
+        let identity = (impact.id.to_string(), impact.version.clone());
+        if !reviewed.contains(&identity) {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle impact identity is not in the reviewed method catalog: {}@{}",
+                impact.id,
+                impact.version
+            ));
+        }
+        if !selected.insert(identity) {
+            return Err(anyhow::anyhow!(
+                "Calculation Bundle impact identity is duplicated: {}@{}",
+                impact.id,
+                impact.version
+            ));
+        }
     }
     Ok(impacts)
 }
@@ -1364,8 +1372,26 @@ mod tests {
         snapshot_index::{SnapshotImpactMapEntry, SnapshotProcessMapEntry},
     };
 
+    fn reviewed_impact(method_index: usize, impact_index: i32) -> SnapshotImpactMapEntry {
+        let (method_id, version, _) = RELEASE_METHOD_IDENTITIES[method_index];
+        SnapshotImpactMapEntry {
+            impact_id: Uuid::parse_str(method_id).unwrap(),
+            impact_index,
+            impact_version: Some(version.to_owned()),
+            impact_key: format!("method:{method_index}"),
+            impact_name: format!("Method {method_index}"),
+            unit: "kg".to_owned(),
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     fn fixture_writer() -> CalculationBundleWriter {
+        let method_indices = (0..RELEASE_METHOD_IDENTITIES.len()).collect::<Vec<_>>();
+        fixture_writer_with_method_indices(&method_indices)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn fixture_writer_with_method_indices(method_indices: &[usize]) -> CalculationBundleWriter {
         let process_id = Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap();
         let flow_id = Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap();
         let elementary_id = Uuid::parse_str("33333333-3333-4333-8333-333333333333").unwrap();
@@ -1388,6 +1414,7 @@ mod tests {
             "method_version": null
         }))
         .unwrap();
+        let method_count = method_indices.len();
         let coverage: SnapshotCoverageReport = serde_json::from_value(json!({
             "schema_version": "snapshot_coverage.v2",
             "matching": {
@@ -1420,32 +1447,27 @@ mod tests {
             "matrix_scale": {
                 "process_count": 1,
                 "flow_count": 1,
-                "impact_count": 25,
+                "impact_count": method_count,
                 "a_nnz": 0,
                 "b_nnz": 1,
-                "c_nnz": 25,
+                "c_nnz": method_count,
                 "m_nnz_estimated": 1,
                 "m_sparsity_estimated": 1.0
             }
         }))
         .unwrap();
-        let impact_map = RELEASE_METHOD_IDENTITIES
+        let impact_map = method_indices
             .iter()
             .enumerate()
-            .map(|(index, (method_id, version, _))| SnapshotImpactMapEntry {
-                impact_id: Uuid::parse_str(method_id).unwrap(),
-                impact_index: i32::try_from(index).unwrap(),
-                impact_version: Some((*version).to_owned()),
-                impact_key: format!("method:{index}"),
-                impact_name: format!("Method {index}"),
-                unit: "kg".to_owned(),
+            .map(|(impact_index, method_index)| {
+                reviewed_impact(*method_index, i32::try_from(impact_index).unwrap())
             })
             .collect();
         let index = SnapshotIndexDocument {
             version: 1,
             snapshot_id,
             process_count: 1,
-            impact_count: 25,
+            impact_count: i32::try_from(method_count).unwrap(),
             process_map: vec![SnapshotProcessMapEntry {
                 process_id,
                 process_index: 0,
@@ -1613,6 +1635,72 @@ mod tests {
         assert!(body.contains(
             "\"path\":\"processes/11111111-1111-4111-8111-111111111111_01.00.000.json\""
         ));
+    }
+
+    #[test]
+    fn accepts_non_empty_reviewed_method_subsets_in_certified_axis_order() {
+        let impacts = validate_impacts(&[
+            reviewed_impact(7, 1),
+            reviewed_impact(3, 0),
+            reviewed_impact(20, 2),
+        ])
+        .unwrap();
+
+        assert_eq!(impacts.len(), 3);
+        assert_eq!(impacts[0].id, reviewed_impact(3, 0).impact_id);
+        assert_eq!(impacts[1].id, reviewed_impact(7, 1).impact_id);
+        assert_eq!(impacts[2].id, reviewed_impact(20, 2).impact_id);
+
+        let single = validate_impacts(&[reviewed_impact(0, 0)]).unwrap();
+        assert_eq!(single.len(), 1);
+    }
+
+    #[test]
+    fn writes_calculation_bundle_for_single_certified_method() {
+        let mut writer = fixture_writer_with_method_indices(&[3]);
+        writer
+            .write_result_chunk(
+                0,
+                &[SolveResult {
+                    x: Some(vec![1.0]),
+                    g: None,
+                    h: Some(vec![42.0]),
+                    factorization_state: FactorizationState::Ready,
+                }],
+            )
+            .unwrap();
+
+        let built = writer.finish().unwrap();
+        assert_eq!(built.manifest.snapshot.impact_count, 1);
+        let lcia = built
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.metadata.kind == "lcia")
+            .unwrap();
+        let mut decoder = GzDecoder::new(File::open(&lcia.local_path).unwrap());
+        let mut body = String::new();
+        decoder.read_to_string(&mut body).unwrap();
+        assert!(body.contains("\"meanAmount\":42.0"));
+        assert!(body.contains(RELEASE_METHOD_IDENTITIES[3].0));
+    }
+
+    #[test]
+    fn rejects_invalid_certified_method_axes() {
+        assert!(validate_impacts(&[]).is_err());
+
+        let duplicate = [reviewed_impact(0, 0), reviewed_impact(0, 1)];
+        assert!(validate_impacts(&duplicate).is_err());
+
+        let gap = [reviewed_impact(0, 0), reviewed_impact(1, 2)];
+        assert!(validate_impacts(&gap).is_err());
+
+        let mut unknown = reviewed_impact(0, 0);
+        unknown.impact_id = Uuid::parse_str("ffffffff-ffff-4fff-8fff-ffffffffffff").unwrap();
+        assert!(validate_impacts(&[unknown]).is_err());
+
+        let mut missing_version = reviewed_impact(0, 0);
+        missing_version.impact_version = None;
+        assert!(validate_impacts(&[missing_version]).is_err());
     }
 
     #[test]

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,8 +28,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 818c95b0cb188471327832bdd3e01c449e1e3c3d
-lastReviewedNote: "Reviewed for Worker Issue #243: direct Bundle reuse changes no memory bounds, artifact payloads, or bounded result-publication semantics."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Reviewed for Worker Issue #245: method-subset materialization changes no Scope Closure memory, artifact-layout, or publication bounds."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 818c95b0cb188471327832bdd3e01c449e1e3c3d
-lastReviewedNote: "Reviewed for Worker Issue #243: Database-authoritative Bundle binding changes no repository topology or public interface."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Reviewed for Worker Issue #245: the certified method-axis fix stays in Calculation Bundle materialization and changes no repository topology."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 818c95b0cb188471327832bdd3e01c449e1e3c3d
-lastReviewedNote: "Reviewed for Worker Issue #243: focused coverage includes fresh and direct-reuse Bundle ownership while mismatched bindings remain fail-closed in Database validation."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Reviewed for Worker Issue #245: focused Calculation Bundle coverage includes one-method and multi-method certified subsets plus invalid-axis rejection."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,8 +25,8 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
-lastReviewedNote: "Reviewed for Worker Issue #241: the internal cache-identity compatibility fix does not change public job, result, artifact, or download contracts."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Updated for Worker Issue #245: Calculation Bundle follows the snapshot's exact non-empty certified LCIA method subset instead of requiring all 25 reviewed methods."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -308,9 +308,9 @@ evidence/coverage.json
   manifest、bundle 与包含完整 snapshot blocker 明细（超单表限制时拆表）的 XLSX；sidecar 缺失、
   损坏或不完整仍按 protocol `error` 失败。
 - 若 exchange 的 Flow 引用省略 `@version`，release evidence 使用本次 snapshot 实际选择并冻结的 Flow metadata version；若引用显式给出版本，则 worker 精确查询并保持该版本绑定，且 unit metadata 只允许来自同一版本，不能静默回退到另一版本。同一 UUID 的不同显式 revision 作为不同 identity 参与 provider lookup 与 flow axis；任何缺失或不可见的 exact revision 都在 snapshot compilation 时 fail closed。
-- 已审 LCIA 方法中 UUID 与 artifact locator 不同的已知 alias，无论来自 static cache 还是 legacy database-backed package build，都只允许 locator 用于精确读取源文档；source closure、LCIA axis 与最终发布始终使用文档内的 canonical method UUID/version。25 个方法任一 identity/version/locator/document UUID 不符合 reviewed mapping 都 fail closed。
+- 已审 LCIA 方法中 UUID 与 artifact locator 不同的已知 alias，无论来自 static cache 还是 legacy database-backed package build，都只允许 locator 用于精确读取源文档；source closure、LCIA axis 与最终发布始终使用文档内的 canonical method UUID/version。Calculation Bundle 接受证书 snapshot 冻结的任意非空已审方法子集，并保持 snapshot impact index 的精确顺序；子集中的任一 identity/version/locator/document UUID 不符合 25-method reviewed catalog mapping、重复或 index 不连续都 fail closed。
 - technosphere evidence 使用中性字段固化 `dependent_process_idx`、`residual_exchange_internal_id`、`balancing_process_idx`、`balancing_reference_exchange_internal_id`、residual/reference coefficient、routing weight、activity requirement、Flow UUID/version 和 location；每个最终 balancing reference port 一条 edge。
-- directional LCI key 固定为 Flow UUID/version + Input/Output + reference unit + optional location；LCIA 固定绑定已审查 static-cache bundle 1.2.4 的 25 个 method UUID/version。
+- directional LCI key 固定为 Flow UUID/version + Input/Output + reference unit + optional location；LCIA 绑定已审查 static-cache bundle 1.2.4 中由证书 snapshot 精确选择的非空 method UUID/version 子集，而不是强制发布全部 25 个方法。
 - object path 使用 `calculation-bundles/<calculation-id>/<bundle-content-hash>/...`，先上传 sidecars，最后上传 manifest。job diagnostics 的 `calculation_bundle`（package build 中为 `artifactManifest.calculationBundle`）保存 manifest URL/hash/byte size 和 bundle content hash。
 - bounded `hdf5:v1` descriptor 与 `all-unit-query:v2` index 是兼容/查询视图；它们不是 canonical release evidence，也不得回退为完整矩阵驻留。旧 `all-unit-query:v1` artifacts remain readable only as historical artifacts; new solves never produce them。旧 snapshot 缺少 frozen `source_datasets` 时必须重建，禁止在 solve 或 release 阶段从数据库当前态补齐。
 

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 452e2736efb14a8df2b833bb2fd21f279d324aab
-lastReviewedNote: "Updated for Worker Issue #241: new requests use the cutoff-readiness scanner revision while historical V1 requests remain executable."
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedNote: "Updated for Worker Issue #245: package materialization preserves the exact certified LCIA method subset while retaining reviewed-catalog validation."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -274,6 +274,8 @@ The database Build V2 command atomically enqueues `lcia_result.package_build` wi
 - `closure_bundle_hash`
 
 The Worker accepts this authoritative eleven-field binding only all-or-none and validates every field against a currently valid, complete, passed closure check before package execution. Closure-bundle ownership is evaluated by the Database-owned binding predicate: a fresh artifact belongs to the current check, while a single-level reused artifact remains owned by the direct source check and is accepted only when the source/target bundle, snapshot, scope, policy, data-snapshot, job, metadata, and checksum identities match exactly. Worker must not reinterpret source-owned `metadata.closureCheckId` as the target check ID. It downloads the exact closure-bundle artifact and numerical snapshot artifact by their certified IDs, recomputes their hashes, and requires the snapshot-index sidecar to preserve the exact ordered effective Process axis while the numerical payload preserves the same count. When Calculation Bundle materialization needs release evidence, Worker follows the verified HDF5 descriptor to release metadata and then the verified source-closure descriptor; it checks compressed hash/size/format/content type and dataset count at every hop rather than requiring a persisted compiled graph. `report_artifact_manifest_hash` remains certificate/audit evidence in the job payload, but it is not a substitute for the exact closure-bundle artifact identity. The Worker consumes the certificate and frozen snapshot; it does not rerun administrative closure.
+
+The Calculation Bundle impact axis is the snapshot-index's exact non-empty certified LCIA method axis. Every selected UUID/version must belong to the reviewed 25-method catalog, indices must be contiguous and identities unique, but the selected axis may contain one method or any other reviewed subset. Bundle materialization must not replace that frozen axis with the complete reviewed catalog.
 
 Closure binding changes provenance and eligibility, not numerical computation. The existing package snapshot build, all-unit solve, result artifact, and ready-marking path remains unchanged. Result JSON, result refs, persisted package metadata, and audit context preserve `closureCheckId` so downstream consumers can prove which certificate authorized the unchanged numerical output.
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 818c95b0cb188471327832bdd3e01c449e1e3c3d
+lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
 lastReviewedAt: 2026-08-10
-lastReviewedNote: "Reviewed for Worker Issue #243: Closure Bundle reuse verification does not change TIDAS package tasks or artifact schemas."
+lastReviewedNote: "Reviewed for Worker Issue #245: certified LCIA method subsets do not change TIDAS import/export tasks or artifact schemas."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #245

## Summary
- remove the fixed 25-method cardinality requirement from Calculation Bundle materialization
- preserve the snapshot-index certified LCIA axis order for any non-empty reviewed subset
- continue rejecting empty, unknown, duplicate, versionless, or gapped axes
- document the distinction between the 25-method reviewed catalog and the method subset selected by this certificate

## Validation
- `cargo test -p solver-worker calculation_bundle`
- `make check`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- docpact strict config validation and enforced worktree lint

## Production follow-up
After merge, deploy only the two production Worker hosts and rerun the one-method package-build acceptance. Do not deploy aws-dev.