### PR TITLE
fix: publish frozen result impact axis

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "1de9c777b57b034c2b703ceedabd692526bb4fd0"
-lastReviewedNote: "Reviewed for Worker Issue #245: certified LCIA method subsets remain within the existing Calculation Bundle runtime and documentation routes."
+lastReviewedCommit: "cd80d622e364d0db3a1d65584dcd79fda2088c76"
+lastReviewedNote: "Reviewed for Worker Issue #247: publishing the frozen impact axis remains within the existing result-package runtime and documentation routes."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Reviewed for Worker Issue #245: accepting the certified LCIA method subset preserves Worker ownership and existing public-interface boundaries."
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
+lastReviewedNote: "Reviewed for Worker Issue #247: frozen impact-axis publication preserves Worker ownership and existing public-interface boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/crates/solver-worker/src/db.rs
+++ b/crates/solver-worker/src/db.rs
@@ -2103,6 +2103,7 @@ async fn solve_all_unit_with_calculation_bundle(
     Ok(SolvedAllUnitArtifacts {
         calculation_bundle: bundle_ref,
         query_artifact_meta,
+        impact_map: snapshot_index.impact_map,
     })
 }
 
@@ -2272,6 +2273,7 @@ struct QueryArtifactMeta {
 struct SolvedAllUnitArtifacts {
     calculation_bundle: CalculationBundleArtifactRef,
     query_artifact_meta: QueryArtifactMeta,
+    impact_map: Vec<crate::snapshot_index::SnapshotImpactMapEntry>,
 }
 
 #[derive(Debug, Clone)]
@@ -2297,6 +2299,7 @@ struct LciaResultPackageArtifacts {
     result_diag: Value,
     query_artifact_meta: QueryArtifactMeta,
     calculation_bundle: CalculationBundleArtifactRef,
+    impact_map: Vec<crate::snapshot_index::SnapshotImpactMapEntry>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -2675,6 +2678,11 @@ pub(crate) async fn handle_lcia_result_package_build_worker_job(
     };
     let artifacts =
         persist_lcia_result_package_all_unit_artifacts(state, result_job_id, snapshot_id).await?;
+    let (available_impact_categories, resolved_default_impact_category) =
+        lcia_result_package_impact_axis(
+            artifacts.impact_map.as_slice(),
+            default_impact_category.as_deref(),
+        )?;
     link_lcia_result_package_worker_job_domain_refs(
         &state.pool,
         build_worker_job_id,
@@ -2755,8 +2763,8 @@ pub(crate) async fn handle_lcia_result_package_build_worker_job(
             result_artifact_ref: lcia_result_artifact_ref(&artifacts.result_diag),
             query_artifact_ref: lcia_result_query_artifact_ref(&artifacts.query_artifact_meta),
             artifact_manifest,
-            available_impact_categories: serde_json::json!([]),
-            default_impact_category: default_impact_category.clone(),
+            available_impact_categories,
+            default_impact_category: Some(resolved_default_impact_category),
             package_result_hash: artifacts
                 .result_diag
                 .get("artifact_sha256")
@@ -3330,7 +3338,39 @@ async fn persist_lcia_result_package_all_unit_artifacts(
         result_diag,
         query_artifact_meta: all_unit_artifacts.query_artifact_meta,
         calculation_bundle: all_unit_artifacts.calculation_bundle,
+        impact_map: all_unit_artifacts.impact_map,
     })
+}
+
+fn lcia_result_package_impact_axis(
+    impact_map: &[crate::snapshot_index::SnapshotImpactMapEntry],
+    requested_default: Option<&str>,
+) -> anyhow::Result<(Value, String)> {
+    let first = impact_map
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("lcia_result package snapshot impact axis is empty"))?;
+    let available = impact_map
+        .iter()
+        .map(|impact| impact.impact_id.to_string())
+        .collect::<Vec<_>>();
+    let default = match requested_default
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(requested) => impact_map
+            .iter()
+            .find(|impact| {
+                impact.impact_id.to_string() == requested || impact.impact_key == requested
+            })
+            .map(|impact| impact.impact_id.to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "default impact category {requested} is not present in the frozen snapshot axis"
+                )
+            })?,
+        None => first.impact_id.to_string(),
+    };
+    Ok((serde_json::to_value(available)?, default))
 }
 
 fn lcia_result_artifact_ref(result_diag: &Value) -> Value {
@@ -4583,14 +4623,15 @@ mod tests {
         SnapshotBuilderProcessFailure, SnapshotBuilderTerminal, SolveOptionsPayload,
         acquire_build_snapshot_worker_jobs_slot_sql, append_scope_closure_snapshot_args,
         build_all_unit_rhs_batch, build_snapshot_heartbeat_interval,
-        lcia_result_package_request_roots, lcia_result_package_version,
-        missing_legacy_tables_sparse_data_error, normalize_all_unit_batch_size,
-        package_snapshot_execution_mode, parse_snapshot_builder_build_timing,
-        parse_snapshot_builder_resolved_snapshot_id, read_certified_closure_bundle_binding,
-        redact_sensitive_diagnostics, redacted_builder_command, resolve_solve_all_unit_options,
-        run_snapshot_builder_job, run_snapshot_builder_job_with_worker_heartbeat,
-        snapshot_builder_process_failure_code, snapshot_builder_wall_timeout_seconds_from,
-        tail_text, utf8_safe_tail, validate_certified_process_axis,
+        lcia_result_package_impact_axis, lcia_result_package_request_roots,
+        lcia_result_package_version, missing_legacy_tables_sparse_data_error,
+        normalize_all_unit_batch_size, package_snapshot_execution_mode,
+        parse_snapshot_builder_build_timing, parse_snapshot_builder_resolved_snapshot_id,
+        read_certified_closure_bundle_binding, redact_sensitive_diagnostics,
+        redacted_builder_command, resolve_solve_all_unit_options, run_snapshot_builder_job,
+        run_snapshot_builder_job_with_worker_heartbeat, snapshot_builder_process_failure_code,
+        snapshot_builder_wall_timeout_seconds_from, tail_text, utf8_safe_tail,
+        validate_certified_process_axis,
     };
     use serde_json::json;
     use sqlx::postgres::PgPoolOptions;
@@ -4607,7 +4648,7 @@ mod tests {
     use tokio::time::sleep;
     use uuid::Uuid;
 
-    use crate::graph_types::RequestRootProcess;
+    use crate::{graph_types::RequestRootProcess, snapshot_index::SnapshotImpactMapEntry};
 
     static SNAPSHOT_BUILDER_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -5293,6 +5334,55 @@ mod tests {
             lcia_result_package_version(build_id),
             "lcia-result-3d620e54-2b83-47f6-9809-0b65ab00bfd9"
         );
+    }
+
+    #[test]
+    fn lcia_result_package_impact_axis_uses_frozen_ids_and_resolves_default_key() {
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let impacts = vec![
+            SnapshotImpactMapEntry {
+                impact_id: first_id,
+                impact_index: 0,
+                impact_version: Some("01.00.000".to_owned()),
+                impact_key: "method:first".to_owned(),
+                impact_name: "First".to_owned(),
+                unit: "kg".to_owned(),
+            },
+            SnapshotImpactMapEntry {
+                impact_id: second_id,
+                impact_index: 1,
+                impact_version: Some("01.00.000".to_owned()),
+                impact_key: "method:second".to_owned(),
+                impact_name: "Second".to_owned(),
+                unit: "kg".to_owned(),
+            },
+        ];
+
+        let (available, default) =
+            lcia_result_package_impact_axis(&impacts, Some("method:second")).unwrap();
+        assert_eq!(
+            available,
+            json!([first_id.to_string(), second_id.to_string()])
+        );
+        assert_eq!(default, second_id.to_string());
+    }
+
+    #[test]
+    fn lcia_result_package_impact_axis_defaults_to_first_and_rejects_unknown() {
+        let impact_id = Uuid::new_v4();
+        let impacts = vec![SnapshotImpactMapEntry {
+            impact_id,
+            impact_index: 0,
+            impact_version: Some("01.00.000".to_owned()),
+            impact_key: "method:only".to_owned(),
+            impact_name: "Only".to_owned(),
+            unit: "kg".to_owned(),
+        }];
+
+        let (_, default) = lcia_result_package_impact_axis(&impacts, None).unwrap();
+        assert_eq!(default, impact_id.to_string());
+        assert!(lcia_result_package_impact_axis(&impacts, Some("method:missing")).is_err());
     }
 
     #[test]

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,8 +28,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Reviewed for Worker Issue #245: method-subset materialization changes no Scope Closure memory, artifact-layout, or publication bounds."
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
+lastReviewedNote: "Reviewed for Worker Issue #247: result-package impact-axis metadata changes no Scope Closure memory, artifact-layout, or publication bounds."
 related:
   - ../../../AGENTS.md
   - ../../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Reviewed for Worker Issue #245: the certified method-axis fix stays in Calculation Bundle materialization and changes no repository topology."
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
+lastReviewedNote: "Reviewed for Worker Issue #247: frozen impact-axis publication stays in result-package persistence and changes no repository topology."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Reviewed for Worker Issue #245: focused Calculation Bundle coverage includes one-method and multi-method certified subsets plus invalid-axis rejection."
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
+lastReviewedNote: "Reviewed for Worker Issue #247: result-package coverage proves frozen impact IDs, default resolution, and invalid-default rejection."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -26,7 +26,7 @@ checkPaths:
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-10
 lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Updated for Worker Issue #245: Calculation Bundle follows the snapshot's exact non-empty certified LCIA method subset instead of requiring all 25 reviewed methods."
+lastReviewedNote: "Updated for Worker Issue #247: result packages publish ordered canonical impact IDs and a normalized default from the frozen snapshot axis."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -227,7 +227,7 @@ Singular/factorization failure diagnostics load the exact `(process_id, process_
 
 On success or failure, the worker links `lca_results`, `lca_result_cache`, `lca_latest_all_unit_results`, and `lca_factorization_registry` rows back to the canonical `worker_jobs.id` where those rows exist. The canonical path never probes or backfills optional `lca_jobs`. On failure, the worker records `worker_jobs.status=failed` with `error_code=solver_worker_job_failed` and updates `lca_result_cache` failed state where a cache row exists. Retained `lca_jobs.status/diagnostics` writes are limited to the explicitly enabled legacy pgmq/debug backend.
 
-For `lcia_result.package_build`, worker builds a published-only snapshot using the package `buildId` as the requested snapshot/result compatibility key, computes and persists the all-unit LCIA result artifact plus query artifact, then calls service-role RPC `public.cmd_lcia_result_package_mark_ready(...)`. Success `result_ref` uses `{"domainSource":"worker_jobs","workerJobId":"<uuid>","buildId":"<uuid>","package":{"table":"lcia_result_packages","id":"<uuid>"}}`; failures use package-specific error codes and do not update `lca_result_cache` or optional legacy `lca_jobs`.
+For `lcia_result.package_build`, worker builds a published-only snapshot using the package `buildId` as the requested snapshot/result compatibility key, computes and persists the all-unit LCIA result artifact plus query artifact, then calls service-role RPC `public.cmd_lcia_result_package_mark_ready(...)`. The ready projection persists `availableImpactCategories` from the frozen snapshot impact axis as ordered canonical impact UUIDs; `defaultImpactCategory` is normalized from either a requested canonical UUID or frozen impact key to the matching canonical UUID, and defaults to the first frozen impact when omitted. An empty impact axis or a requested default outside that axis fails closed instead of publishing an empty category list. Success `result_ref` uses `{"domainSource":"worker_jobs","workerJobId":"<uuid>","buildId":"<uuid>","package":{"table":"lcia_result_packages","id":"<uuid>"}}`; failures use package-specific error codes and do not update `lca_result_cache` or optional legacy `lca_jobs`.
 
 ## 4. 作业状态机
 

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
-lastReviewedNote: "Updated for Worker Issue #245: package materialization preserves the exact certified LCIA method subset while retaining reviewed-catalog validation."
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
+lastReviewedNote: "Reviewed for Worker Issue #247: result-package impact metadata does not alter certificate, snapshot, or Closure Bundle binding."
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,9 +19,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedCommit: 1de9c777b57b034c2b703ceedabd692526bb4fd0
+lastReviewedCommit: cd80d622e364d0db3a1d65584dcd79fda2088c76
 lastReviewedAt: 2026-08-10
-lastReviewedNote: "Reviewed for Worker Issue #245: certified LCIA method subsets do not change TIDAS import/export tasks or artifact schemas."
+lastReviewedNote: "Reviewed for Worker Issue #247: result-package impact metadata does not change TIDAS import/export tasks or artifact schemas."
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
Closes #247

## Summary
- Publish ordered canonical impact category IDs from the exact frozen snapshot axis instead of an empty list.
- Normalize the requested default from canonical UUID or frozen impact key and fail closed on an empty or unknown axis.

## Key Decisions
- Carry the already-validated snapshot impact map through package persistence; do not query mutable database method state.

## Validation
- make check (workspace tests and qualification unit harness)
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- Docpact enforce lint passed

## Risks / Rollback
- Existing ready packages are not rewritten; they require a new package build after deployment. Rollback is the single Worker commit.

## Follow-ups
- After merge, roll out the Worker binary and rebuild the affected package so the corrected impact metadata is persisted.

## Workspace Integration
- Root workspace pointer update remains pending after the child main merge.