### PR TITLE
Fix blocked Scope Closure scan reuse

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "8d646f8531100e44e734a3a233e9cb60f29983ef"
+lastReviewedCommit: "223892ac89d08e5266b41c7d697ecb121d20d508"
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: the private schema cutover preserves the frozen impact axis and current runtime/documentation routes."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: private runtime boundaries, indexed digital-file handling, and frozen impact-axis publication preserve Worker ownership."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -5259,15 +5259,12 @@ async fn reuse_completed_scan_execution(
         .copied()
         .ok_or_else(|| anyhow::anyhow!("reused scan report artifact was not persisted"))?;
     let report_hash = report_artifact_manifest_hash(&state.pool, report_artifact_id).await?;
+    let reused = parse_reused_scan_projection(&data, report_hash.clone())?;
     let result_summary = json!({
         "schemaVersion": "lcia.scope-closure-summary.v1",
         "issueCount": issues.len(),
         "blockerCount": issues.iter().filter(|issue| issue.blocking).count(),
-        "evidenceHash": required_json_text(
-            data.get("evidence")
-                .ok_or_else(|| anyhow::anyhow!("reusable scan omitted evidence"))?,
-            "evidenceHash",
-        )?,
+        "evidenceHash": reused.evidence.evidence_hash.clone(),
         "artifacts": persisted,
         "reusedFromCheckId": completed_check_id,
         "reportArtifactId": report_artifact_id,
@@ -5283,32 +5280,83 @@ async fn reuse_completed_scan_execution(
         &result_summary,
     )
     .await?;
+    Ok(ScopeClosureExecutionResult {
+        closure_check_id,
+        worker_job_id,
+        status: reused.status,
+        scan_completeness: reused.scan_completeness,
+        certificate_hash: finalize
+            .get("data")
+            .and_then(|item| item.get("certificateHash"))
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        evidence: reused.evidence,
+        report_artifact_id,
+        blocker_codes: reused.blocker_codes,
+    })
+}
+
+#[derive(Debug, PartialEq)]
+struct ReusedScanProjection {
+    status: String,
+    scan_completeness: String,
+    evidence: ScopeClosureEvidence,
+    blocker_codes: Vec<String>,
+}
+
+fn parse_reused_scan_projection(
+    data: &Value,
+    report_artifact_manifest_hash: String,
+) -> anyhow::Result<ReusedScanProjection> {
+    let status = required_json_text(data, "status")?;
+    let scan_completeness = required_json_text(data, "scanCompleteness")?;
+    if scan_completeness != "complete" {
+        return Err(anyhow::anyhow!(
+            "reusable scan must have complete scan evidence"
+        ));
+    }
     let evidence_json = data
         .get("evidence")
         .ok_or_else(|| anyhow::anyhow!("reusable scan omitted evidence"))?;
-    let evidence = ScopeClosureEvidence {
-        schema_version: "lcia.scope-closure-evidence.v2".to_owned(),
-        source_fingerprint: required_json_text(evidence_json, "sourceFingerprint")?,
-        resolution_map_hash: required_json_text(evidence_json, "resolutionMapHash")?,
-        closure_bundle_hash: required_json_text(evidence_json, "closureBundleHash")?,
-        closure_bundle_artifact_id: required_json_text(evidence_json, "closureBundleArtifactId")?
-            .parse()?,
-        snapshot_id: Some(required_json_text(evidence_json, "snapshotId")?.parse()?),
-        snapshot_hash: Some(required_json_text(evidence_json, "snapshotHash")?),
-        snapshot_artifact_id: Some(
-            required_json_text(evidence_json, "snapshotArtifactId")?.parse()?,
+    let source_fingerprint = required_json_text(evidence_json, "sourceFingerprint")?;
+    let resolution_map_hash = required_json_text(evidence_json, "resolutionMapHash")?;
+    let closure_bundle_hash = required_json_text(evidence_json, "closureBundleHash")?;
+    let closure_bundle_artifact_id =
+        required_json_text(evidence_json, "closureBundleArtifactId")?.parse()?;
+    let evidence = match status.as_str() {
+        "passed" => ScopeClosureEvidence {
+            schema_version: "lcia.scope-closure-evidence.v2".to_owned(),
+            source_fingerprint,
+            resolution_map_hash,
+            closure_bundle_hash,
+            closure_bundle_artifact_id,
+            snapshot_id: Some(required_json_text(evidence_json, "snapshotId")?.parse()?),
+            snapshot_hash: Some(required_json_text(evidence_json, "snapshotHash")?),
+            snapshot_artifact_id: Some(
+                required_json_text(evidence_json, "snapshotArtifactId")?.parse()?,
+            ),
+            snapshot_index_sha256: Some(required_json_text(evidence_json, "snapshotIndexSha256")?),
+            snapshot_build_contract_hash: Some(required_json_text(
+                evidence_json,
+                "snapshotBuildContractHash",
+            )?),
+            artifact_format: Some(required_json_text(evidence_json, "artifactFormat")?),
+            report_artifact_manifest_hash,
+            evidence_hash: Some(required_json_text(evidence_json, "evidenceHash")?),
+        },
+        "blocked" => administrative_only_evidence(
+            source_fingerprint,
+            resolution_map_hash,
+            closure_bundle_hash,
+            closure_bundle_artifact_id,
+            report_artifact_manifest_hash,
         ),
-        snapshot_index_sha256: Some(required_json_text(evidence_json, "snapshotIndexSha256")?),
-        snapshot_build_contract_hash: Some(required_json_text(
-            evidence_json,
-            "snapshotBuildContractHash",
-        )?),
-        artifact_format: Some(required_json_text(evidence_json, "artifactFormat")?),
-        report_artifact_manifest_hash: report_hash,
-        evidence_hash: Some(required_json_text(evidence_json, "evidenceHash")?),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "reusable scan has unsupported status {status}"
+            ));
+        }
     };
-    let status = required_json_text(&data, "status")?;
-    let scan_completeness = required_json_text(&data, "scanCompleteness")?;
     let blocker_codes = data
         .get("blockerCodes")
         .and_then(Value::as_array)
@@ -5317,18 +5365,10 @@ async fn reuse_completed_scan_execution(
         .filter_map(Value::as_str)
         .map(str::to_owned)
         .collect();
-    Ok(ScopeClosureExecutionResult {
-        closure_check_id,
-        worker_job_id,
+    Ok(ReusedScanProjection {
         status,
         scan_completeness,
-        certificate_hash: finalize
-            .get("data")
-            .and_then(|item| item.get("certificateHash"))
-            .and_then(Value::as_str)
-            .map(str::to_owned),
         evidence,
-        report_artifact_id,
         blocker_codes,
     })
 }
@@ -15001,6 +15041,109 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn blocked_reused_scan_accepts_administrative_evidence_without_numerical_fields() {
+        let closure_bundle_artifact_id = id("97979797-9797-4797-8797-979797979797");
+        let projection = parse_reused_scan_projection(
+            &json!({
+                "status": "blocked",
+                "scanCompleteness": "complete",
+                "evidence": {
+                    "sourceFingerprint": "1".repeat(64),
+                    "resolutionMapHash": "2".repeat(64),
+                    "closureBundleHash": "3".repeat(64),
+                    "closureBundleArtifactId": closure_bundle_artifact_id,
+                },
+                "blockerCodes": ["provider_outside_scope_universe"],
+            }),
+            "4".repeat(64),
+        )
+        .expect("complete blocked scans have reusable administrative evidence");
+
+        assert_eq!(projection.status, "blocked");
+        assert_eq!(projection.scan_completeness, "complete");
+        assert_eq!(
+            projection.blocker_codes,
+            vec!["provider_outside_scope_universe"]
+        );
+        assert_eq!(
+            projection.evidence.closure_bundle_artifact_id,
+            closure_bundle_artifact_id
+        );
+        assert!(projection.evidence.snapshot_id.is_none());
+        assert!(projection.evidence.snapshot_hash.is_none());
+        assert!(projection.evidence.snapshot_artifact_id.is_none());
+        assert!(projection.evidence.snapshot_index_sha256.is_none());
+        assert!(projection.evidence.snapshot_build_contract_hash.is_none());
+        assert!(projection.evidence.artifact_format.is_none());
+        assert!(projection.evidence.evidence_hash.is_none());
+    }
+
+    #[test]
+    fn passed_reused_scan_still_requires_every_numerical_evidence_field() {
+        let response = json!({
+            "status": "passed",
+            "scanCompleteness": "complete",
+            "evidence": {
+                "sourceFingerprint": "1".repeat(64),
+                "resolutionMapHash": "2".repeat(64),
+                "closureBundleHash": "3".repeat(64),
+                "closureBundleArtifactId": "98989898-9898-4898-8898-989898989898",
+                "snapshotId": "99999999-9999-4999-8999-999999999999",
+                "snapshotHash": "5".repeat(64),
+                "snapshotArtifactId": "90909090-9090-4090-8090-909090909090",
+                "snapshotIndexSha256": "6".repeat(64),
+                "snapshotBuildContractHash": "7".repeat(64),
+                "artifactFormat": "snapshot-hdf5:v1",
+                "evidenceHash": "8".repeat(64),
+            },
+            "blockerCodes": [],
+        });
+        let projection = parse_reused_scan_projection(&response, "4".repeat(64))
+            .expect("complete passed evidence remains reusable");
+        assert_eq!(projection.status, "passed");
+        assert!(projection.evidence.snapshot_id.is_some());
+        assert!(projection.evidence.evidence_hash.is_some());
+
+        for key in [
+            "snapshotId",
+            "snapshotHash",
+            "snapshotArtifactId",
+            "snapshotIndexSha256",
+            "snapshotBuildContractHash",
+            "artifactFormat",
+            "evidenceHash",
+        ] {
+            let mut missing = response.clone();
+            missing["evidence"].as_object_mut().unwrap().remove(key);
+            let error = parse_reused_scan_projection(&missing, "4".repeat(64)).unwrap_err();
+            assert!(
+                format!("{error:#}").contains(key),
+                "missing {key} must remain a hard error"
+            );
+        }
+    }
+
+    #[test]
+    fn reused_scan_rejects_incomplete_or_nonterminal_status() {
+        let administrative = json!({
+            "status": "blocked",
+            "scanCompleteness": "incomplete",
+            "evidence": {
+                "sourceFingerprint": "1".repeat(64),
+                "resolutionMapHash": "2".repeat(64),
+                "closureBundleHash": "3".repeat(64),
+                "closureBundleArtifactId": "91919191-9191-4191-8191-919191919191",
+            },
+        });
+        assert!(parse_reused_scan_projection(&administrative, "4".repeat(64)).is_err());
+
+        let mut running = administrative;
+        running["scanCompleteness"] = json!("complete");
+        running["status"] = json!("running");
+        assert!(parse_reused_scan_projection(&running, "4".repeat(64)).is_err());
     }
 
     #[test]

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,7 +28,7 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: private schema boundaries and frozen impact-axis metadata preserve bounded file-backed Scope Closure results and memory limits."
 related:
   - ../../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: private control-plane access, indexed digital-file handling, and frozen impact-axis publication preserve the repository topology."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: existing schema-cutover, indexed-reference, certificate-binding, and result-package impact-axis gates remain required."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,7 +25,7 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Updated for Worker PR #225 conflict resolution: private runtime boundaries preserve indexed source closure and frozen canonical impact-axis publication."
 related:
   - AGENTS.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
-lastReviewedNote: "Updated for Worker PR #225 conflict resolution: private runtime boundaries preserve verified discovery, certificate, snapshot, Closure Bundle, and frozen impact-axis binding."
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
+lastReviewedNote: "Updated for Worker Issue #251: shared-scan reuse distinguishes certificate-bearing passed evidence from administrative-only blocked evidence."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -253,7 +253,7 @@ A certificate is available only for `status=passed` and `scanCompleteness=comple
 - busy executions wait with lease heartbeats and bounded exponential backoff;
 - completed executions may reuse immutable scan evidence only when the database verifies all request, policy, snapshot, and scan bindings.
 
-Reuse does not copy the source run's report or result summary. The current run rebuilds and uploads a new XLSX tagged with its own `closureCheckId`, supplies a new result summary to the six-argument reuse finalizer, and receives a new target-scoped certificate bound to the new report manifest. Source `evidenceHash` remains immutable.
+Reuse does not copy the source run's report or result summary. The current run rebuilds and uploads a new XLSX tagged with its own `closureCheckId` and supplies a new result summary to the six-argument reuse finalizer. A reused `passed` scan must retain its complete numerical snapshot fields and immutable source `evidenceHash`, and receives a new target-scoped certificate bound to the new report manifest. A reused `blocked` scan carries only its administrative evidence, blocker details, and source Closure Bundle; its target remains `blocked` with no numerical snapshot fields, `evidenceHash`, or certificate.
 
 The early-failure RPC is safe before or after scan claim. It fails only the current run and releases a scan execution only when this job holds its lease; a waiter cannot destroy another run's reusable work.
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -20,7 +20,7 @@ checkPaths:
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 8d646f8531100e44e734a3a233e9cb60f29983ef
+lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
 lastReviewedNote: "Reviewed for Worker PR #225 conflict resolution: package schema cutover, certificate binding, and result-package impact metadata preserve TIDAS import/export tasks and artifact schemas."
 related:
   - AGENTS.md


### PR DESCRIPTION
## Summary

- parse reusable Scope Closure evidence according to the returned terminal status
- keep all numerical snapshot and `evidenceHash` fields mandatory for `passed` reuse
- accept administrative-only evidence for `blocked` reuse and preserve its blocker codes without synthesizing numerical evidence
- document the distinct passed/blocked shared-scan contracts and record docpact review evidence

Closes #251

## Validation

- `cargo test -p solver-worker reused_scan`
- `cargo test -p solver-worker`
- `cargo clippy -p solver-worker --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `make check`
- `scripts/docpact validate-config --root . --strict --format json`
- `scripts/docpact lint --root . --worktree --format json`
- pre-push docpact and `make check` gates

## Notes

- No Database Engine, Edge, or Next changes are required.
- This PR does not mutate production or retry the failed production job.
- The isolated Database/S3 E2E remains environment-gated; the regression is covered by status-aware Worker tests, existing target-scoped XLSX tests, and Database Engine blocked-reuse SQL coverage.