### PR TITLE
fix: disambiguate review quality worker id

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "ad0b5871390f907a9421e484c99c03601de38d1c"
+lastReviewedAt: "2026-08-14"
+lastReviewedCommit: "4949413104b478017b7194dd476d156d959d677c"
 lastReviewedNote: "Worker routes cover the manual non-blocking Review Admin diagnostic, actor-owned collaborative draft scope, private runtime, scope closure, and calculation-product contracts."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
 lastReviewedNote: "Worker owns the manual informational Review Admin diagnostic and actor-owned draft snapshot scope; submit-time Gate code is compatibility-only, and private runtime and publication boundaries remain authoritative."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/bin/review_quality_diagnostic_runner.rs
+++ b/crates/solver-worker/src/bin/review_quality_diagnostic_runner.rs
@@ -28,7 +28,7 @@ struct Cli {
         env = "REVIEW_QUALITY_WORKER_ID",
         default_value = "review_quality_diagnostic_runner"
     )]
-    worker_id: String,
+    review_quality_worker_id: String,
     #[arg(
         long = "review-quality-worker-lease-seconds",
         env = "REVIEW_QUALITY_WORKER_LEASE_SECONDS",
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
             poll_interval: Duration::from_millis(cli.poll_ms.max(100)),
             max_runs: cli.max_runs.or_else(|| cli.once.then_some(1)),
             exit_when_idle: cli.once,
-            worker_id: cli.worker_id,
+            worker_id: cli.review_quality_worker_id,
             lease_seconds: cli.lease_seconds.max(60),
         },
     )
@@ -64,4 +64,109 @@ async fn main() -> anyhow::Result<()> {
     info!(?summary, "review quality diagnostic runner stopped");
     println!("{}", serde_json::to_string_pretty(&summary)?);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        ffi::OsString,
+        sync::{Mutex, MutexGuard},
+    };
+
+    use super::*;
+
+    static WORKER_ID_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct WorkerIdEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous_worker_id: Option<OsString>,
+        previous_review_quality_worker_id: Option<OsString>,
+    }
+
+    impl WorkerIdEnvGuard {
+        fn set(worker_id: Option<&str>, review_quality_worker_id: Option<&str>) -> Self {
+            let lock = WORKER_ID_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let previous_worker_id = std::env::var_os("WORKER_ID");
+            let previous_review_quality_worker_id = std::env::var_os("REVIEW_QUALITY_WORKER_ID");
+            // SAFETY: these tests serialize every mutation through WORKER_ID_ENV_LOCK.
+            unsafe {
+                set_or_remove_env("WORKER_ID", worker_id);
+                set_or_remove_env("REVIEW_QUALITY_WORKER_ID", review_quality_worker_id);
+            }
+            Self {
+                _lock: lock,
+                previous_worker_id,
+                previous_review_quality_worker_id,
+            }
+        }
+    }
+
+    impl Drop for WorkerIdEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: this guard still owns WORKER_ID_ENV_LOCK.
+            unsafe {
+                restore_env("WORKER_ID", self.previous_worker_id.take());
+                restore_env(
+                    "REVIEW_QUALITY_WORKER_ID",
+                    self.previous_review_quality_worker_id.take(),
+                );
+            }
+        }
+    }
+
+    unsafe fn set_or_remove_env(key: &str, value: Option<&str>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    unsafe fn restore_env(key: &str, value: Option<OsString>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    #[test]
+    fn parses_default_worker_ids_without_argument_collision() {
+        let _env = WorkerIdEnvGuard::set(None, None);
+
+        let cli = Cli::try_parse_from(["review-quality-diagnostic-runner"]).unwrap();
+
+        assert!(cli.config.worker_id().starts_with("solver-worker-"));
+        assert_eq!(
+            cli.review_quality_worker_id,
+            "review_quality_diagnostic_runner"
+        );
+    }
+
+    #[test]
+    fn parses_distinct_worker_ids_from_environment() {
+        let _env = WorkerIdEnvGuard::set(Some("shared-worker"), Some("review-quality-worker"));
+
+        let cli = Cli::try_parse_from(["review-quality-diagnostic-runner"]).unwrap();
+
+        assert_eq!(cli.config.worker_id(), "shared-worker");
+        assert_eq!(cli.review_quality_worker_id, "review-quality-worker");
+    }
+
+    #[test]
+    fn parses_distinct_worker_ids_from_cli() {
+        let _env = WorkerIdEnvGuard::set(None, None);
+
+        let cli = Cli::try_parse_from([
+            "review-quality-diagnostic-runner",
+            "--worker-id",
+            "shared-worker",
+            "--review-quality-worker-id",
+            "review-quality-worker",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.config.worker_id(), "shared-worker");
+        assert_eq!(cli.review_quality_worker_id, "review-quality-worker");
+    }
 }

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
 lastReviewedNote: "The review-quality runtime is the joint pending-review diagnostic runner; actor-owned draft scope and compatibility-only submit Gate handling preserve private control-plane and publication boundaries."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
 lastReviewedNote: "Validation proves joint pending-review diagnostics remain informational and non-blocking while schema, indexed-reference, certificate, and result-package gates remain required."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 223892ac89d08e5266b41c7d697ecb121d20d508
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
 lastReviewedNote: "The shared review-quality contract is a manual informational Review Admin job rather than a submit-time Gate; private runtime and canonical publication boundaries remain intact."
 related:
   - AGENTS.md

--- a/docs/review-quality-diagnostic-contract.md
+++ b/docs/review-quality-diagnostic-contract.md
@@ -29,7 +29,7 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/agents/repo-architecture.md
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
+lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
 lastReviewedNote: "Reviewed after versioned calculation snapshots made legacy team/review guard fields optional; Review Admin diagnostics use their separate pending-review scope and this contract remains unchanged."
 related:
   - AGENTS.md


### PR DESCRIPTION
## Summary

- give the Review Quality runner its own Clap field identity so it no longer collides with flattened AppConfig.worker_id
- preserve the existing --worker-id / WORKER_ID and --review-quality-worker-id / REVIEW_QUALITY_WORKER_ID public flags
- add parser regression coverage for defaults, environment variables, and explicit CLI values
- record docpact review evidence after confirming runtime and report contracts are unchanged

## Validation

- cargo test -p solver-worker --bin review_quality_diagnostic_runner
- cargo test -p solver-worker worker_jobs
- cargo test -p solver-worker review_quality_diagnostic_runner
- cargo test -p solver-worker snapshot_builder_protocol
- cargo check -p solver-worker --bin review_quality_diagnostic_runner
- make check (passed: 362 library tests passed, 13 ignored, plus all binary/workspace tests)
- docpact strict config validation and enforced lint

A later pre-push re-run hit the existing timing-sensitive db::tests::heartbeat_failure_cancels_and_reaps_snapshot_builder test before its child wrote a PID; the same full gate had already passed earlier and all touched-path tests pass.

## Deployment follow-up

After merge, the exact main merge SHA will be built into a new immutable release and used to re-enable the reviewed Review Quality systemd unit on the Main Worker host.

Closes #257