### PR TITLE
fix: separate scope closure lineage from provider scope

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "4949413104b478017b7194dd476d156d959d677c"
+lastReviewedAt: "2026-08-17"
+lastReviewedCommit: "5e9f45dca1570378b8c4ff21975422839ca8cc0c"
 lastReviewedNote: "Worker routes cover the manual non-blocking Review Admin diagnostic, actor-owned collaborative draft scope, private runtime, scope closure, and calculation-product contracts."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "Worker owns the manual informational Review Admin diagnostic and actor-owned draft snapshot scope; submit-time Gate code is compatibility-only, and private runtime and publication boundaries remain authoritative."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -37,6 +37,7 @@ use crate::{
     readiness::{ReadinessFinding, ReadinessStatus},
     resource::{CancellationToken, ResourceCounters, ResourceMeasurement},
     snapshot_artifacts::ScopeClosureSnapshotBinding,
+    source_reference_policy::{ArtifactPurpose, SourceReferenceRole, classify_reference},
     storage::ObjectTransferOptions,
     tidas_cli,
     worker_jobs::{WorkerJobProgress, lease_heartbeat_period},
@@ -52,6 +53,8 @@ pub const SCOPE_CLOSURE_SCANNER_VERSION: &str = "scope-closure-scanner.v1";
 const VALIDATOR_SCANNER_FINGERPRINT_V1: &str = "scope-closure-validator-scanner.v1";
 const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1: &str =
     "scope-closure-validator-scanner.v1+cutoff-readiness-r1";
+const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2: &str =
+    "scope-closure-validator-scanner.v1+cutoff-readiness-r2";
 pub const TIDAS_BATCH_PROTOCOL: &str = tidas_cli::TIDAS_BATCH_PROTOCOL;
 pub const TIDAS_BATCH_PROFILE: &str = tidas_cli::TIDAS_BATCH_PROFILE;
 pub const REFERENCE_EDGE_SCHEMA_VERSION: &str = "tidas.reference-edge.v1";
@@ -89,6 +92,7 @@ const SCOPE_CLOSURE_ARTIFACT_STAGING_SECONDS: i32 = 3_600;
 fn validate_validator_scanner_fingerprint(fingerprint: &str) -> anyhow::Result<()> {
     if fingerprint == VALIDATOR_SCANNER_FINGERPRINT_V1
         || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1
+        || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2
     {
         return Ok(());
     }
@@ -1965,7 +1969,15 @@ async fn collect_scope_closure<P: ScopeClosureProvider>(
                     .iter()
                     .map(|issue| extraction_issue(&document.identity, issue)),
             );
-            for edge in extraction.edges {
+            for mut edge in extraction.edges {
+                let classified_reference =
+                    classify_reference(&edge, ArtifactPurpose::CertificateClosure).ok();
+                if let Some(classified_reference) = &classified_reference {
+                    classified_reference
+                        .role
+                        .as_str()
+                        .clone_into(&mut edge.reference_role);
+                }
                 let target_category = parse_category(edge.target_category.as_str())?;
                 let target_id = Uuid::parse_str(edge.target_uuid.as_str()).ok();
                 let target = match (
@@ -2005,7 +2017,16 @@ async fn collect_scope_closure<P: ScopeClosureProvider>(
                     raw_issues.push(omitted_version_issue(&document.identity, &edge, target_id));
                 }
                 if let Some(target) = target {
+                    // Certificate closure traverses lineage and other administrative Process
+                    // references, but only a real provider_process edge is governed by the
+                    // numerical provider universe. Unknown Process paths keep the historical
+                    // fail-closed behavior until they receive an explicit shared-policy role.
+                    let process_reference_is_provider =
+                        classified_reference.as_ref().is_none_or(|classified| {
+                            classified.role == SourceReferenceRole::ProviderProcess
+                        });
                     if target.category == DatasetCategory::Processes
+                        && process_reference_is_provider
                         && !root_set.contains(&target)
                         && manifest.link_policy.provider_universe_policy == "scope_only"
                     {
@@ -9981,6 +10002,7 @@ mod tests {
         for fingerprint in [
             VALIDATOR_SCANNER_FINGERPRINT_V1,
             VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1,
+            VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2,
         ] {
             assert!(validate_validator_scanner_fingerprint(fingerprint).is_ok());
         }
@@ -10411,6 +10433,107 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn preceding_dataset_version_is_lineage_not_a_provider_dependency() {
+        let mut current = identity(
+            DatasetCategory::Processes,
+            "51515151-5151-4151-8151-515151515151",
+        );
+        current.version = "01.01.011".to_owned();
+        let mut preceding = current.clone();
+        preceding.version = "01.01.002".to_owned();
+        let documents = [
+            ClosureDocument {
+                identity: current.clone(),
+                payload: json!({
+                    "processDataSet": {
+                        "administrativeInformation": {
+                            "publicationAndOwnership": {
+                                "common:referenceToPrecedingDataSetVersion": reference(
+                                    "process",
+                                    preceding.id,
+                                    Some(&preceding.version),
+                                )
+                            }
+                        }
+                    }
+                }),
+            },
+            ClosureDocument {
+                identity: preceding.clone(),
+                payload: json!({}),
+            },
+        ]
+        .into_iter()
+        .map(|document| (document.identity.clone(), document))
+        .collect();
+        let provider = FakeProvider {
+            documents,
+            ..FakeProvider::default()
+        };
+
+        let scan = collect_scope_closure(&provider, &manifest(vec![current.clone()]))
+            .await
+            .unwrap();
+
+        assert!(scan.complete);
+        assert!(scan.issues.is_empty());
+        assert_eq!(scan.roots, vec![current]);
+        assert!(scan.provider_universe.contains(&preceding));
+        let mut roles = Vec::new();
+        scan.resolved_references
+            .visit(|reference| {
+                roles.push(reference["referenceRole"].as_str().unwrap().to_owned());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(roles, vec!["lineage"]);
+    }
+
+    #[tokio::test]
+    async fn true_provider_process_outside_scope_only_roots_stays_blocked() {
+        let root = identity(
+            DatasetCategory::Processes,
+            "52525252-5252-4252-8252-525252525252",
+        );
+        let provider_process = identity(
+            DatasetCategory::Processes,
+            "53535353-5353-4353-8353-535353535353",
+        );
+        let documents = [ClosureDocument {
+            identity: root.clone(),
+            payload: json!({
+                "provider": {
+                    "referenceProcess": reference(
+                        "process",
+                        provider_process.id,
+                        Some(&provider_process.version),
+                    )
+                }
+            }),
+        }]
+        .into_iter()
+        .map(|document| (document.identity.clone(), document))
+        .collect();
+        let provider = FakeProvider {
+            documents,
+            ..FakeProvider::default()
+        };
+
+        let scan = collect_scope_closure(&provider, &manifest(vec![root]))
+            .await
+            .unwrap();
+
+        assert!(scan.complete);
+        assert_eq!(scan.issues.len(), 1);
+        assert_eq!(scan.issues[0].issue_code, "provider_outside_scope_universe");
+        assert_eq!(
+            scan.issues[0].reference_role.as_deref(),
+            Some("provider_process")
+        );
+        assert!(!scan.provider_universe.contains(&provider_process));
     }
 
     #[tokio::test]

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -27,8 +27,8 @@ checkPaths:
   - docs/agents/contracts/scope-closure-external-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "The review-quality snapshot helper and actor-owned draft scope preserve bounded file-backed Scope Closure results, private schema boundaries, memory limits, cancellation, and staged publication."
 related:
   - ../../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "The review-quality runtime is the joint pending-review diagnostic runner; actor-owned draft scope and compatibility-only submit Gate handling preserve private control-plane and publication boundaries."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -40,8 +40,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "Validation proves joint pending-review diagnostics remain informational and non-blocking while schema, indexed-reference, certificate, and result-package gates remain required."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -24,8 +24,8 @@ checkPaths:
   - docs/edge-function-integration.md
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4949413104b478017b7194dd476d156d959d677c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "The shared review-quality contract is a manual informational Review Admin job rather than a submit-time Gate; private runtime and canonical publication boundaries remain intact."
 related:
   - AGENTS.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -31,9 +31,9 @@ checkPaths:
   - scripts/scope_closure_qualification.py
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
-lastReviewedAt: 2026-08-13
+lastReviewedAt: 2026-08-17
 lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
-lastReviewedNote: "Review-quality snapshots remain non-certificate diagnostics; actor-owned draft scope and shared-scan reuse preserve the distinction between certificate-bearing passed evidence and administrative-only blocked evidence."
+lastReviewedNote: "Certificate closure now keeps lineage references in exact-identity administrative traversal while excluding them from provider-universe enforcement; the scanner cache identity advances to cutoff-readiness-r2."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -62,7 +62,7 @@ The canonical job kind is `lcia.scope_closure_check` with payload schema `lcia.s
 
 The Worker loads the full service input through `svc_lcia_scope_closure_check_get_worker_input`. It requires the normalized requested scope, scope/policy/request hashes, expected validator-scanner fingerprint, publication epoch, and `lcia.scope-closure-data-snapshot.v2`.
 
-The current internal request identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r1`. Worker also accepts the historical exact value `scope-closure-validator-scanner.v1` so already-enqueued and in-flight requests remain executable during rollout. This is a closed compatibility set: any other fingerprint fails before scan claim. The revision changes cache identity only; it does not version or alter the public V1 job, result, certificate, or artifact contracts.
+The current internal request identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r2`. Worker also accepts the historical exact values `scope-closure-validator-scanner.v1+cutoff-readiness-r1` and `scope-closure-validator-scanner.v1` so already-enqueued and in-flight requests remain executable during rollout. This is a closed compatibility set: any other fingerprint fails before scan claim. The revision changes cache identity only; it does not version or alter the public V1 job, result, certificate, or artifact contracts.
 
 Every newly normalized certificate-grade request freezes `linkPolicy.technosphereBoundaryPolicy=cutoff`. Database accepts the legacy supported input spellings `closed`, `open`, and `cutoff` during normalization, but all of them produce the same canonical cutoff scope before hashes and snapshot identity are computed. Worker requires the frozen value to be exactly `cutoff` at both the service-input and snapshot-builder child-protocol boundaries. It never silently overrides a noncanonical frozen manifest; such input fails before scan claim/publication with `scope_closure_boundary_policy_must_be_cutoff`. Historical artifacts remain readable and generic snapshot/readiness diagnostics retain their explicit three-policy surface.
 
@@ -104,7 +104,7 @@ Every database fetch is constrained to an identity in the frozen release manifes
 
 An exact reference never falls back to another version. A missing exact identity is a complete negative finding when it is absent from both the release allowlist and the observed closure. The legacy omitted-version policy is normally `reject`. If a tracked future scope explicitly uses `latest_eligible`, candidates and the deterministic winner must come only from the frozen release manifest, and the resolution map records the policy, candidate universe, candidates, and selected identity.
 
-`linkPolicy.providerUniversePolicy=scope_only` rejects a process provider outside the requested roots. `eligible_transitive_expansion-v1` may add a referenced process only when that exact identity is in the frozen release. Every accepted transitive process is part of the effective scope and evidence; the Worker never searches a mutable live provider universe.
+`linkPolicy.providerUniversePolicy=scope_only` rejects a `provider_process` reference outside the requested roots. It does not apply to a Process-target `lineage` reference such as `referenceToPrecedingDataSetVersion`: certificate closure traverses and validates that exact frozen-release identity as administrative evidence without adding it to the numerical Process axis. `eligible_transitive_expansion-v1` may add a referenced provider process only when that exact identity is in the frozen release. Every accepted transitive provider process is part of the effective scope and evidence; the Worker never searches a mutable live provider universe.
 
 ## TIDAS validation
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -19,8 +19,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
 lastReviewedNote: "Review Admin diagnostics and actor-owned draft scope do not change TIDAS import/export jobs, artifact schemas, validation, retention, certificate binding, or result-package metadata."
 related:
   - AGENTS.md


### PR DESCRIPTION
## Summary

- classify Scope Closure reference edges through the shared source-reference policy
- traverse and validate referenceToPrecedingDataSetVersion as lineage evidence without applying provider-universe blocking
- preserve fail-closed provider blocking for real provider_process references and unknown Process paths
- accept the r2 scanner fingerprint while retaining r1 and v1 in-flight compatibility

## Validation

- make check
- cargo test -p solver-worker scope_closure
- cargo test -p solver-worker snapshot_builder_protocol
- cargo check -p solver-worker --all-targets
- cargo clippy -p solver-worker --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- Docpact strict config validation and enforced lint

## Rollout

Deploy this Worker compatibility change before Database Engine switches new requests to the r2 scanner fingerprint. Existing r1 and v1 requests remain executable.

Closes linancn/tiangong-lca-worker#259

Parent: tiangong-lca/workspace#589
Follow-up coupling redesign: tiangong-lca/workspace#590