### PR TITLE
Exclude Source digital-file locators from scope closure

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "5e9f45dca1570378b8c4ff21975422839ca8cc0c"
+lastReviewedCommit: "eca5c551ff4eb8332f074f1b988b692b4074483c"
 lastReviewedNote: "Worker routes cover the manual non-blocking Review Admin diagnostic, actor-owned collaborative draft scope, private runtime, scope closure, and calculation-product contracts."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "Worker owns the manual informational Review Admin diagnostic and actor-owned draft snapshot scope; submit-time Gate code is compatibility-only, and private runtime and publication boundaries remain authoritative."
 related:
   - .docpact/config.yaml

--- a/crates/solver-worker/src/scope_closure.rs
+++ b/crates/solver-worker/src/scope_closure.rs
@@ -55,6 +55,8 @@ const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1: &str =
     "scope-closure-validator-scanner.v1+cutoff-readiness-r1";
 const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2: &str =
     "scope-closure-validator-scanner.v1+cutoff-readiness-r2";
+const VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R3: &str =
+    "scope-closure-validator-scanner.v1+cutoff-readiness-r3";
 pub const TIDAS_BATCH_PROTOCOL: &str = tidas_cli::TIDAS_BATCH_PROTOCOL;
 pub const TIDAS_BATCH_PROFILE: &str = tidas_cli::TIDAS_BATCH_PROFILE;
 pub const REFERENCE_EDGE_SCHEMA_VERSION: &str = "tidas.reference-edge.v1";
@@ -93,6 +95,7 @@ fn validate_validator_scanner_fingerprint(fingerprint: &str) -> anyhow::Result<(
     if fingerprint == VALIDATOR_SCANNER_FINGERPRINT_V1
         || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1
         || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2
+        || fingerprint == VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R3
     {
         return Ok(());
     }
@@ -2406,6 +2409,13 @@ fn walk_references(
     include_process_lcia_results: bool,
     result: &mut ReferenceExtractionResult,
 ) {
+    if source_category == DatasetCategory::Sources
+        && path.eq_ignore_ascii_case(
+            "$.sourceDataSet.sourceInformation.dataSetInformation.referenceToDigitalFile",
+        )
+    {
+        return;
+    }
     if !include_process_lcia_results
         && source_category == DatasetCategory::Processes
         && path.eq_ignore_ascii_case("$.processDataSet.LCIAResults")
@@ -10003,6 +10013,7 @@ mod tests {
             VALIDATOR_SCANNER_FINGERPRINT_V1,
             VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R1,
             VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R2,
+            VALIDATOR_SCANNER_FINGERPRINT_CUTOFF_READINESS_R3,
         ] {
             assert!(validate_validator_scanner_fingerprint(fingerprint).is_ok());
         }
@@ -10013,6 +10024,36 @@ mod tests {
             error.to_string(),
             format!("unsupported validator/scanner fingerprint: {unsupported}")
         );
+    }
+
+    #[test]
+    fn source_digital_file_locators_are_not_dataset_references() {
+        let contact_id = id("11111111-1111-4111-8111-111111111111");
+        let result = extract_references(
+            "source:test@01.00.000",
+            DatasetCategory::Sources,
+            &json!({
+                "sourceDataSet": {
+                    "sourceInformation": {
+                        "dataSetInformation": {
+                            "referenceToDigitalFile": [
+                                {"@uri": "../external_docs/report.jpg"},
+                                {"@uri": "https://example.test/report.pdf"}
+                            ],
+                            "referenceToContact": {
+                                "@type": "contact data set",
+                                "@refObjectId": contact_id,
+                                "@version": "01.00.000"
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert!(result.issues.is_empty());
+        assert_eq!(result.edges.len(), 1);
+        assert_eq!(result.edges[0].target_uuid, contact_id.to_string());
     }
 
     fn identity(category: DatasetCategory, value: &str) -> ExactDatasetIdentity {

--- a/crates/solver-worker/src/snapshot_source_closure.rs
+++ b/crates/solver-worker/src/snapshot_source_closure.rs
@@ -133,11 +133,6 @@ pub fn classify_source_document_with_lcia_flow_axis(
             ) {
                 return None;
             }
-            if purpose != ArtifactPurpose::CertificateClosure
-                && is_external_digital_file_path(issue.json_path.as_str())
-            {
-                return None;
-            }
             let role = classify_malformed_reference_role(
                 issue.source_category.as_str(),
                 issue.json_path.as_str(),
@@ -214,31 +209,6 @@ fn lcia_factor_reference_is_active(
     Uuid::parse_str(target_uuid)
         .ok()
         .is_some_and(|flow_id| active_lcia_flow_ids.contains(&flow_id))
-}
-
-fn is_external_digital_file_path(json_path: &str) -> bool {
-    let path = json_path.to_ascii_lowercase();
-    let terminal = path.rsplit('.').next().unwrap_or(path.as_str());
-    terminal
-        .strip_prefix("referencetodigitalfile")
-        .is_some_and(is_json_array_index_suffix)
-}
-
-fn is_json_array_index_suffix(mut suffix: &str) -> bool {
-    while !suffix.is_empty() {
-        let Some(rest) = suffix.strip_prefix('[') else {
-            return false;
-        };
-        let Some(end) = rest.find(']') else {
-            return false;
-        };
-        let index = &rest[..end];
-        if index.is_empty() || !index.bytes().all(|byte| byte.is_ascii_digit()) {
-            return false;
-        }
-        suffix = &rest[end + 1..];
-    }
-    true
 }
 
 fn malformed_evidence_target_type(
@@ -692,6 +662,7 @@ mod tests {
         for purpose in [
             ArtifactPurpose::ReviewSubmit,
             ArtifactPurpose::CalculationBundle,
+            ArtifactPurpose::CertificateClosure,
         ] {
             let classified = classify_source_document(
                 &source(CompiledReleaseSourceDatasetType::Source, document.clone()),
@@ -701,37 +672,5 @@ mod tests {
             assert!(classified.references.is_empty());
             assert!(classified.extraction_issues.is_empty());
         }
-
-        let certificate = classify_source_document(
-            &source(CompiledReleaseSourceDatasetType::Source, document),
-            ArtifactPurpose::CertificateClosure,
-        )
-        .unwrap();
-        assert!(certificate.references.is_empty());
-        assert!(!certificate.extraction_issues.is_empty());
-        assert!(certificate.extraction_issues.iter().all(|issue| {
-            issue["jsonPath"]
-                .as_str()
-                .is_some_and(|path| path.contains("referenceToDigitalFile["))
-        }));
-    }
-
-    #[test]
-    fn external_digital_file_path_matches_only_terminal_numeric_indexes() {
-        assert!(is_external_digital_file_path(
-            "$.sourceDataSet.referenceToDigitalFile"
-        ));
-        assert!(is_external_digital_file_path(
-            "$.sourceDataSet.referenceToDigitalFile[12]"
-        ));
-        assert!(!is_external_digital_file_path(
-            "$.sourceDataSet.referenceToDigitalFileMetadata"
-        ));
-        assert!(!is_external_digital_file_path(
-            "$.sourceDataSet.referenceToDigitalFile[latest]"
-        ));
-        assert!(!is_external_digital_file_path(
-            "$.sourceDataSet.referenceToDigitalFile[0].uri"
-        ));
     }
 }

--- a/docs/agents/contracts/scope-closure-memory-and-result-contract.md
+++ b/docs/agents/contracts/scope-closure-memory-and-result-contract.md
@@ -28,7 +28,7 @@ checkPaths:
   - docs/agents/contracts/scope-closure-provider-result.v1.schema.json
   - docs/agents/contracts/scope-closure-provider-owned-result.v1.schema.json
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "The review-quality snapshot helper and actor-owned draft scope preserve bounded file-backed Scope Closure results, private schema boundaries, memory limits, cancellation, and staged publication."
 related:
   - ../../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "The review-quality runtime is the joint pending-review diagnostic runner; actor-owned draft scope and compatibility-only submit Gate handling preserve private control-plane and publication boundaries."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,7 +41,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "Validation proves joint pending-review diagnostics remain informational and non-blocking while schema, indexed-reference, certificate, and result-package gates remain required."
 related:
   - ../../AGENTS.md

--- a/docs/lca-api-contract.md
+++ b/docs/lca-api-contract.md
@@ -25,7 +25,7 @@ checkPaths:
   - docs/frontend-integration.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "The shared review-quality contract is a manual informational Review Admin job rather than a submit-time Gate; private runtime and canonical publication boundaries remain intact."
 related:
   - AGENTS.md

--- a/docs/scope-closure-contract.md
+++ b/docs/scope-closure-contract.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/run_scope_closure_external_qualification.sh
   - scripts/run_scope_closure_provider_qualification.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: ad0b5871390f907a9421e484c99c03601de38d1c
-lastReviewedNote: "Certificate closure now keeps lineage references in exact-identity administrative traversal while excluding them from provider-universe enforcement; the scanner cache identity advances to cutoff-readiness-r2."
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
+lastReviewedNote: "Source digital-file locators are excluded from dataset-reference traversal for every consumer; the scanner cache identity advances to cutoff-readiness-r3."
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -62,7 +62,7 @@ The canonical job kind is `lcia.scope_closure_check` with payload schema `lcia.s
 
 The Worker loads the full service input through `svc_lcia_scope_closure_check_get_worker_input`. It requires the normalized requested scope, scope/policy/request hashes, expected validator-scanner fingerprint, publication epoch, and `lcia.scope-closure-data-snapshot.v2`.
 
-The current internal request identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r2`. Worker also accepts the historical exact values `scope-closure-validator-scanner.v1+cutoff-readiness-r1` and `scope-closure-validator-scanner.v1` so already-enqueued and in-flight requests remain executable during rollout. This is a closed compatibility set: any other fingerprint fails before scan claim. The revision changes cache identity only; it does not version or alter the public V1 job, result, certificate, or artifact contracts.
+The current internal request identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r3`. Worker also accepts the historical exact values `scope-closure-validator-scanner.v1+cutoff-readiness-r2`, `scope-closure-validator-scanner.v1+cutoff-readiness-r1`, and `scope-closure-validator-scanner.v1` so already-enqueued and in-flight requests remain executable during rollout. This is a closed compatibility set: any other fingerprint fails before scan claim. The revision changes cache identity only; it does not version or alter the public V1 job, result, certificate, or artifact contracts.
 
 Every newly normalized certificate-grade request freezes `linkPolicy.technosphereBoundaryPolicy=cutoff`. Database accepts the legacy supported input spellings `closed`, `open`, and `cutoff` during normalization, but all of them produce the same canonical cutoff scope before hashes and snapshot identity are computed. Worker requires the frozen value to be exactly `cutoff` at both the service-input and snapshot-builder child-protocol boundaries. It never silently overrides a noncanonical frozen manifest; such input fails before scan claim/publication with `scope_closure_boundary_policy_must_be_cutoff`. Historical artifacts remain readable and generic snapshot/readiness diagnostics retain their explicit three-policy surface.
 
@@ -211,10 +211,10 @@ targets are fetched when available, while malformed placeholders and unavailable
 retained only in bounded provenance evidence. Numerical exchange/provider references and required
 Flow Property, Unit Group, and LCIA support remain fail-closed. This distinction is identified by
 `source-reference-policy.v4` and participates in snapshot/review fingerprints.
-Schema-defined `referenceToDigitalFile` URI values are external attachment locators rather than
-dataset references. The numerical source walk ignores their raw extraction findings for
-review-submit and ordinary Calculation Bundles; certificate-grade administrative traversal keeps
-its existing strict extraction and issue-aggregation behavior.
+Schema-defined `sourceDataSet.sourceInformation.dataSetInformation.referenceToDigitalFile` values
+are opaque external attachment locators rather than dataset references. Reference extraction skips
+that exact field for review-submit, Calculation Bundle, and certificate-grade Scope Closure. The
+Worker does not resolve the locator, enforce path safety, or check file or network availability.
 
 Each fresh scan produces deterministic administrative artifacts:
 

--- a/docs/tidas-package-contract.md
+++ b/docs/tidas-package-contract.md
@@ -20,7 +20,7 @@ checkPaths:
   - docs/scope-closure-contract.md
   - docs/agents/contracts/scope-closure-memory-and-result-contract.md
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 5e9f45dca1570378b8c4ff21975422839ca8cc0c
+lastReviewedCommit: eca5c551ff4eb8332f074f1b988b692b4074483c
 lastReviewedNote: "Review Admin diagnostics and actor-owned draft scope do not change TIDAS import/export jobs, artifact schemas, validation, retention, certificate binding, or result-package metadata."
 related:
   - AGENTS.md


### PR DESCRIPTION
## Summary

- Exclude the exact Source `referenceToDigitalFile` subtree at the scope-closure reference traversal boundary.
- Apply the same behavior to Review Submit, Calculation Bundle, and certificate-grade closure instead of consumer-specific issue filtering.
- Advance scanner compatibility to `cutoff-readiness-r3` while retaining v1/r1/r2 in-flight compatibility.

## Implementation decisions

- Digital-file values are opaque attachment locators, not dataset references.
- Worker does not resolve them, enforce path safety, or check filesystem/network availability.
- Other Source references and their exact-version validation remain unchanged.

## Validation

- `make check`
- Focused regression tests for Source digital-file traversal and all three consumers
- `docpact lint --worktree`
- Pre-push gate repeated docpact and the complete `make check` suite successfully

## Dependency and rollout

- Database Engine must advance new request/cache identity to r3 before or with rollout.
- tidas-tools/tidas-sdk schema changes are tracked separately under workspace#591.

Closes #261
